### PR TITLE
Explicit marshalling of Py_SetPythonHome string.

### DIFF
--- a/src/embed_tests/pysethome.cs
+++ b/src/embed_tests/pysethome.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Python.Runtime;
+
+
+namespace Python.EmbeddingTest
+{
+    public class PySetHomeSet
+    {
+        [SetUp]
+        public void SetUp()
+        {
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void TestSetHome()
+        {
+            string homePath = @"C:\Python27\";
+            PythonEngine.PythonHome = homePath;
+            PythonEngine.Initialize();
+            Assert.AreEqual(PythonEngine.PythonHome, homePath);
+        }
+    }
+}

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -11,6 +11,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Python.Runtime {
 
@@ -62,7 +63,8 @@ namespace Python.Runtime {
                 return result;
             }
             set {
-                Runtime.Py_SetPythonHome(value);
+                IntPtr pythonHome = Marshal.StringToHGlobalAnsi(value);
+                Runtime.Py_SetPythonHome(pythonHome);
             }
         }
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -762,7 +762,7 @@ namespace Python.Runtime {
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
         internal unsafe static extern void
-        Py_SetPythonHome([MarshalAsAttribute(UnmanagedType.LPWStr)]string home);
+        Py_SetPythonHome(IntPtr home);
 
     [DllImport(Runtime.dll, CallingConvention=CallingConvention.Cdecl,
         ExactSpelling=true, CharSet=CharSet.Ansi)]
@@ -793,7 +793,7 @@ namespace Python.Runtime {
     [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
         ExactSpelling = true, CharSet = CharSet.Ansi)]
     internal unsafe static extern void
-    Py_SetPythonHome(string home);
+    Py_SetPythonHome(IntPtr home);
 
     [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
         ExactSpelling = true, CharSet = CharSet.Ansi)]


### PR DESCRIPTION
Updates as described in https://github.com/pythonnet/pythonnet/issues/179.

I did look at calling `Marshal.FreeHGlobal()` in the `PythonEngine.Shutdown()` method after the call to shutdown Python is made, however it looks as though Python is doing the required memory tidy up.

Unit test has been created but is written to assume Python is installed at C:\Python27\. 