### PR TITLE
Move the type subscript implementation into ClassBase.

### DIFF
--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -51,7 +51,21 @@ namespace Python.Runtime {
          //====================================================================
  
         public virtual IntPtr type_subscript(IntPtr idx) {
-            return Exceptions.RaiseTypeError("unsubscriptable object");
+            Type[] types = Runtime.PythonArgsToTypeArray(idx);
+            if (types == null) {
+                return Exceptions.RaiseTypeError("type(s) expected");
+            }
+
+            Type target = GenericUtil.GenericForType(this.type, types.Length);
+
+            if (target != null) {
+                Type t = target.MakeGenericType(types);
+                ManagedType c = (ManagedType)ClassManager.GetClass(t);
+                Runtime.Incref(c.pyHandle);
+                return c.pyHandle;
+            }
+
+            return Exceptions.RaiseTypeError("no type matches params");
         } 
 
         //====================================================================

--- a/src/runtime/generictype.cs
+++ b/src/runtime/generictype.cs
@@ -44,57 +44,6 @@ namespace Python.Runtime {
                                 "object is not callable");
             return IntPtr.Zero;
         }
-
-        //====================================================================
-        // Implements subscript syntax for reflected generic types. A closed 
-        // type is created by binding the generic type via subscript syntax:
-        // inst = List[str]()
-        //====================================================================
-
-        public override IntPtr type_subscript(IntPtr idx) {
-            Type[] types = Runtime.PythonArgsToTypeArray(idx);
-            if (types == null) {
-                return Exceptions.RaiseTypeError("type(s) expected");
-            }
-            if (!this.type.IsGenericTypeDefinition) {
-                return Exceptions.RaiseTypeError(
-                                  "type is not a generic type definition"
-                                  );
-            }
-
-            // This is a little tricky, because an instance of GenericType
-            // may represent either a specific generic type, or act as an
-            // alias for one or more generic types with the same base name.
-
-            if (this.type.ContainsGenericParameters) {
-                Type[] args = this.type.GetGenericArguments();
-                Type target = null;
-
-                if (args.Length == types.Length) {
-                    target = this.type;
-                }
-                else {
-                    foreach (Type t in 
-                             GenericUtil.GenericsForType(this.type)) {
-                        if (t.GetGenericArguments().Length == types.Length) {
-                            target = t;
-                            break;
-                        }
-                    }
-                }
-
-                if (target != null) {
-                    Type t = target.MakeGenericType(types);
-                    ManagedType c = (ManagedType)ClassManager.GetClass(t);
-                    Runtime.Incref(c.pyHandle);
-                    return c.pyHandle;
-                }
-                return Exceptions.RaiseTypeError("no type matches params");
-            }
-
-            return Exceptions.RaiseTypeError("unsubscriptable object");
-        }
-
     }
 
 }

--- a/src/runtime/genericutil.cs
+++ b/src/runtime/genericutil.cs
@@ -81,14 +81,33 @@ namespace Python.Runtime {
         // xxx
         //====================================================================
 
-        public static List<Type> GenericsForType(Type t) {
+        public static Type GenericForType(Type t, int paramCount)
+        {
+            return GenericByName(t.Namespace, t.Name, paramCount);
+        }
+
+        public static Type GenericByName(string ns, string name, int paramCount)
+        {
+            foreach (Type t in GenericsByName(ns, name))
+            {
+                if (t.GetGenericArguments().Length == paramCount)
+                    return t;
+            }
+            return null;
+        }
+
+        public static List<Type> GenericsForType(Type t)
+        {
+            return GenericsByName(t.Namespace, t.Name);
+        }
+
+        public static List<Type> GenericsByName(string ns, string basename) {
             Dictionary<string, List<string>> nsmap = null;
-            mapping.TryGetValue(t.Namespace, out nsmap);
+            mapping.TryGetValue(ns, out nsmap);
             if (nsmap == null) {
                 return null;
             }
 
-            string basename = t.Name;
             int tick = basename.IndexOf("`");
             if (tick > -1) {
                 basename = basename.Substring(0, tick);
@@ -102,7 +121,7 @@ namespace Python.Runtime {
 
             List<Type> result = new List<Type>();
             foreach (string name in names) {
-                string qname = t.Namespace + "." + name;
+                string qname = ns + "." + name;
                 Type o = AssemblyManager.LookupType(qname);
                 if (o != null) {
                     result.Add(o);


### PR DESCRIPTION
This fixes issues #157 and #128 by allowing the use of the type
subscript operator on all types instead of just generic types,
preventing the shadowing of generic types by a non-generic one like
System.Action or System.EventHandler.