### PR TITLE
install packages using nuget in setup.py and cosmetic changes to make more PEP8 compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ before_install:
   - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
   - sudo apt-get -qq update
   - sudo apt-get -qq install mono-devel mono-gmcs mono-xbuild nunit-console
+  - sudo mozroots --import --machine --sync
+  - yes | sudo certmgr -ssl -m https://go.microsoft.com
+  - yes | sudo certmgr -ssl -m https://nugetgallery.blob.core.windows.net
+  - yes | sudo certmgr -ssl -m https://nuget.org
 install:
   - cd pythonnet
   - python setup.py build_ext --inplace


### PR DESCRIPTION
running setup.py shouldn't need the project to be loaded/built in visual studio first so setup.py has to call nuget to install any dependencies before building.
