### PR TITLE
Struct default constructor

### DIFF
--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -26,7 +26,7 @@ namespace Python.Runtime {
 
         internal ClassObject(Type tp) : base(tp) {
             ctors = type.GetConstructors();
-            binder = new ConstructorBinder();
+            binder = new ConstructorBinder(type);
 
             for (int i = 0; i < ctors.Length; i++) {
                 binder.AddMethod(ctors[i]);

--- a/src/tests/test_class.py
+++ b/src/tests/test_class.py
@@ -130,10 +130,9 @@ class ClassTests(unittest.TestCase):
         """Test construction of structs."""
         from System.Drawing import Point
 
-        def test():
-            p = Point()
-
-        self.assertRaises(TypeError, test)
+        p = Point()
+        self.assertTrue(p.X == 0)
+        self.assertTrue(p.Y == 0)
 
         p = Point(0, 0)
         self.assertTrue(p.X == 0)


### PR DESCRIPTION
I updated the ConstructorBinder to support the creation of struct instances by calling the struct's default constructor which allows users to create instances of structs with no explicit constructors defined.