### PR TITLE
Added Python 3.5 Support

### DIFF
--- a/pythonnet.sln
+++ b/pythonnet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Python.Runtime", "src\runtime\Python.Runtime.csproj", "{097B4AC0-74E9-4C58-BCF8-C69746EC8271}"
 EndProject
@@ -89,10 +89,14 @@ Global
 		{E29DCF0A-5114-4A98-B1DD-71264B6EA349}.ReleaseWin|x64.Build.0 = Release|x64
 		{E29DCF0A-5114-4A98-B1DD-71264B6EA349}.ReleaseWin|x86.ActiveCfg = Release|x86
 		{E29DCF0A-5114-4A98-B1DD-71264B6EA349}.ReleaseWin|x86.Build.0 = Release|x86
+		{86E834DE-1139-4511-96CC-69636A56E7AC}.DebugMono|x64.ActiveCfg = DebugWin|x64
+		{86E834DE-1139-4511-96CC-69636A56E7AC}.DebugMono|x86.ActiveCfg = DebugWin|x86
 		{86E834DE-1139-4511-96CC-69636A56E7AC}.DebugWin|x64.ActiveCfg = DebugWin|x64
 		{86E834DE-1139-4511-96CC-69636A56E7AC}.DebugWin|x64.Build.0 = DebugWin|x64
 		{86E834DE-1139-4511-96CC-69636A56E7AC}.DebugWin|x86.ActiveCfg = DebugWin|x86
 		{86E834DE-1139-4511-96CC-69636A56E7AC}.DebugWin|x86.Build.0 = DebugWin|x86
