### PR TITLE
Method Default Arguments

### DIFF
--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -233,7 +233,7 @@ namespace Python.Runtime {
                 free = true;
             }
 
-            // Add args given from caller
+            // Add args given from caller + 1 for the value
             int i = Runtime.PyTuple_Size(args);
             IntPtr real = Runtime.PyTuple_New(i + 1);
             for (int n = 0; n < i; n++) {
@@ -243,10 +243,12 @@ namespace Python.Runtime {
             }
 
             // Do we need default arguments added to the list
-            if (cls.indexer.NeedsDefaultArgs(ob, real)) {
-                IntPtr defaultArgs = cls.indexer.GetDefaultArgs(ob, real);
-                int sizeOfDefaultArgs = Runtime.PyTuple_Size(defaultArgs);
-                int temp = i + sizeOfDefaultArgs;
+            if (cls.indexer.NeedsDefaultArgs(real)) {
+                // Need to add default args to the end of real tuple
+                // before adding the value v
+                IntPtr defaultArgs = cls.indexer.GetDefaultArgs(real);
+                int numOfDefaultArgs = Runtime.PyTuple_Size(defaultArgs);
+                int temp = i + numOfDefaultArgs;
                 real = Runtime.PyTuple_New(temp + 1);
                 for (int n = 0; n < i; n++) {
                     IntPtr item = Runtime.PyTuple_GetItem(args, n);
@@ -254,13 +256,11 @@ namespace Python.Runtime {
                     Runtime.PyTuple_SetItem(real, n, item);
                 }
 
-                for (int n = 0; n < sizeOfDefaultArgs; n++) {
-
+                for (int n = 0; n < numOfDefaultArgs; n++) {
                     IntPtr item = Runtime.PyTuple_GetItem(defaultArgs, n);
                     Runtime.Incref(item);
                     Runtime.PyTuple_SetItem(real, n + i, item);
                 }
-
                 i = temp;
             }
 

--- a/src/runtime/indexer.cs
+++ b/src/runtime/indexer.cs
@@ -62,7 +62,61 @@ namespace Python.Runtime {
             SetterBinder.Invoke(inst, args, IntPtr.Zero);
         }
 
-    }
+        internal bool NeedsDefaultArgs(IntPtr inst, IntPtr args){
+            int pynargs = Runtime.PyTuple_Size(args) - 1;
+            var methods = SetterBinder.GetMethods();
+            if(methods.Length == 0)
+                return false;
 
+            MethodBase mi = methods[0];
+            ParameterInfo[] pi = mi.GetParameters();
+            // need to subtract one for the value
+            int clrnargs = pi.Length - 1;
+            if(pynargs == clrnargs)
+                return false;
+
+            for (int v = pynargs; v < clrnargs; v++){
+                if (pi[v].DefaultValue == DBNull.Value)
+                    return false;
+            }
+            return true;
+        }
+
+        internal IntPtr GetDefaultArgs(IntPtr inst, IntPtr args){
+            //IntPtr real = Runtime.PyTuple_New(i + 1);
+            int pynargs = Runtime.PyTuple_Size(args) - 1;
+            var methods = SetterBinder.GetMethods();
+            IntPtr defaultArgs;
+            if(methods.Length == 0){
+                 defaultArgs = Runtime.PyTuple_New(0);
+                return defaultArgs;
+            }
+            MethodBase mi = methods[0];
+            ParameterInfo[] pi = mi.GetParameters();
+            int clrnargs = pi.Length - 1;
+            if(pynargs == clrnargs|| pynargs > clrnargs){
+                 defaultArgs = Runtime.PyTuple_New(0);
+                return defaultArgs;
+            }
+
+            defaultArgs = Runtime.PyTuple_New(clrnargs - pynargs);
+            for (int i = 0; i < (clrnargs - pynargs); i++) {
+                // Here we own the reference to the Python value, and we
+                // give the ownership to the arg tuple.
+                if (pi[i + pynargs].DefaultValue == DBNull.Value)
+                    continue;
+                else{
+                    IntPtr arg = Converter.ToPython(pi[i + pynargs].DefaultValue, pi[i + pynargs].ParameterType);
+                    Type type = typeof(String);
+                    Object arg2;
+                    Converter.ToManaged(arg, type, out arg2, false);
+                    Runtime.PyTuple_SetItem(defaultArgs, i, arg);
+                }
+            }
+            return defaultArgs;
+        }
+
+
+    }
 
 }

--- a/src/runtime/indexer.cs
+++ b/src/runtime/indexer.cs
@@ -62,7 +62,7 @@ namespace Python.Runtime {
             SetterBinder.Invoke(inst, args, IntPtr.Zero);
         }
 
-        internal bool NeedsDefaultArgs(IntPtr inst, IntPtr args){
+        internal bool NeedsDefaultArgs(IntPtr args){
             int pynargs = Runtime.PyTuple_Size(args) - 1;
             var methods = SetterBinder.GetMethods();
             if(methods.Length == 0)
@@ -82,7 +82,7 @@ namespace Python.Runtime {
             return true;
         }
 
-        internal IntPtr GetDefaultArgs(IntPtr inst, IntPtr args){
+        internal IntPtr GetDefaultArgs(IntPtr args){
             //IntPtr real = Runtime.PyTuple_New(i + 1);
             int pynargs = Runtime.PyTuple_Size(args) - 1;
             var methods = SetterBinder.GetMethods();

--- a/src/testing/indexertest.cs
+++ b/src/testing/indexertest.cs
@@ -347,6 +347,23 @@ namespace Python.Test {
 
     }
 
+    public class MultiDefaultKeyIndexerTest : IndexerBase {
+
+        public MultiDefaultKeyIndexerTest() : base() { }
+
+        public string this[int i1, int i2 = 2] {
+            get {
+                string key = i1.ToString() + i2.ToString();
+                return (string)t[key];
+            }
+            set {
+                string key = i1.ToString() + i2.ToString();
+                t[key] = value;
+            }
+        }
+
+    }
+
 
 
 

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -155,6 +155,16 @@ namespace Python.Test {
             i = 42;
         }
 
+        public static int TestSingleDefaultParam(int i = 5) {
+            return i;
+        }
+        public static int TestTwoDefaultParam(int i = 5, int j = 6) {
+            return i + j;
+        }
+        public static int TestOneArgAndTwoDefaultParam(int z, int i = 5, int j = 6) {
+            return i + j + z;
+        }
+
 
 
         // overload selection test support 

--- a/src/tests/test_indexer.py
+++ b/src/tests/test_indexer.py
@@ -8,6 +8,8 @@
 # ===========================================================================
 
 import sys, os, string, unittest, types
+import clr
+clr.AddReference("Python.Test")
 import Python.Test as Test
 import six
 
@@ -630,6 +632,17 @@ class IndexerTests(unittest.TestCase):
             object[0, 1, spam] = "wrong"
 
         self.assertRaises(TypeError, test)
+        
+        
+    def testMultiDefaultKeyIndexer(self):
+        """Test indexers that take multiple indices with a default key arguments."""
+        #default argument is 2 in the MultiDefaultKeyIndexerTest object
+        object = Test.MultiDefaultKeyIndexerTest()
+        object[0, 2] = "zero one spam"
+        self.assertTrue(object[0] == "zero one spam")
+        
+        object[1] = "one nine spam"
+        self.assertTrue(object[1, 2] == "one nine spam")
 
 
     def testIndexerWrongKeyType(self):

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -13,12 +13,6 @@ clr.AddReference("Python.Test")
 
 from Python.Test import MethodTest, MethodTestSub
 import System
-import six
-
-if six.PY3:
-    long = int
-    unichr = chr
-
 
 class MethodTests(unittest.TestCase):
     """Test CLR method support."""
@@ -241,11 +235,11 @@ class MethodTests(unittest.TestCase):
 
     def testSubclassInstanceConversion(self):
         """Test subclass instance conversion in method call."""
-        class TestSubException(System.Exception):
+        class sub(System.Exception):
             pass
 
         object = MethodTest()
-        instance = TestSubException()
+        instance = sub()
         result = object.TestSubclassConversion(instance)
         self.assertTrue(isinstance(result, System.Exception))
 
@@ -447,6 +441,27 @@ class MethodTests(unittest.TestCase):
 
         # None cannot be converted to a value type
         self.assertRaises(TypeError, test)
+        
+    def testSingleDefaultParam(self):
+        """Test void method with single ref-parameter."""
+        result = MethodTest.TestSingleDefaultParam()
+        self.assertTrue(result == 5)
+        
+    def testOneArgAndTwoDefaultParam(self):
+        """Test void method with single ref-parameter."""
+        result = MethodTest.TestOneArgAndTwoDefaultParam(11)
+        self.assertTrue(result == 22)
+        
+        result = MethodTest.TestOneArgAndTwoDefaultParam(15)
+        self.assertTrue(result == 26)
+        
+        result = MethodTest.TestOneArgAndTwoDefaultParam(20)
+        self.assertTrue(result == 31)
+        
+    def testTwoDefaultParam(self):
+        """Test void method with single ref-parameter."""
+        result = MethodTest.TestTwoDefaultParam()
+        self.assertTrue(result == 11)        
 
 
     def testExplicitSelectionWithOutModifier(self):
@@ -507,8 +522,8 @@ class MethodTests(unittest.TestCase):
         value = MethodTest.Overloaded.__overloads__[System.SByte](127)
         self.assertTrue(value == 127)
 
-        value = MethodTest.Overloaded.__overloads__[System.Char](six.u('A'))
-        self.assertTrue(value == six.u('A'))
+        value = MethodTest.Overloaded.__overloads__[System.Char](u'A')
+        self.assertTrue(value == u'A')
 
         value = MethodTest.Overloaded.__overloads__[System.Char](65535)
         self.assertTrue(value == unichr(65535))
@@ -523,27 +538,25 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value == 2147483647)
 
         value = MethodTest.Overloaded.__overloads__[System.Int64](
-            long(9223372036854775807)
+            9223372036854775807L
             )
-        self.assertTrue(value == long(9223372036854775807))
+        self.assertTrue(value == 9223372036854775807L)
 
-        # Python 3 has no explicit long type, use System.Int64 instead
-        if not six.PY3:
-            value = MethodTest.Overloaded.__overloads__[long](
-                long(9223372036854775807)
-                )
-            self.assertTrue(value == long(9223372036854775807))
+        value = MethodTest.Overloaded.__overloads__[long](
+            9223372036854775807L
+            )
+        self.assertTrue(value == 9223372036854775807L)
 
         value = MethodTest.Overloaded.__overloads__[System.UInt16](65000)
         self.assertTrue(value == 65000)
 
-        value = MethodTest.Overloaded.__overloads__[System.UInt32](long(4294967295))
-        self.assertTrue(value == long(4294967295))
+        value = MethodTest.Overloaded.__overloads__[System.UInt32](4294967295L)
+        self.assertTrue(value == 4294967295L)
 
         value = MethodTest.Overloaded.__overloads__[System.UInt64](
-            long(18446744073709551615)
+            18446744073709551615L
             )
-        self.assertTrue(value == long(18446744073709551615))
+        self.assertTrue(value == 18446744073709551615L)
 
         value = MethodTest.Overloaded.__overloads__[System.Single](3.402823e38)
         self.assertTrue(value == 3.402823e38)
@@ -625,10 +638,10 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value[1] == 127)        
 
         vtype = Array[System.Char]
-        input = vtype([six.u('A'), six.u('Z')])
+        input = vtype([u'A', u'Z'])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
-        self.assertTrue(value[0] == six.u('A'))
-        self.assertTrue(value[1] == six.u('Z'))
+        self.assertTrue(value[0] == u'A')
+        self.assertTrue(value[1] == u'Z')
 
         vtype = Array[System.Char]
         input = vtype([0, 65535])
@@ -655,18 +668,16 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value[1] == 2147483647)        
 
         vtype = Array[System.Int64]
-        input = vtype([0, long(9223372036854775807)])
+        input = vtype([0, 9223372036854775807L])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
         self.assertTrue(value[0] == 0)
-        self.assertTrue(value[1] == long(9223372036854775807))
+        self.assertTrue(value[1] == 9223372036854775807L)        
 
-        # Python 3 has no explicit long type, use System.Int64 instead
-        if not six.PY3:
-            vtype = Array[long]
-            input = vtype([0, long(9223372036854775807)])
-            value = MethodTest.Overloaded.__overloads__[vtype](input)
-            self.assertTrue(value[0] == 0)
-            self.assertTrue(value[1] == long(9223372036854775807))
+        vtype = Array[long]
+        input = vtype([0, 9223372036854775807L])
+        value = MethodTest.Overloaded.__overloads__[vtype](input)
+        self.assertTrue(value[0] == 0)
+        self.assertTrue(value[1] == 9223372036854775807L)        
 
         vtype = Array[System.UInt16]
         input = vtype([0, 65000])
@@ -675,16 +686,16 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value[1] == 65000)        
 
         vtype = Array[System.UInt32]
-        input = vtype([0, long(4294967295)])
+        input = vtype([0, 4294967295L])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
         self.assertTrue(value[0] == 0)
-        self.assertTrue(value[1] == long(4294967295))
+        self.assertTrue(value[1] == 4294967295L)        
 
         vtype = Array[System.UInt64]
-        input = vtype([0, long(18446744073709551615)])
+        input = vtype([0, 18446744073709551615L])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
         self.assertTrue(value[0] == 0)
-        self.assertTrue(value[1] == long(18446744073709551615))
+        self.assertTrue(value[1] == 18446744073709551615L)        
 
         vtype = Array[System.Single]
         input = vtype([0.0, 3.402823e38])

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -13,6 +13,12 @@ clr.AddReference("Python.Test")
 
 from Python.Test import MethodTest, MethodTestSub
 import System
+import six
+
+if six.PY3:
+    long = int
+    unichr = chr
+
 
 class MethodTests(unittest.TestCase):
     """Test CLR method support."""
@@ -235,11 +241,11 @@ class MethodTests(unittest.TestCase):
 
     def testSubclassInstanceConversion(self):
         """Test subclass instance conversion in method call."""
-        class sub(System.Exception):
+        class TestSubException(System.Exception):
             pass
 
         object = MethodTest()
-        instance = sub()
+        instance = TestSubException()
         result = object.TestSubclassConversion(instance)
         self.assertTrue(isinstance(result, System.Exception))
 
@@ -522,8 +528,8 @@ class MethodTests(unittest.TestCase):
         value = MethodTest.Overloaded.__overloads__[System.SByte](127)
         self.assertTrue(value == 127)
 
-        value = MethodTest.Overloaded.__overloads__[System.Char](u'A')
-        self.assertTrue(value == u'A')
+        value = MethodTest.Overloaded.__overloads__[System.Char](six.u('A'))
+        self.assertTrue(value == six.u('A'))
 
         value = MethodTest.Overloaded.__overloads__[System.Char](65535)
         self.assertTrue(value == unichr(65535))
@@ -538,25 +544,27 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value == 2147483647)
 
         value = MethodTest.Overloaded.__overloads__[System.Int64](
-            9223372036854775807L
+            long(9223372036854775807)
             )
