### PR TITLE
Calling isinstance(x,t) repeatedly when x or t is not actually a CLR …

### DIFF
--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -281,8 +281,10 @@ namespace Python.Runtime
         {
             ClassBase cb = GetManagedObject(tp) as ClassBase;
 
-            if (cb == null)
+            if (cb == null) {
+                Runtime.Incref(Runtime.PyFalse);
                 return Runtime.PyFalse;
+            }
 
             using (PyList argsObj = new PyList(args))
             {
@@ -296,12 +298,16 @@ namespace Python.Runtime
                 else
                     otherType = arg.GetPythonType();
 
-                if (Runtime.PyObject_TYPE(otherType.Handle) != PyCLRMetaType)
+                if (Runtime.PyObject_TYPE(otherType.Handle) != PyCLRMetaType) {
+                    Runtime.Incref(Runtime.PyFalse);
                     return Runtime.PyFalse;
+                }
 
                 ClassBase otherCb = GetManagedObject(otherType.Handle) as ClassBase;
-                if (otherCb == null)
+                if (otherCb == null) {
+                    Runtime.Incref(Runtime.PyFalse);
                     return Runtime.PyFalse;
+                }
 
                 return Converter.ToPython(cb.type.IsAssignableFrom(otherCb.type));
             }

--- a/src/tests/test_subclass.py
+++ b/src/tests/test_subclass.py
@@ -147,6 +147,21 @@ class SubClassTests(unittest.TestCase):
         self.assertEqual(event_handler.value, 3)
         self.assertEqual(len(d.event_handlers), 1)
 
+    def test_isinstance(self):
+        from System import Object
+        from System import String
+
+        a = [str(x) for x in range(0, 1000)]
+        b = [String(x) for x in a]
+
+        for x in a:
+            self.assertFalse(isinstance(x, Object))
+            self.assertFalse(isinstance(x, String))
+
+        for x in b:
+            self.assertTrue(isinstance(x, Object))
+            self.assertTrue(isinstance(x, String))
+
 
 def test_suite():
     return unittest.makeSuite(SubClassTests)


### PR DESCRIPTION
…object will leak reference counts to PyFalse, resulting in memory corruption once the reference count drops to zero and PyFalse gets freed