+		{86E834DE-1139-4511-96CC-69636A56E7AC}.ReleaseMono|x64.ActiveCfg = ReleaseWin|x64
+		{86E834DE-1139-4511-96CC-69636A56E7AC}.ReleaseMono|x86.ActiveCfg = ReleaseWin|x86
 		{86E834DE-1139-4511-96CC-69636A56E7AC}.ReleaseWin|x64.ActiveCfg = ReleaseWin|x64
 		{86E834DE-1139-4511-96CC-69636A56E7AC}.ReleaseWin|x64.Build.0 = ReleaseWin|x64
 		{86E834DE-1139-4511-96CC-69636A56E7AC}.ReleaseWin|x86.ActiveCfg = ReleaseWin|x86

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -38,8 +38,8 @@ public class clrModule
 // ReSharper restore InconsistentNaming
 // ReSharper restore CheckNamespace
 {
-// ReSharper disable InconsistentNaming
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+    // ReSharper disable InconsistentNaming
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [RGiesecke.DllExport.DllExport("PyInit_clr", System.Runtime.InteropServices.CallingConvention.StdCall)]
     public static IntPtr PyInit_clr()
 #else
@@ -107,7 +107,7 @@ public class clrModule
 #if DEBUG_PRINT
                 System.Console.WriteLine("Could not load Python.Runtime, so sad.");
 #endif
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
                 return IntPtr.Zero;
 #else
                 return;
@@ -119,7 +119,7 @@ public class clrModule
 		// So now we get the PythonEngine and execute the InitExt method on it.
         var pythonEngineType = pythonRuntime.GetType("Python.Runtime.PythonEngine");
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         return (IntPtr)pythonEngineType.InvokeMember("InitExt", System.Reflection.BindingFlags.InvokeMethod, null, null, null);
 #else
         pythonEngineType.InvokeMember("InitExt", System.Reflection.BindingFlags.InvokeMethod, null, null, null);

--- a/src/clrmodule/clrmodule.csproj
+++ b/src/clrmodule/clrmodule.csproj
@@ -40,7 +40,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseMono|x86'">
     <OutputPath>bin\x86\ReleaseMono\</OutputPath>
-    <DefineConstants Condition="'$(DefineConstants)' == ''"></DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -51,7 +52,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseMono|x64'">
     <OutputPath>bin\x64\ReleaseMono\</OutputPath>
-    <DefineConstants Condition="'$(DefineConstants)' == ''"></DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -84,7 +86,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseWin|x86'">
     <OutputPath>bin\x86\ReleaseWin\</OutputPath>
-    <DefineConstants Condition="'$(DefineConstants)' == ''"></DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -95,7 +98,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseWin|x64'">
     <OutputPath>bin\x64\ReleaseWin\</OutputPath>
-    <DefineConstants Condition="'$(DefineConstants)' == ''"></DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
@@ -103,6 +107,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <DefineConstants>PYTHON35</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RGiesecke.DllExport.Metadata">
@@ -124,8 +129,8 @@
     <TargetAssemblyPdb>$(TargetDir)$(TargetName).pdb</TargetAssemblyPdb>
   </PropertyGroup>
   <Target Name="AfterBuild" DependsOnTargets="RGieseckeDllExport">
-	<Copy SourceFiles="$(TargetAssembly)" DestinationFiles="$(PythonBuildDir)\clr.pyd" />
-	<Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFiles="$(PythonBuildDir)\clr.pdb" />
+    <Copy SourceFiles="$(TargetAssembly)" DestinationFiles="$(PythonBuildDir)\clr.pyd" />
+    <Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFiles="$(PythonBuildDir)\clr.pdb" />
   </Target>
   <Import Project="../../packages/UnmanagedExports.1.2.6/tools/RGiesecke.DllExport.targets" Condition="Exists('../../packages/UnmanagedExports.1.2.6/tools/RGiesecke.DllExport.targets')" />
 </Project>

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>Python.Runtime</AssemblyName>
     <RootNamespace>Python.Runtime</RootNamespace>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-  	<PythonBuildDir Condition=" '$(PythonBuildDir)' == '' ">$(SolutionDir)</PythonBuildDir>
+    <PythonBuildDir Condition=" '$(PythonBuildDir)' == '' ">$(SolutionDir)</PythonBuildDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseMono|x86'">
     <OutputPath>bin\x86\ReleaseMono\</OutputPath>
@@ -51,6 +51,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <DefineConstants>PYTHON35, UCS2</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugMono|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -94,27 +95,27 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-	<Choose>
-        <When Condition=" '$(Configuration)'=='DebugMono' ">
-            <ItemGroup>
-				<Reference Include="Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-				  <SpecificVersion>False</SpecificVersion>
-				  <HintPath>..\..\packages\MonoGAC\Mono.Posix\4.0.0.0__0738eb9f132ed756\Mono.Posix.dll</HintPath>
-				</Reference>
-            </ItemGroup>
-        </When>
-        <When Condition=" '$(Configuration)'=='ReleaseMono' ">
-            <ItemGroup>
-				<Reference Include="Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-				  <SpecificVersion>False</SpecificVersion>
-				  <HintPath>..\..\packages\MonoGAC\Mono.Posix\4.0.0.0__0738eb9f132ed756\Mono.Posix.dll</HintPath>
-				</Reference>
-            </ItemGroup>
-        </When>
-    </Choose>
-	<ItemGroup>
-		<Reference Include="System" />
-	</ItemGroup>
+  <Choose>
+    <When Condition=" '$(Configuration)'=='DebugMono' ">
+      <ItemGroup>
+        <Reference Include="Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+          <SpecificVersion>False</SpecificVersion>
+          <HintPath>..\..\packages\MonoGAC\Mono.Posix\4.0.0.0__0738eb9f132ed756\Mono.Posix.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition=" '$(Configuration)'=='ReleaseMono' ">
+      <ItemGroup>
+        <Reference Include="Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+          <SpecificVersion>False</SpecificVersion>
+          <HintPath>..\..\packages\MonoGAC\Mono.Posix\4.0.0.0__0738eb9f132ed756\Mono.Posix.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="arrayobject.cs" />
     <Compile Include="assemblyinfo.cs" />
@@ -184,7 +185,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="resources\clr.py">
-        <LogicalName>clr.py</LogicalName>
+      <LogicalName>clr.py</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
@@ -196,7 +197,7 @@
     <TargetAssemblyPdb>$(TargetDir)$(TargetName).pdb</TargetAssemblyPdb>
   </PropertyGroup>
   <Target Name="AfterBuild">
-	<Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />
-	<Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" />
+    <Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />
+    <Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" />
   </Target>
 </Project>

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -57,7 +57,7 @@ namespace Python.Runtime {
         //====================================================================
         // Standard comparison implementation for instances of reflected types.
         //====================================================================
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static IntPtr tp_richcompare(IntPtr ob, IntPtr other, int op) {
             if (op != Runtime.Py_EQ && op != Runtime.Py_NE)
             {

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -405,7 +405,7 @@ namespace Python.Runtime {
                 return true;
 
             case TypeCode.Int32:
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
                 // Trickery to support 64-bit platforms.
                 if (IntPtr.Size == 4) {
                     op = Runtime.PyNumber_Int(value);
@@ -456,7 +456,7 @@ namespace Python.Runtime {
                 return true;
 
             case TypeCode.Byte:
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
                 if (Runtime.PyObject_TypeCheck(value, Runtime.PyBytesType))
                 {
                     if (Runtime.PyBytes_Size(value) == 1)
@@ -496,7 +496,7 @@ namespace Python.Runtime {
                 return true;
 
             case TypeCode.SByte:
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
                 if (Runtime.PyObject_TypeCheck(value, Runtime.PyBytesType)) {
                     if (Runtime.PyBytes_Size(value) == 1) {
                         op = Runtime.PyBytes_AS_STRING(value);
@@ -534,7 +534,7 @@ namespace Python.Runtime {
                 return true;
 
             case TypeCode.Char:
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
                 if (Runtime.PyObject_TypeCheck(value, Runtime.PyBytesType)) {
                     if (Runtime.PyBytes_Size(value) == 1) {
                         op = Runtime.PyBytes_AS_STRING(value);

--- a/src/runtime/delegateobject.cs
+++ b/src/runtime/delegateobject.cs
@@ -103,7 +103,7 @@ namespace Python.Runtime {
         //====================================================================
         // Implements __cmp__ for reflected delegate types.
         //====================================================================
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static new IntPtr tp_richcompare(IntPtr ob, IntPtr other, int op) {
             if (op != Runtime.Py_EQ && op != Runtime.Py_NE)
             {

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -31,7 +31,7 @@ namespace Python.Runtime {
         internal ExceptionClassObject(Type tp) : base(tp) {
         }
 
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         internal static Exception ToException(IntPtr ob) {
             CLRObject co = GetManagedObject(ob) as CLRObject;
             if (co == null) {
@@ -114,7 +114,7 @@ namespace Python.Runtime {
 
             return Runtime.PyObject_GenericGetAttr(ob, key);
         }
-#endif      // (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#endif      // (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     }
 
     /// <summary>
@@ -136,7 +136,7 @@ namespace Python.Runtime {
         //===================================================================
 
         internal static void Initialize() {
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             exceptions_module = Runtime.PyImport_ImportModule("builtins");
 #else
             exceptions_module = Runtime.PyImport_ImportModule("exceptions");
@@ -572,15 +572,15 @@ namespace Python.Runtime {
            puplic static variables on the Exceptions class filled in from
            the python class using reflection in Initialize() looked up by
 		   name, not posistion. */
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static IntPtr BaseException;
 #endif
         public static IntPtr Exception;
         public static IntPtr StopIteration;
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static IntPtr GeneratorExit;
 #endif
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static IntPtr StandardError;
 #endif
         public static IntPtr ArithmeticError;
@@ -637,7 +637,7 @@ namespace Python.Runtime {
         public static IntPtr SyntaxWarning;
         public static IntPtr RuntimeWarning;
         public static IntPtr FutureWarning;
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static IntPtr ImportWarning;
         public static IntPtr UnicodeWarning;
         //PyAPI_DATA(PyObject *) PyExc_BytesWarning;

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -23,7 +23,7 @@ namespace Python.Runtime {
         static CLRModule root;
         static MethodWrapper hook;
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         static IntPtr py_clr_module;
         static IntPtr module_def;
 #endif
@@ -38,7 +38,7 @@ namespace Python.Runtime {
             // but it provides the most "Pythonic" way of dealing with CLR
             // modules (Python doesn't provide a way to emulate packages).
             IntPtr dict = Runtime.PyImport_GetModuleDict();
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             IntPtr mod = Runtime.PyImport_ImportModule("builtins");
             py_import = Runtime.PyObject_GetAttrString(mod, "__import__");
 #else
@@ -51,7 +51,7 @@ namespace Python.Runtime {
 
             root = new CLRModule();
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             // create a python module with the same methods as the clr module-like object
             module_def = ModuleDefOffset.AllocModuleDef("clr");
             py_clr_module = Runtime.PyModule_Create2(module_def, 3);
@@ -78,7 +78,7 @@ namespace Python.Runtime {
         //===================================================================
 
         internal static void Shutdown() {
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if (0 != Runtime.Py_IsInitialized()) {
                 Runtime.Decref(py_clr_module);
                 Runtime.Decref(root.pyHandle);
@@ -100,7 +100,7 @@ namespace Python.Runtime {
         //===================================================================
         public static IntPtr GetCLRModule(IntPtr? fromList=null) {
             root.InitializePreload();
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             // update the module dictionary with the contents of the root dictionary
             root.LoadNames();
             IntPtr py_mod_dict = Runtime.PyModule_GetDict(py_clr_module);

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -79,7 +79,7 @@ namespace Python.Runtime {
         }
 
         public static int magic(IntPtr ob) {
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
             {
@@ -91,7 +91,7 @@ namespace Python.Runtime {
 
         public static int DictOffset(IntPtr ob)
         {
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
             {
@@ -102,7 +102,7 @@ namespace Python.Runtime {
         }
 
         public static int Size(IntPtr ob) {
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
             {
@@ -126,7 +126,7 @@ namespace Python.Runtime {
         private static int ob_data;
     }
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
     internal class ExceptionOffset
     {
@@ -258,11 +258,11 @@ namespace Python.Runtime {
         public static int tp_subclasses = 0;
         public static int tp_weaklist = 0;
         public static int tp_del = 0;
-#if (PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         /* Type attribute cache version tag. Added in version 2.6 */
-	    public static int tp_version_tag;
+        public static int tp_version_tag;
 #endif
-#if (PYTHON34)
+#if (PYTHON34 || PYTHON35)
         public static int tp_finalize = 0;
 #endif
         // COUNT_ALLOCS adds some more stuff to PyTypeObject 
@@ -274,13 +274,13 @@ namespace Python.Runtime {
         public static int tp_prev = 0;
         public static int tp_next = 0;
 #endif
-//} PyTypeObject;
+        //} PyTypeObject;
 
-//typedef struct {
+        //typedef struct {
         public static int nb_add = 0;
         public static int nb_subtract = 0;
         public static int nb_multiply = 0;
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int nb_divide = 0;
 #endif
         public static int nb_remainder = 0;
@@ -296,13 +296,13 @@ namespace Python.Runtime {
         public static int nb_and = 0;
         public static int nb_xor = 0;
         public static int nb_or = 0;
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int nb_coerce = 0;
 #endif
         public static int nb_int = 0;
         public static int nb_long = 0;
         public static int nb_float = 0;
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int nb_oct = 0;
         public static int nb_hex = 0;
 #endif
@@ -310,7 +310,7 @@ namespace Python.Runtime {
         public static int nb_inplace_add = 0;
         public static int nb_inplace_subtract = 0;
         public static int nb_inplace_multiply = 0;
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int nb_inplace_divide = 0;
 #endif
         public static int nb_inplace_remainder = 0;
@@ -326,7 +326,7 @@ namespace Python.Runtime {
         public static int nb_true_divide = 0;
         public static int nb_inplace_floor_divide = 0;
         public static int nb_inplace_true_divide = 0;
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         /* Added in release 2.5 */
         public static int nb_index = 0;
 #endif
@@ -348,17 +348,17 @@ namespace Python.Runtime {
         /* Added in release 2.0 */
         public static int sq_inplace_concat = 0;
         public static int sq_inplace_repeat = 0;
-//} PySequenceMethods;
-//typedef struct {
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+        //} PySequenceMethods;
+        //typedef struct {
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int bf_getreadbuffer = 0;
         public static int bf_getwritebuffer = 0;
         public static int bf_getsegcount = 0;
         public static int bf_getcharbuffer = 0;
 #endif
-#if (PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         // This addition is not actually noted in the 2.6.5 object.h
-	    public static int bf_getbuffer = 0;
+        public static int bf_getbuffer = 0;
 	    public static int bf_releasebuffer = 0;
 //} PyBufferProcs;
 #endif
@@ -366,7 +366,7 @@ namespace Python.Runtime {
         public static int name = 0;
         public static int slots = 0;
 
-#if (PYTHON33 || PYTHON34)
+#if (PYTHON33 || PYTHON34 || PYTHON35)
         public static int qualname = 0;
         public static int cached_keys;
 #endif
@@ -375,7 +375,7 @@ namespace Python.Runtime {
         public static int members = 0;
     }
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
     internal class BytesOffset
     {
@@ -495,10 +495,10 @@ namespace Python.Runtime {
         /* XXX Reusing reserved constants */
         public static int Managed = (1 << 15); // PythonNet specific
         public static int Subclass = (1 << 16); // PythonNet specific
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int HaveIndex = (1 << 17);
 #endif
-#if (PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         /* Objects support nb_index in PyNumberMethods */
         public static int HaveVersionTag = (1 << 18);
         public static int ValidVersionTag = (1 << 19);
@@ -533,8 +533,8 @@ namespace Python.Runtime {
                              0);
 #endif
 
-// Default flags for Python 3
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+        // Default flags for Python 3
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int Default = (
                             HaveStacklessExtension |
                             HaveVersionTag);
@@ -597,7 +597,7 @@ namespace Python.Runtime {
             pmap["nb_add"] = p["BinaryFunc"];
             pmap["nb_subtract"] = p["BinaryFunc"];
             pmap["nb_multiply"] = p["BinaryFunc"];
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             pmap["nb_divide"] = p["BinaryFunc"];
 #endif
             pmap["nb_remainder"] = p["BinaryFunc"];
@@ -622,7 +622,7 @@ namespace Python.Runtime {
             pmap["nb_inplace_add"] = p["BinaryFunc"];
             pmap["nb_inplace_subtract"] = p["BinaryFunc"];
             pmap["nb_inplace_multiply"] = p["BinaryFunc"];
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             pmap["nb_inplace_divide"] = p["BinaryFunc"];
 #endif
             pmap["nb_inplace_remainder"] = p["BinaryFunc"];
@@ -636,7 +636,7 @@ namespace Python.Runtime {
             pmap["nb_true_divide"] = p["BinaryFunc"];
             pmap["nb_inplace_floor_divide"] = p["BinaryFunc"];
             pmap["nb_inplace_true_divide"] = p["BinaryFunc"];
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             pmap["nb_index"] = p["UnaryFunc"];
 #endif
 

--- a/src/runtime/methodwrapper.cs
+++ b/src/runtime/methodwrapper.cs
@@ -34,7 +34,7 @@ namespace Python.Runtime {
             // XXX - here we create a Python string object, then take the
             // char * of the internal string to pass to our methoddef
             // structure. Its a hack, and the name is leaked!
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             IntPtr ps = Runtime.PyBytes_FromString(name);
             IntPtr sp = Runtime.PyBytes_AS_STRING(ps);
 #else

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -195,7 +195,7 @@ namespace Python.Runtime {
         // CPython interpreter process - this bootstraps the managed runtime
         // when it is imported by the CLR extension module.
         //====================================================================
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static IntPtr InitExt() {
 #else
         public static void InitExt() {
@@ -242,12 +242,12 @@ namespace Python.Runtime {
             catch (PythonException e)
             {
                 e.Restore();
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
                 return IntPtr.Zero;
 #endif
             }
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             return Python.Runtime.ImportHook.GetCLRModule();
 #endif
         }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -15,7 +15,7 @@ using System.Text;
 using Mono.Unix;
 #endif
 
-#if (UCS2 && (PYTHON32 || PYTHON33 || PYTHON34))
+#if (UCS2 && (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35))
 using System.Text;
 #endif
 
@@ -144,8 +144,12 @@ namespace Python.Runtime {
         public const string pyversion = "3.4";
         public const int pyversionnumber = 34;
 #endif
-#if ! (PYTHON23 || PYTHON24 || PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
-#error You must define one of PYTHON23 to PYTHON34
+#if (PYTHON35)
+        public const string pyversion = "3.5";
+        public const int pyversionnumber = 35;
+#endif
+#if !(PYTHON23 || PYTHON24 || PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
+#error You must define one of PYTHON23 to PYTHON35
 #endif
 
 #if (PYTHON23)
@@ -173,6 +177,9 @@ namespace Python.Runtime {
 #if (PYTHON34)
         internal const string dllBase = "python3.4";
 #endif
+#if (PYTHON35)
+        internal const string dllBase = "python3.4";
+#endif
 #else
 #if (PYTHON32)
         internal const string dllBase = "python32";
@@ -182,6 +189,9 @@ namespace Python.Runtime {
 #endif
 #if (PYTHON34)
         internal const string dllBase = "python34";
+#endif
+#if (PYTHON35)
+        internal const string dllBase = "python35";
 #endif
 #endif
 
@@ -231,7 +241,7 @@ namespace Python.Runtime {
             Runtime.PyEval_InitThreads();
         }
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         IntPtr op = Runtime.PyImport_ImportModule("builtins");
         IntPtr dict = Runtime.PyObject_GetAttrString(op, "__dict__");
         PyNotImplemented = Runtime.PyObject_GetAttrString(op, "NotImplemented");
@@ -254,7 +264,7 @@ namespace Python.Runtime {
         PyMethodType = Runtime.PyObject_Type(op);
         Runtime.Decref(op);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         Runtime.Decref(dict);
         Runtime.Decref(op);
 #endif
@@ -267,7 +277,7 @@ namespace Python.Runtime {
         PyUnicodeType = Runtime.PyObject_Type(op);
         Runtime.Decref(op);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         op = Runtime.PyBytes_FromString("bytes");
         PyBytesType = Runtime.PyObject_Type(op);
         Runtime.Decref(op);
@@ -297,7 +307,7 @@ namespace Python.Runtime {
         PyFloatType = Runtime.PyObject_Type(op);
         Runtime.Decref(op);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         PyClassType = IntPtr.Zero;
         PyInstanceType = IntPtr.Zero;
 #else
@@ -318,7 +328,7 @@ namespace Python.Runtime {
 
         Error = new IntPtr(-1);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         IntPtr dll = IntPtr.Zero;
         if ("__Internal" != Runtime.dll) {
             NativeMethods.LoadLibrary(Runtime.dll);
@@ -336,7 +346,7 @@ namespace Python.Runtime {
         // of the Python runtime that do not allow new-style classes to
         // be used as exceptions (Python versions 2.4 and lower).
 
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         wrap_exceptions = false;
 #else
         IntPtr m = PyImport_ImportModule("exceptions");
@@ -404,7 +414,7 @@ namespace Python.Runtime {
     internal static IntPtr PyNoneType;
     internal static IntPtr PyTypeType;
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     internal static IntPtr PyBytesType;
     internal static IntPtr PyNotImplemented;
     internal const int Py_LT = 0;
@@ -663,7 +673,7 @@ namespace Python.Runtime {
     internal unsafe static extern IntPtr
     PyGILState_GetThisThreadState();
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
     public unsafe static extern int
@@ -731,7 +741,7 @@ namespace Python.Runtime {
     PyEval_GetLocals();
 
 
-#if PYTHON32 || PYTHON33 || PYTHON34
+#if PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
          ExactSpelling=true, CharSet=CharSet.Ansi)]
     [return: MarshalAs(UnmanagedType.LPWStr)]
@@ -976,7 +986,7 @@ namespace Python.Runtime {
     internal unsafe static extern IntPtr
     PyObject_CallObject(IntPtr pointer, IntPtr args);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
     internal unsafe static extern int
@@ -1058,7 +1068,7 @@ namespace Python.Runtime {
     internal unsafe static extern IntPtr
     PyObject_Str(IntPtr pointer);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
         EntryPoint="PyObject_Str",
         ExactSpelling = true, CharSet = CharSet.Ansi)]
@@ -1081,7 +1091,7 @@ namespace Python.Runtime {
     // Python number API
     //====================================================================
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         EntryPoint = "PyNumber_Long",
         ExactSpelling=true, CharSet=CharSet.Ansi)]
@@ -1130,7 +1140,7 @@ namespace Python.Runtime {
         return PyInt_FromLong(v);
     }
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "PyLong_FromLong",
         ExactSpelling = true, CharSet = CharSet.Ansi)]
@@ -1472,7 +1482,7 @@ namespace Python.Runtime {
         return PyString_FromStringAndSize(value, value.Length);
     }
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
     internal unsafe static extern IntPtr
@@ -1503,7 +1513,7 @@ namespace Python.Runtime {
         }
     }
 
-#if (PYTHON33 || PYTHON34)
+#if (PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
         ExactSpelling = true, CharSet = CharSet.Unicode)]
     internal unsafe static extern IntPtr
@@ -1545,7 +1555,7 @@ namespace Python.Runtime {
     }
 
 #if (UCS2)
-#if (PYTHON33 || PYTHON34)
+#if (PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Unicode)]
     internal unsafe static extern IntPtr
@@ -1642,7 +1652,7 @@ namespace Python.Runtime {
         IntPtr type = PyObject_TYPE(op);
 
 // Python 3 strings are all unicode
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         if (type == Runtime.PyStringType)
         {
             return Marshal.PtrToStringAnsi(
@@ -1664,7 +1674,7 @@ namespace Python.Runtime {
 
 #endif
 #if (UCS4)
-#if (PYTHON33 || PYTHON34)
+#if (PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Unicode)]
     internal unsafe static extern IntPtr
@@ -1767,7 +1777,7 @@ namespace Python.Runtime {
         IntPtr type = PyObject_TYPE(op);
 
 // Python 3 strings are all unicode
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         if (type == Runtime.PyStringType)
         {
             return Marshal.PtrToStringAnsi(
@@ -1982,7 +1992,7 @@ namespace Python.Runtime {
     // Python iterator API
     //====================================================================
 
-#if !(PYTHON32 || PYTHON33 || PYTHON34)
+#if !(PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
         ExactSpelling = true, CharSet = CharSet.Ansi)]
     internal unsafe static extern bool
@@ -2026,7 +2036,7 @@ namespace Python.Runtime {
     internal unsafe static extern string
     PyModule_GetFilename(IntPtr module);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
     internal unsafe static extern IntPtr

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -129,7 +129,7 @@ namespace Python.Runtime {
             // XXX Hack, use a different base class for System.Exception
             // Python 2.5+ allows new style class exceptions but they *must*
             // subclass BaseException (or better Exception).
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if (typeof(System.Exception).IsAssignableFrom(clrType))
             {
                 ob_size = ObjectOffset.Size(Exceptions.BaseException);
@@ -365,7 +365,7 @@ namespace Python.Runtime {
             // Cheat a little: we'll set tp_name to the internal char * of
             // the Python version of the type name - otherwise we'd have to
             // allocate the tp_name and would have no way to free it.
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             // For python3 we leak two objects. One for the ascii representation
             // required for tp_name, and another for the unicode representation
             // for ht_name.
@@ -379,7 +379,7 @@ namespace Python.Runtime {
             Marshal.WriteIntPtr(type, TypeOffset.tp_name, raw);
             Marshal.WriteIntPtr(type, TypeOffset.name, temp);
 
-#if (PYTHON33 || PYTHON34)
+#if (PYTHON33 || PYTHON34 || PYTHON35)
             Marshal.WriteIntPtr(type, TypeOffset.qualname, temp);
 #endif
 
@@ -394,7 +394,7 @@ namespace Python.Runtime {
             temp = new IntPtr(ptr + TypeOffset.mp_length);
             Marshal.WriteIntPtr(type, TypeOffset.tp_as_mapping, temp);
 
-#if (PYTHON32 || PYTHON33 || PYTHON34)
+#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             temp = new IntPtr(ptr + TypeOffset.bf_getbuffer);
             Marshal.WriteIntPtr(type, TypeOffset.tp_as_buffer, temp);
 #else


### PR DESCRIPTION
I added preliminary Python 3.5 support. A quick test (getting some properties from the System.Environment class) worked perfectly fine on Windows 10 x64 with Python 3.5.0 amd64.