### PR TITLE
Fix for 3dsMax Python

### DIFF
--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -67,7 +67,7 @@ namespace Python.Runtime {
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine($"Error scaning assembly {a}. {ex}");
+                    Debug.WriteLine(string.Format("Error scanning assembly {0}. {1}", a, ex));
                 }
             }
         }

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -57,10 +58,17 @@ namespace Python.Runtime {
             domain.AssemblyResolve += rhandler;
 
             Assembly[] items = domain.GetAssemblies();
-            for (int i = 0; i < items.Length; i++) {
-                Assembly a = items[i];
-                assemblies.Add(a);
-                ScanAssembly(a);
+            foreach (var a in items)
+            {
+                try
+                {
+                    ScanAssembly(a);
+                    assemblies.Add(a);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Error scaning assembly {a}. {ex}");
+                }
             }
         }
 
@@ -282,15 +290,15 @@ namespace Python.Runtime {
         // be valid namespaces (to better match Python import semantics).
         //===================================================================
 
-        static void ScanAssembly(Assembly assembly) {
-
+        static void ScanAssembly(Assembly assembly)
+        {
             // A couple of things we want to do here: first, we want to
             // gather a list of all of the namespaces contributed to by
             // the assembly.
 
             Type[] types = assembly.GetTypes();
-            for (int i = 0; i < types.Length; i++) {
-                Type t = types[i];
+            foreach (var t in types)
+            {
                 string ns = t.Namespace;
                 if ((ns != null) && (!namespaces.ContainsKey(ns))) {
                     string[] names = ns.Split('.');
@@ -298,9 +306,7 @@ namespace Python.Runtime {
                     for (int n = 0; n < names.Length; n++) {
                         s = (n == 0) ? names[0] : s + "." + names[n];
                         if (!namespaces.ContainsKey(s)) {
-                            namespaces.Add(s,
-                                           new Dictionary<Assembly, string>()
-                                           );
+                            namespaces.Add(s, new Dictionary<Assembly, string>());
                         }
                     }
                 }


### PR DESCRIPTION
Importing clr in 3dsMax python, causes the application to crash on
GetTypes from certain assemblies.