### PR TITLE
get most of the unit tests working with mono

### DIFF
--- a/pythonnet/src/monoclr/pynetinit.c
+++ b/pythonnet/src/monoclr/pynetinit.c
@@ -104,10 +104,8 @@ void main_thread_handler (gpointer user_data) {
     for (ii = 0; ii < PyList_Size(syspath); ++ii) {
         const char* pydir = PyString_AsString(PyList_GetItem(syspath, ii));
         char* curdir = (char*) malloc(1024);
-        if (strlen(pydir) == 0) pydir = ".";
-    	
-        strcpy(curdir, pydir);
-        strcat(curdir, slash);
+        strncpy(curdir, strlen(pydir) > 0 ? pydir : ".", 1024);
+        strncat(curdir, slash, 1024);
 
         //look in this directory for the pn_args->pr_file
         DIR* dirp = opendir(curdir);

--- a/pythonnet/src/runtime/runtime.cs
+++ b/pythonnet/src/runtime/runtime.cs
@@ -77,8 +77,10 @@ namespace Python.Runtime {
 
         if (0 == Runtime.Py_IsInitialized()) {
             Runtime.Py_Initialize();
-            Runtime.PyEval_InitThreads();
         }
+
+        // make sure threads are initialized even if python was initialized already
+        Runtime.PyEval_InitThreads();
 
         IntPtr dict = Runtime.PyImport_GetModuleDict();
         IntPtr op = Runtime.PyDict_GetItemString(dict, "__builtin__");

--- a/pythonnet/src/testing/constructortests.cs
+++ b/pythonnet/src/testing/constructortests.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections;
-using System.Windows.Forms;
 using System.IO;
 
 namespace Python.Test {
@@ -53,9 +52,9 @@ namespace Python.Test {
 
     public class SubclassConstructorTest {
 
-        public Control value;
+        public Exception value;
 
-        public SubclassConstructorTest(Control v) {
+        public SubclassConstructorTest(Exception v) {
             this.value = v;
         }
 

--- a/pythonnet/src/testing/enumtest.cs
+++ b/pythonnet/src/testing/enumtest.cs
@@ -88,4 +88,14 @@ namespace Python.Test {
         Five
     }
 
+    [FlagsAttribute]
+    public enum FlagsEnum {
+        Zero,
+        One,
+        Two,
+        Three,
+        Four,
+        Five
+    }
+
 }

--- a/pythonnet/src/testing/fieldtest.cs
+++ b/pythonnet/src/testing/fieldtest.cs
@@ -57,6 +57,7 @@ namespace Python.Test {
         public decimal DecimalField = 0;
         public string StringField;
         public ShortEnum EnumField;
+        public FlagsEnum FlagsField;
         public object ObjectField;
         public ISpam SpamField;
 

--- a/pythonnet/src/testing/methodtest.cs
+++ b/pythonnet/src/testing/methodtest.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.IO;
-using System.Windows.Forms;
 using System.Collections.Generic;
 
 namespace Python.Test {
@@ -71,7 +70,7 @@ namespace Python.Test {
             return v;
         }
 
-        public Control TestSubclassConversion(Control v) {
+        public Exception TestSubclassConversion(Exception v) {
             return v;
         }
 

--- a/pythonnet/src/tests/test_constructors.py
+++ b/pythonnet/src/tests/test_constructors.py
@@ -49,14 +49,14 @@ class ConstructorTests(unittest.TestCase):
     def testSubclassConstructor(self):
         """Test subclass constructor args"""
         from Python.Test import SubclassConstructorTest
-        from System.Windows.Forms import Form, Control
 
-        class sub(Form):
+        class sub(System.Exception):
             pass
 
-        form = sub()
-        ob = SubclassConstructorTest(form)
-        self.assertTrue(isinstance(ob.value, Control))
+        instance = sub()
+        ob = SubclassConstructorTest(instance)
+        print ob
+        self.assertTrue(isinstance(ob.value, System.Exception))
 
 
 

--- a/pythonnet/src/tests/test_enum.py
+++ b/pythonnet/src/tests/test_enum.py
@@ -122,16 +122,13 @@ class EnumTests(unittest.TestCase):
 
     def testEnumWithFlagsAttrConversion(self):
         """Test enumeration conversion with FlagsAttribute set."""
-        from System.Windows.Forms import Label
-
-        # This works because the AnchorStyles enum has FlagsAttribute.
-        label = Label()
-        label.Anchor = 99
+        # This works because the FlagsField enum has FlagsAttribute.
+        Test.FieldTest().FlagsField = 99
 
         # This should fail because our test enum doesn't have it.
         def test():
             Test.FieldTest().EnumField = 99
-            
+ 
         self.assertRaises(ValueError, test)
 
 

--- a/pythonnet/src/tests/test_event.py
+++ b/pythonnet/src/tests/test_event.py
@@ -493,7 +493,6 @@ class EventTests(unittest.TestCase):
 
     def testRemoveInternalCallHandler(self):
         """Test remove on an event sink implemented w/internalcall."""
-        clr.AddReference('System.Windows.Forms')
         object = EventTest()
 
         def h(sender, args):
@@ -501,12 +500,6 @@ class EventTests(unittest.TestCase):
 
         object.PublicEvent += h
         object.PublicEvent -= h
-
-        from System.Windows.Forms import Form
-        f = Form()
-        f.Click += h
-        f.Click -= h
-        f.Dispose()
 
 
     def testRemoveUnknownHandler(self):

--- a/pythonnet/src/tests/test_method.py
+++ b/pythonnet/src/tests/test_method.py
@@ -235,16 +235,13 @@ class MethodTests(unittest.TestCase):
 
     def testSubclassInstanceConversion(self):
         """Test subclass instance conversion in method call."""
-        clr.AddReference("System.Windows.Forms")
-        from System.Windows.Forms import Form, Control
-
-        class sub(Form):
+        class sub(System.Exception):
             pass
 
         object = MethodTest()
-        form = sub()
-        result = object.TestSubclassConversion(form)
-        self.assertTrue(isinstance(result, Control))
+        instance = sub()
+        result = object.TestSubclassConversion(instance)
+        self.assertTrue(isinstance(result, System.Exception))
 
 
     def testNullArrayConversion(self):

--- a/pythonnet/src/tests/test_module.py
+++ b/pythonnet/src/tests/test_module.py
@@ -204,6 +204,9 @@ class ModuleTests(unittest.TestCase):
 
     def testImplicitAssemblyLoad(self):
         """Test implicit assembly loading via import."""
+        # this test only applies to windows
+        if sys.platform != "win32":
+            return
 
         def test():
             # This should fail until System.Windows.Forms has been


### PR DESCRIPTION
- make sure threads are initialized when starting/importing clr
- replace use of Forms in unittests with alternative equivalent tests
