### PR TITLE
Strings should be able to be passed to functions expecting Object

### DIFF
--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -364,9 +364,11 @@ namespace Python.Runtime
                                     if (!typematch)
                                     {
                                         // this takes care of enum values
+                                        // special case: string is assignable to object
                                         TypeCode argtypecode = Type.GetTypeCode(pi[n].ParameterType);
                                         TypeCode paramtypecode = Type.GetTypeCode(clrtype);
-                                        if (argtypecode == paramtypecode)
+                                        if (argtypecode == paramtypecode
+                                            || (argtypecode == TypeCode.Object && paramtypecode == TypeCode.String)) 
                                         {
                                             typematch = true;
                                             clrtype = pi[n].ParameterType;

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -616,6 +616,10 @@ namespace Python.Test
         {
             return i;
         }
+
+        public static object ObjectParam(object o) {
+            return o;
+        }
     }
 
 

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -782,6 +782,11 @@ class MethodTests(unittest.TestCase):
         data = ''.join(data)
         self.assertEqual(data, 'Some testing string')
 
+    def testStringAsObjectArg(self):
+        s = "hello world"
+        self.assertEqual(s, MethodTest.ObjectParam(s))
+
+
 def test_suite():
     return unittest.makeSuite(MethodTests)
 


### PR DESCRIPTION
We discovered this problem during our Python 3 conversion. This used to work with Python 2 where we had a roundtrip of
call C# method that returns C# string -> Python unicode -> pass Python unicode to C# function which takes object
Now in Python 3 this no longer works since the C# string is converted to a Python string.