### PR TITLE
Fix appveyor config.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,24 +3,23 @@ os: Windows Server 2012
 environment:
   global:
     PYTHONPATH: c:\testdir
+    PYTHONWARNINGS: 'ignore:::pip.pep425tags:'
+    PIPURL: https://bootstrap.pypa.io/get-pip.py
 
   matrix:
   - pythonurl: http://www.python.org/ftp/python/2.7.6/python-2.7.6.amd64.msi
   - pythonurl: http://www.python.org/ftp/python/2.7.6/python-2.7.6.msi
-  - pythonurl: http://www.python.org/ftp/python/2.6.6/python-2.6.6.msi
-  - pythonurl: http://www.python.org/ftp/python/2.6.6/python-2.6.6.amd64.msi
-  - pythonurl: http://www.python.org/ftp/python/3.2.3/python-3.2.3.msi
-  - pythonurl: http://www.python.org/ftp/python/3.2.3/python-3.2.3.amd64.msi 
+  - pythonurl: http://www.python.org/ftp/python/3.3.5/python-3.3.5.msi
+  - pythonurl: http://www.python.org/ftp/python/3.3.5/python-3.3.5.amd64.msi 
   - pythonurl: http://www.python.org/ftp/python/3.4.2/python-3.4.2.msi
   - pythonurl: http://www.python.org/ftp/python/3.4.2/python-3.4.2.amd64.msi 
 
 install:
   - ps: (new-object net.webclient).DownloadFile($env:pythonurl, 'C:\python.msi')
-  - ps: start-process -wait -FilePath msiexec.exe -ArgumentList "/qn /i C:\python.msi TARGETDIR=C:\Python"
-  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:\get-pip.py')
-  # appveyor has python 2.7.6 x86 preinstalled, but in the wrong directory, this works around this
-  - ps: if ($env:pythonurl -eq "http://www.python.org/ftp/python/2.7.6/python-2.7.6.msi") {mi c:\python27 c:\python}
-  - set PATH=C:\Python;%PATH%
+  - ps: start-process -wait -FilePath msiexec.exe -ArgumentList '/qn /x C:\python.msi TARGETDIR=C:\Python'
+  - ps: start-process -wait -FilePath msiexec.exe -ArgumentList '/qn /i C:\python.msi TARGETDIR=C:\Python'
+  - ps: (new-object net.webclient).DownloadFile($env:PIPURL, 'C:\get-pip.py')
+  - C:\Python\python.exe --version
   - C:\Python\python.exe c:\get-pip.py
   - C:\Python\Scripts\pip.exe install wheel
   - C:\Python\Scripts\pip.exe install six
@@ -29,7 +28,7 @@ build_script:
   - C:\python\python.exe setup.py bdist_wheel
 
 test_script:
-  - ps: C:\python\scripts\pip.exe install ("dist\" + (gci dist)[0].Name)
+  - ps: C:\Python\Scripts\pip.exe install --no-cache-dir --force-reinstall --ignore-installed ('dist\' + (gci dist)[0].Name)
   - mkdir c:\testdir
   - ps: copy-item (gci -path build -re -include Python.Test.dll)[0].FullName c:\testdir
   - c:\python\python.exe src\tests\runtests.py


### PR DESCRIPTION
Drop tests for Python 2.6 and 3.2 as pip no longer supports those versions.
Add tests for Python 3.3.