-        self.assertTrue(value == 9223372036854775807L)
+        self.assertTrue(value == long(9223372036854775807))
 
-        value = MethodTest.Overloaded.__overloads__[long](
-            9223372036854775807L
-            )
-        self.assertTrue(value == 9223372036854775807L)
+        # Python 3 has no explicit long type, use System.Int64 instead
+        if not six.PY3:
+            value = MethodTest.Overloaded.__overloads__[long](
+                long(9223372036854775807)
+                )
+            self.assertTrue(value == long(9223372036854775807))
 
         value = MethodTest.Overloaded.__overloads__[System.UInt16](65000)
         self.assertTrue(value == 65000)
 
-        value = MethodTest.Overloaded.__overloads__[System.UInt32](4294967295L)
-        self.assertTrue(value == 4294967295L)
+        value = MethodTest.Overloaded.__overloads__[System.UInt32](long(4294967295))
+        self.assertTrue(value == long(4294967295))
 
         value = MethodTest.Overloaded.__overloads__[System.UInt64](
-            18446744073709551615L
+            long(18446744073709551615)
             )
-        self.assertTrue(value == 18446744073709551615L)
+        self.assertTrue(value == long(18446744073709551615))
 
         value = MethodTest.Overloaded.__overloads__[System.Single](3.402823e38)
         self.assertTrue(value == 3.402823e38)
