### PR TITLE
Move the implicit loading deprecation warning into LoadImplicit and use

### DIFF
--- a/pythonnet/src/runtime/importhook.cs
+++ b/pythonnet/src/runtime/importhook.cs
@@ -156,15 +156,7 @@ namespace Python.Runtime {
 
             AssemblyManager.UpdatePath();
             if (!AssemblyManager.IsValidNamespace(realname)) {
-                bool fromFile = false;
-                if (AssemblyManager.LoadImplicit(realname, out fromFile)) {
-                    if (true == fromFile) {
-                        string deprWarning = String.Format("\nThe module was found, but not in a referenced namespace.\n" +
-                                     "Implicit loading is deprecated. Please use clr.AddReference(\"{0}\").", realname);
-                        Exceptions.deprecation(deprWarning);
-                    }
-                }
-                else
+                if (!AssemblyManager.LoadImplicit(realname))
                 {
                     // May be called when a module being imported imports a module.
                     // In particular, I've seen decimal import copy import org.python.core
@@ -174,7 +166,6 @@ namespace Python.Runtime {
 
             // See if sys.modules for this interpreter already has the
             // requested module. If so, just return the exising module.
-
             IntPtr modules = Runtime.PyImport_GetModuleDict();
             IntPtr module = Runtime.PyDict_GetItem(modules, py_mod_name);
 

--- a/pythonnet/src/runtime/moduleobject.cs
+++ b/pythonnet/src/runtime/moduleobject.cs
@@ -109,14 +109,8 @@ namespace Python.Runtime {
             // thing happens with implicit assembly loading at a reasonable
             // cost. Ask the AssemblyManager to do implicit loading for each 
             // of the steps in the qualified name, then try it again.
-            bool fromFile;
-            if (AssemblyManager.LoadImplicit(qname, out fromFile)) {
-                bool ignore = name.StartsWith("__");
-                if (true == fromFile && (!ignore)) {
-                    string deprWarning = String.Format("\nThe module was found, but not in a referenced namespace.\n" +
-                                 "Implicit loading is deprecated. Please use clr.AddReference(\"{0}\").", qname);
-                    Exceptions.deprecation(deprWarning);
-                }
+            bool ignore = name.StartsWith("__");
+            if (AssemblyManager.LoadImplicit(qname, !ignore)) {
                 if (AssemblyManager.IsValidNamespace(qname)) {
                     m = new ModuleObject(qname);
                     StoreAttribute(name, m);

--- a/pythonnet/src/testing/classtest.cs
+++ b/pythonnet/src/testing/classtest.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections;
-using System.Windows.Forms;
 
 namespace Python.Test {
 

--- a/pythonnet/src/testing/eventtest.cs
+++ b/pythonnet/src/testing/eventtest.cs
@@ -8,7 +8,6 @@
 // ==========================================================================
 
 using System;
-using System.Windows.Forms;
 
 namespace Python.Test {
 
@@ -20,22 +19,6 @@ namespace Python.Test {
 
 
     public class EventTest {
-
-
-        public void WinFormTest() {
-            EventTest e = new EventTest();
-            EventHandler h = new EventHandler(e.ClickHandler);
-
-            Form f = new Form();
-            f.Click += h;
-            //f.Click(null, new EventArgs());
-            f.Click -= h;
-        }
-
-        public void ClickHandler(object sender, EventArgs e) {
-            Console.WriteLine("click");
-        }
-
 
         public static event TestEventHandler PublicStaticEvent;
 

--- a/pythonnet/src/testing/generictest.cs
+++ b/pythonnet/src/testing/generictest.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections;
-using System.Windows.Forms;
 
 namespace Python.Test {
 

--- a/pythonnet/src/tests/test_class.py
+++ b/pythonnet/src/tests/test_class.py
@@ -6,7 +6,6 @@
 # WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
 # FOR A PARTICULAR PURPOSE.
 # ===========================================================================
-
 from System.Collections import Hashtable
 from Python.Test import ClassTest
 import sys, os, string, unittest, types


### PR DESCRIPTION
the assembly location in the warning instead of the namespace.
Update test to check for the implicit loading warning.

fixes #33 and #35
