### PR TITLE
Fix crash "Name must not be empty!"

### DIFF
--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -357,7 +357,7 @@ namespace Python.Runtime {
         //===================================================================
 
         public static bool IsValidNamespace(string name) {
-            return namespaces.ContainsKey(name);
+            return !String.IsNullOrEmpty(name) && namespaces.ContainsKey(name);
         }
 
         //===================================================================


### PR DESCRIPTION
Not sure why PythonNet was getting this exception (only on production server not dev machine).  Running my module with `python -m mymodule` would work fine.  Anyways, I debugged a bit and the attached change fixed my issue.

Please note this is a quick hack, just to keep my project going and it worked.  I have no idea of the underlying cause and do not want to investigate but if you think my change is not risky you may want to merge as it does fix this issue (or at least hides the issue).

A quick [Google](https://www.google.com.au/search?num=100&q="Name+must+not+be+empty%21"+PythonNet) shows that I'm not the first to get this exception.

Exception Details:
```
System.ArgumentException: Name must not be empty!
   at Python.Runtime.ModuleObject..ctor(String name) in c:\dev\libs\pythonnet\src\runtime\moduleobject.cs:line 36
   at Python.Runtime.ModuleObject.GetAttribute(String name, Boolean guess) in c:\dev\libs\pythonnet\src\runtime\moduleobject.cs:line 104
   at Python.Runtime.ImportHook.__import__(IntPtr self, IntPtr args, IntPtr kw) in c:\dev\libs\pythonnet\src\runtime\importhook.cs:line 301
   at Python.Runtime.Runtime.PyObject_Call(IntPtr pointer, IntPtr args, IntPtr kw)
   at Python.Runtime.ImportHook.__import__(IntPtr self, IntPtr args, IntPtr kw) in c:\dev\libs\pythonnet\src\runtime\importhook.cs:line 230
   at Python.Runtime.Runtime.PyObject_Call(IntPtr pointer, IntPtr args, IntPtr kw)
   at Python.Runtime.ImportHook.__import__(IntPtr self, IntPtr args, IntPtr kw) in c:\dev\libs\pythonnet\src\runtime\importhook.cs:line 230
   at Python.Runtime.Runtime.PyObject_Call(IntPtr pointer, IntPtr args, IntPtr kw)
   at Python.Runtime.ImportHook.__import__(IntPtr self, IntPtr args, IntPtr kw) in c:\dev\libs\pythonnet\src\runtime\importhook.cs:line 230
   at Python.Runtime.Runtime.PyObject_Call(IntPtr pointer, IntPtr args, IntPtr kw)
   at Python.Runtime.ImportHook.__import__(IntPtr self, IntPtr args, IntPtr kw) in c:\dev\libs\pythonnet\src\runtime\importhook.cs:line 230
   at Python.Runtime.Runtime.PyObject_Call(IntPtr pointer, IntPtr args, IntPtr kw)
   at Python.Runtime.ImportHook.__import__(IntPtr self, IntPtr args, IntPtr kw) in c:\dev\libs\pythonnet\src\runtime\importhook.cs:line 230
   at Python.Runtime.Runtime.PyObject_Call(IntPtr pointer, IntPtr args, IntPtr kw)
   at Python.Runtime.ImportHook.__import__(IntPtr self, IntPtr args, IntPtr kw) in c:\dev\libs\pythonnet\src\runtime\importhook.cs:line 230
   at Python.Runtime.Runtime.PyImport_ImportModule(String name)
   at Python.Runtime.PythonEngine.ImportModule(String name) in c:\dev\libs\pythonnet\src\runtime\pythonengine.cs:line 361
```