@@ -638,10 +646,10 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value[1] == 127)        
 
         vtype = Array[System.Char]
-        input = vtype([u'A', u'Z'])
+        input = vtype([six.u('A'), six.u('Z')])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
-        self.assertTrue(value[0] == u'A')
-        self.assertTrue(value[1] == u'Z')
+        self.assertTrue(value[0] == six.u('A'))
+        self.assertTrue(value[1] == six.u('Z'))
 
         vtype = Array[System.Char]
         input = vtype([0, 65535])
@@ -668,16 +676,18 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value[1] == 2147483647)        
 
         vtype = Array[System.Int64]
-        input = vtype([0, 9223372036854775807L])
+        input = vtype([0, long(9223372036854775807)])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
         self.assertTrue(value[0] == 0)
-        self.assertTrue(value[1] == 9223372036854775807L)        
+        self.assertTrue(value[1] == long(9223372036854775807))
 
-        vtype = Array[long]
-        input = vtype([0, 9223372036854775807L])
-        value = MethodTest.Overloaded.__overloads__[vtype](input)
-        self.assertTrue(value[0] == 0)
-        self.assertTrue(value[1] == 9223372036854775807L)        
+        # Python 3 has no explicit long type, use System.Int64 instead
+        if not six.PY3:
+            vtype = Array[long]
+            input = vtype([0, long(9223372036854775807)])
+            value = MethodTest.Overloaded.__overloads__[vtype](input)
+            self.assertTrue(value[0] == 0)
+            self.assertTrue(value[1] == long(9223372036854775807))
 
         vtype = Array[System.UInt16]
         input = vtype([0, 65000])
