### PR TITLE
[WIP] Implement __instancecheck__.

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -80,6 +80,10 @@ namespace Python.Runtime {
         // This always returns a new reference. Note that the System.Decimal
         // type has no Python equivalent and converts to a managed instance.
         //====================================================================
+        internal static IntPtr ToPython<T>(T value)
+        {
+            return ToPython(value, typeof(T));
+        }
 
         internal static IntPtr ToPython(Object value, Type type) {
             IntPtr result = IntPtr.Zero;

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -45,8 +45,8 @@ namespace Python.Runtime {
             IntPtr mod = Runtime.PyDict_GetItemString(dict, "__builtin__");
             py_import = Runtime.PyObject_GetAttrString(mod, "__import__");
 #endif
-              hook = new MethodWrapper(typeof(ImportHook), "__import__");
-              Runtime.PyObject_SetAttrString(mod, "__import__", hook.ptr);
+            hook = new MethodWrapper(typeof(ImportHook), "__import__", "TernaryFunc");
+            Runtime.PyObject_SetAttrString(mod, "__import__", hook.ptr);
             Runtime.Decref(hook.ptr);
 
             root = new CLRModule();

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -445,17 +445,19 @@ namespace Python.Runtime {
             pmap["bf_getwritebuffer"] = p["IntObjArgFunc"];
             pmap["bf_getsegcount"] = p["ObjObjFunc"];
             pmap["bf_getcharbuffer"] = p["IntObjArgFunc"];
-
-            pmap["__import__"] = p["TernaryFunc"];
-            pmap["__instancecheck__"] = p["BinaryFunc"];
         }
 
         internal static Type GetPrototype(string name) {
             return pmap[name] as Type;
         }
 
-        internal static IntPtr GetThunk(MethodInfo method) {
-            Type dt = Interop.GetPrototype(method.Name);
+        internal static IntPtr GetThunk(MethodInfo method, string funcType = null) {
+            Type dt;
+            if (funcType != null)
+                dt = typeof(Interop).GetNestedType(funcType) as Type;
+            else
+                dt = GetPrototype(method.Name);
+
             if (dt != null) {
                 IntPtr tmp = Marshal.AllocHGlobal(IntPtr.Size);
                 Delegate d = Delegate.CreateDelegate(dt, method);

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -447,6 +447,7 @@ namespace Python.Runtime {
             pmap["bf_getcharbuffer"] = p["IntObjArgFunc"];
 
             pmap["__import__"] = p["TernaryFunc"];
+            pmap["__instancecheck__"] = p["BinaryFunc"];
         }
 
         internal static Type GetPrototype(string name) {

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -260,7 +260,7 @@ namespace Python.Runtime {
             return;
         }
 
-        public static IntPtr __instancecheck__(IntPtr tp, IntPtr args)
+        static IntPtr DoInstanceCheck(IntPtr tp, IntPtr args, bool checkType)
         {
             ClassBase cb = GetManagedObject(tp) as ClassBase;
 
@@ -273,7 +273,11 @@ namespace Python.Runtime {
                     return Exceptions.RaiseTypeError("Invalid parameter count");
 
                 PyObject arg = argsObj[0];
-                PyObject otherType = arg.GetPythonType();
+                PyObject otherType;
+                if (checkType)
+                    otherType = arg;
+                else
+                    otherType = arg.GetPythonType();
 
                 if (Runtime.PyObject_TYPE(otherType.Handle) != PyCLRMetaType)
                     return Runtime.PyFalse;
@@ -284,6 +288,16 @@ namespace Python.Runtime {
 
                 return Converter.ToPython(cb.type.IsAssignableFrom(otherCb.type));
             }
+        }
+
+        public static IntPtr __instancecheck__(IntPtr tp, IntPtr args)
+        {
+            return DoInstanceCheck(tp, args, false);
+        }
+
+        public static IntPtr __subclasscheck__(IntPtr tp, IntPtr args)
+        {
+            return DoInstanceCheck(tp, args, true);
         }
     }
 }

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -260,10 +260,30 @@ namespace Python.Runtime {
             return;
         }
 
+        public static IntPtr __instancecheck__(IntPtr tp, IntPtr args)
+        {
+            ClassBase cb = GetManagedObject(tp) as ClassBase;
 
+            if (cb == null)
+                return Runtime.PyFalse;
 
+            using (PyList argsObj = new PyList(args))
+            {
+                if (argsObj.Length() != 1)
+                    return Exceptions.RaiseTypeError("Invalid parameter count");
 
+                PyObject arg = argsObj[0];
+                PyObject otherType = arg.GetPythonType();
+
+                if (Runtime.PyObject_TYPE(otherType.Handle) != PyCLRMetaType)
+                    return Runtime.PyFalse;
+
+                ClassBase otherCb = GetManagedObject(otherType.Handle) as ClassBase;
+                if (otherCb == null)
+                    return Runtime.PyFalse;
+
+                return Converter.ToPython(cb.type.IsAssignableFrom(otherCb.type));
+            }
+        }
     }
-
-
 }

--- a/src/runtime/methodwrapper.cs
+++ b/src/runtime/methodwrapper.cs
@@ -31,24 +31,13 @@ namespace Python.Runtime {
 
             IntPtr fp = Interop.GetThunk(type.GetMethod(name));
 
-            // XXX - here we create a Python string object, then take the
-            // char * of the internal string to pass to our methoddef
-            // structure. Its a hack, and the name is leaked!
-#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
-            IntPtr ps = Runtime.PyBytes_FromString(name);
-            IntPtr sp = Runtime.PyBytes_AS_STRING(ps);
-#else
-            IntPtr ps = Runtime.PyString_FromString(name);
-            IntPtr sp = Runtime.PyString_AS_STRING(ps);
-#endif
-
             // Allocate and initialize a PyMethodDef structure to represent 
             // the managed method, then create a PyCFunction. 
 
             mdef = Runtime.PyMem_Malloc(4 * IntPtr.Size);
-            Marshal.WriteIntPtr(mdef, sp);
+            Marshal.WriteIntPtr(mdef, Marshal.StringToHGlobalAnsi(name));
             Marshal.WriteIntPtr(mdef, (1 * IntPtr.Size), fp);
-            Marshal.WriteIntPtr(mdef, (2 * IntPtr.Size), (IntPtr)0x0003); // METH_VARARGS | METH_KEYWORDS
+            Marshal.WriteInt32(mdef, (2 * IntPtr.Size), 0x0003); // METH_VARARGS | METH_KEYWORDS
             Marshal.WriteIntPtr(mdef, (3 * IntPtr.Size), IntPtr.Zero);
             ptr = Runtime.PyCFunction_NewEx(mdef, IntPtr.Zero, IntPtr.Zero);
         }
@@ -56,10 +45,5 @@ namespace Python.Runtime {
         public IntPtr Call(IntPtr args, IntPtr kw) {
             return Runtime.PyCFunction_Call(ptr, args, kw);
         }
-
-
     }
-
-
 }
-

--- a/src/runtime/methodwrapper.cs
+++ b/src/runtime/methodwrapper.cs
@@ -25,20 +25,17 @@ namespace Python.Runtime {
         public IntPtr mdef;
         public IntPtr ptr;
 
-        public MethodWrapper(Type type, string name) {
+        public MethodWrapper(Type type, string name, string funcType = null) {
 
             // Turn the managed method into a function pointer
 
-            IntPtr fp = Interop.GetThunk(type.GetMethod(name));
+            IntPtr fp = Interop.GetThunk(type.GetMethod(name), funcType);
 
             // Allocate and initialize a PyMethodDef structure to represent 
             // the managed method, then create a PyCFunction. 
 
             mdef = Runtime.PyMem_Malloc(4 * IntPtr.Size);
-            Marshal.WriteIntPtr(mdef, Marshal.StringToHGlobalAnsi(name));
-            Marshal.WriteIntPtr(mdef, (1 * IntPtr.Size), fp);
-            Marshal.WriteInt32(mdef, (2 * IntPtr.Size), 0x0003); // METH_VARARGS | METH_KEYWORDS
-            Marshal.WriteIntPtr(mdef, (3 * IntPtr.Size), IntPtr.Zero);
+            TypeManager.WriteMethodDef(mdef, name, fp, 0x0003);
             ptr = Runtime.PyCFunction_NewEx(mdef, IntPtr.Zero, IntPtr.Zero);
         }
 

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -306,9 +306,14 @@ namespace Python.Runtime {
             IntPtr mdef = Runtime.PyMem_Malloc(5 * IntPtr.Size);
             Marshal.WriteIntPtr(mdef, Marshal.StringToHGlobalAnsi("__instancecheck__"));
             Marshal.WriteIntPtr(mdef, (1 * IntPtr.Size), fp);
-            Marshal.WriteIntPtr(mdef, (2 * IntPtr.Size), (IntPtr)0x0001); // METH_VARARGS
+            Marshal.WriteInt32(mdef, (2 * IntPtr.Size), 0x0001);
             Marshal.WriteIntPtr(mdef, (3 * IntPtr.Size), IntPtr.Zero);
+
+            // Write empty sentinel struct
             Marshal.WriteIntPtr(mdef, (4 * IntPtr.Size), IntPtr.Zero);
+            Marshal.WriteIntPtr(mdef, (5 * IntPtr.Size), IntPtr.Zero);
+            Marshal.WriteIntPtr(mdef, (6 * IntPtr.Size), IntPtr.Zero);
+            Marshal.WriteIntPtr(mdef, (7 * IntPtr.Size), IntPtr.Zero);
 
             Marshal.WriteIntPtr(type, TypeOffset.tp_methods, mdef);
 

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -302,6 +302,16 @@ namespace Python.Runtime {
             flags |= TypeFlags.HaveGC;
             Marshal.WriteIntPtr(type, TypeOffset.tp_flags, (IntPtr)flags);
 
+            IntPtr fp = Interop.GetThunk(typeof(MetaType).GetMethod("__instancecheck__"));
+            IntPtr mdef = Runtime.PyMem_Malloc(5 * IntPtr.Size);
+            Marshal.WriteIntPtr(mdef, Marshal.StringToHGlobalAnsi("__instancecheck__"));
+            Marshal.WriteIntPtr(mdef, (1 * IntPtr.Size), fp);
+            Marshal.WriteIntPtr(mdef, (2 * IntPtr.Size), (IntPtr)0x0001); // METH_VARARGS
+            Marshal.WriteIntPtr(mdef, (3 * IntPtr.Size), IntPtr.Zero);
+            Marshal.WriteIntPtr(mdef, (4 * IntPtr.Size), IntPtr.Zero);
+
+            Marshal.WriteIntPtr(type, TypeOffset.tp_methods, mdef);
+
             Runtime.PyType_Ready(type);
 
             IntPtr dict = Marshal.ReadIntPtr(type, TypeOffset.tp_dict);

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -348,12 +348,20 @@ class ExceptionTests(unittest.TestCase):
         # without causing a crash in the CPython interpreter). This test is
         # here mainly to remind me to update the caveat in the documentation
         # one day when when exceptions can be new-style classes.
+
+        # This behaviour is now over-shadowed by the implementation of
+        # __instancecheck__ (i.e., overloading isinstance), so for all Python
+        # version >= 2.6 we expect isinstance(<managed exception>, Object) to
+        # be true, even though it does not really subclass Object.
         from System import OverflowException
         from System import Object
         
         o = OverflowException('error')
-        self.assertFalse(isinstance(o, Object))
-    
+
+        if sys.version_info >= (2, 6):
+            self.assertTrue(isinstance(o, Object))
+        else:
+            self.assertFalse(isinstance(o, Object))
         
 
 def test_suite():


### PR DESCRIPTION
This implements the `__instancecheck__` method on the CLR metaclass which results in `isinstance` working for interfaces. I'm not completely sure whether everything still works and this is missing the `__subclasscheck__` to make `issubclass` work accordingly.

Also, I'd like to simplify the method def generation in `MethodWrapper` and this particular implementation as a prerequisite to implementing `__enter__` and `__exit__` for `IDisposable` objects.