### PR TITLE
quick fix for old nuget can't find packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,10 @@ class PythonNET_BuildExt(build_ext):
             nuget = "mono %s" % nuget
             use_shell = True
 
+        cmd = "%s update -self" % nuget
+        self.announce("Updating NuGet: %s" % cmd)
+        check_call(cmd, shell=use_shell)
+
         cmd = "%s restore pythonnet.sln -o packages" % nuget
         self.announce("Installing packages: %s" % cmd)
         check_call(cmd, shell=use_shell)


### PR DESCRIPTION
In Linux with Mono, NuGet leaves error message:
  Unable to find version '1.2.6' of package 'UnmanagedExports'.
It can be simply solved by updating nuget.exe itself, but that's not obvious through error message, so I modified setup.py.