@@ -686,16 +696,16 @@ class MethodTests(unittest.TestCase):
         self.assertTrue(value[1] == 65000)        
 
         vtype = Array[System.UInt32]
-        input = vtype([0, 4294967295L])
+        input = vtype([0, long(4294967295)])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
         self.assertTrue(value[0] == 0)
-        self.assertTrue(value[1] == 4294967295L)        
+        self.assertTrue(value[1] == long(4294967295))
 
         vtype = Array[System.UInt64]
-        input = vtype([0, 18446744073709551615L])
+        input = vtype([0, long(18446744073709551615)])
         value = MethodTest.Overloaded.__overloads__[vtype](input)
         self.assertTrue(value[0] == 0)
-        self.assertTrue(value[1] == 18446744073709551615L)        
+        self.assertTrue(value[1] == long(18446744073709551615))
 
         vtype = Array[System.Single]
         input = vtype([0.0, 3.402823e38])


### PR DESCRIPTION
In my local code I ran into a issue with default arguments. The code in the methodbinder.bind check if the arguments given is less than the arguments needed. If it is true check if there are any default arguments if so pull the default values.

The one exception is the indexer where setter is mapped to the arguments are passed along with the value. An example  T[k1, k2] = v would be passed down as a tuple like (k1,k2,v). I had to check for the default arguments in the mp_ass_subscript method before calling the SetItem. 

I've included simple unit tests that tests the default argument for method calls and indexers. 