### PR TITLE
Remove printing if Decref is called with NULL. Rename Decref/Incref to XDecref/XIncref

### DIFF
--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -57,7 +57,7 @@ namespace Python.Runtime
             {
                 Type t = target.MakeGenericType(types);
                 ManagedType c = (ManagedType)ClassManager.GetClass(t);
-                Runtime.Incref(c.pyHandle);
+                Runtime.XIncref(c.pyHandle);
                 return c.pyHandle;
             }
 
@@ -71,7 +71,7 @@ namespace Python.Runtime
         public static IntPtr tp_richcompare(IntPtr ob, IntPtr other, int op) {
             if (op != Runtime.Py_EQ && op != Runtime.Py_NE)
             {
-                Runtime.Incref(Runtime.PyNotImplemented);
+                Runtime.XIncref(Runtime.PyNotImplemented);
                 return Runtime.PyNotImplemented;
             }
 
@@ -86,14 +86,14 @@ namespace Python.Runtime
             }
 
             if (ob == other) {
-                Runtime.Incref(pytrue);
+                Runtime.XIncref(pytrue);
                 return pytrue;
             }
 
             CLRObject co1 = GetManagedObject(ob) as CLRObject;
             CLRObject co2 = GetManagedObject(other) as CLRObject;
 			if (null == co2) {
-				Runtime.Incref(pyfalse);
+				Runtime.XIncref(pyfalse);
 				return pyfalse;
 			}
 
@@ -101,11 +101,11 @@ namespace Python.Runtime
             Object o2 = co2.inst;
 
             if (Object.Equals(o1, o2)) {
-                Runtime.Incref(pytrue);
+                Runtime.XIncref(pytrue);
                 return pytrue;
             }
 
-            Runtime.Incref(pyfalse);
+            Runtime.XIncref(pyfalse);
             return pyfalse;
         }
 #else
@@ -237,11 +237,11 @@ namespace Python.Runtime
             IntPtr dict = Marshal.ReadIntPtr(ob, ObjectOffset.DictOffset(ob));
             if (dict != IntPtr.Zero)
             {
-                Runtime.Decref(dict);
+                Runtime.XDecref(dict);
             }
             Runtime.PyObject_GC_UnTrack(self.pyHandle);
             Runtime.PyObject_GC_Del(self.pyHandle);
-            Runtime.Decref(self.tpHandle);
+            Runtime.XDecref(self.tpHandle);
             self.gcHandle.Free();
         }
     }

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -81,7 +81,7 @@ namespace Python.Runtime
             FieldInfo fi = obj.GetType().GetField("__pyobj__");
             CLRObject self = (CLRObject)fi.GetValue(obj);
 
-            Runtime.Incref(self.pyHandle);
+            Runtime.XIncref(self.pyHandle);
 
             // when the C# constructor creates the python object it starts as a weak
             // reference with a reference count of 0. Now we're passing this object
@@ -153,7 +153,7 @@ namespace Python.Runtime
             HashSet<string> pyProperties = new HashSet<string>();
             if (py_dict != IntPtr.Zero && Runtime.PyDict_Check(py_dict))
             {
-                Runtime.Incref(py_dict);
+                Runtime.XIncref(py_dict);
                 using (PyDict dict = new PyDict(py_dict))
                 using (PyObject keys = dict.Keys())
                 {
@@ -196,7 +196,7 @@ namespace Python.Runtime
             // Add any additional methods and properties explicitly exposed from Python.
             if (py_dict != IntPtr.Zero && Runtime.PyDict_Check(py_dict))
             {
-                Runtime.Incref(py_dict);
+                Runtime.XIncref(py_dict);
                 using (PyDict dict = new PyDict(py_dict))
                 using (PyObject keys = dict.Keys())
                 {
@@ -588,11 +588,11 @@ namespace Python.Runtime
                 IntPtr gs = Runtime.PyGILState_Ensure();
                 try
                 {
-                    Runtime.Incref(self.pyHandle);
+                    Runtime.XIncref(self.pyHandle);
                     PyObject pyself = new PyObject(self.pyHandle);
                     disposeList.Add(pyself);
 
-                    Runtime.Incref(Runtime.PyNone);
+                    Runtime.XIncref(Runtime.PyNone);
                     PyObject pynone = new PyObject(Runtime.PyNone);
                     disposeList.Add(pynone);
 
@@ -649,11 +649,11 @@ namespace Python.Runtime
                 IntPtr gs = Runtime.PyGILState_Ensure();
                 try
                 {
-                    Runtime.Incref(self.pyHandle);
+                    Runtime.XIncref(self.pyHandle);
                     PyObject pyself = new PyObject(self.pyHandle);
                     disposeList.Add(pyself);
 
-                    Runtime.Incref(Runtime.PyNone);
+                    Runtime.XIncref(Runtime.PyNone);
                     PyObject pynone = new PyObject(Runtime.PyNone);
                     disposeList.Add(pynone);
 
@@ -710,7 +710,7 @@ namespace Python.Runtime
             IntPtr gs = Runtime.PyGILState_Ensure();
             try
             {
-                Runtime.Incref(self.pyHandle);
+                Runtime.XIncref(self.pyHandle);
                 using (PyObject pyself = new PyObject(self.pyHandle))
                 using (PyObject pyvalue = pyself.GetAttr(propertyName))
                     return (T)pyvalue.AsManagedObject(typeof(T));
@@ -732,7 +732,7 @@ namespace Python.Runtime
             IntPtr gs = Runtime.PyGILState_Ensure();
             try
             {
-                Runtime.Incref(self.pyHandle);
+                Runtime.XIncref(self.pyHandle);
                 using (PyObject pyself = new PyObject(self.pyHandle))
                 using (PyObject pyvalue = new PyObject(Converter.ToPythonImplicit(value)))
                     pyself.SetAttr(propertyName, pyvalue);
@@ -766,11 +766,11 @@ namespace Python.Runtime
                 FieldInfo fi = obj.GetType().GetField("__pyobj__");
                 fi.SetValue(obj, self);
 
-                Runtime.Incref(self.pyHandle);
+                Runtime.XIncref(self.pyHandle);
                 PyObject pyself = new PyObject(self.pyHandle);
                 disposeList.Add(pyself);
 
-                Runtime.Incref(Runtime.PyNone);
+                Runtime.XIncref(Runtime.PyNone);
                 PyObject pynone = new PyObject(Runtime.PyNone);
                 disposeList.Add(pynone);
 
@@ -806,7 +806,7 @@ namespace Python.Runtime
                 // This doesn't actually destroy the object, it just sets the reference to this object
                 // to be a weak reference and it will be destroyed when the C# object is destroyed.
                 if (null != self)
-                    Runtime.Decref(self.pyHandle);
+                    Runtime.XDecref(self.pyHandle);
 
                 Runtime.PyGILState_Release(gs);
             }
@@ -848,7 +848,7 @@ namespace Python.Runtime
                         // python object.
                         IntPtr dict = Marshal.ReadIntPtr(self.pyHandle, ObjectOffset.DictOffset(self.pyHandle));
                         if (dict != IntPtr.Zero)
-                            Runtime.Decref(dict);
+                            Runtime.XDecref(dict);
                         Runtime.PyObject_GC_Del(self.pyHandle);
                         self.gcHandle.Free();
                     }

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -160,7 +160,7 @@ namespace Python.Runtime
                 string docStr = attr.DocString;
                 doc = Runtime.PyString_FromString(docStr);
                 Runtime.PyDict_SetItemString(dict, "__doc__", doc);
-                Runtime.Decref(doc);
+                Runtime.XDecref(doc);
             }
 
             ClassObject co = impl as ClassObject;
@@ -185,7 +185,7 @@ namespace Python.Runtime
                     {
                         doc = co.GetDocString();
                         Runtime.PyDict_SetItemString(dict, "__doc__", doc);
-                        Runtime.Decref(doc);
+                        Runtime.XDecref(doc);
                     }
                 }
             }

--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -159,7 +159,7 @@ namespace Python.Runtime
             {
                 GenericType g = ClassManager.GetClass(gtype) as GenericType;
                 return g.type_subscript(idx);
-                /*Runtime.Incref(g.pyHandle);
+                /*Runtime.XIncref(g.pyHandle);
                 return g.pyHandle;*/
             }
             return Exceptions.RaiseTypeError("unsubscriptable object");

--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -139,7 +139,7 @@ namespace Python.Runtime
                 }
                 Type a = t.MakeArrayType();
                 ClassBase o = ClassManager.GetClass(a);
-                Runtime.Incref(o.pyHandle);
+                Runtime.XIncref(o.pyHandle);
                 return o.pyHandle;
             }
 
@@ -194,7 +194,7 @@ namespace Python.Runtime
             if (!Runtime.PyTuple_Check(idx))
             {
                 args = Runtime.PyTuple_New(1);
-                Runtime.Incref(idx);
+                Runtime.XIncref(idx);
                 Runtime.PyTuple_SetItem(args, 0, idx);
                 free = true;
             }
@@ -209,7 +209,7 @@ namespace Python.Runtime
             {
                 if (free)
                 {
-                    Runtime.Decref(args);
+                    Runtime.XDecref(args);
                 }
             }
             return value;
@@ -243,7 +243,7 @@ namespace Python.Runtime
             if (!Runtime.PyTuple_Check(idx))
             {
                 args = Runtime.PyTuple_New(1);
-                Runtime.Incref(idx);
+                Runtime.XIncref(idx);
                 Runtime.PyTuple_SetItem(args, 0, idx);
                 free = true;
             }
@@ -257,7 +257,7 @@ namespace Python.Runtime
             for (int n = 0; n < i; n++)
             {
                 IntPtr item = Runtime.PyTuple_GetItem(args, n);
-                Runtime.Incref(item);
+                Runtime.XIncref(item);
                 Runtime.PyTuple_SetItem(real, n, item);
             }
 
@@ -265,15 +265,15 @@ namespace Python.Runtime
             for (int n = 0; n < numOfDefaultArgs; n++)
             {
                 IntPtr item = Runtime.PyTuple_GetItem(defaultArgs, n);
-                Runtime.Incref(item);
+                Runtime.XIncref(item);
                 Runtime.PyTuple_SetItem(real, n + i, item);
             }
             // no longer need defaultArgs
-            Runtime.Decref(defaultArgs);
+            Runtime.XDecref(defaultArgs);
             i = temp;
 
             // Add value to argument list
-            Runtime.Incref(v);
+            Runtime.XIncref(v);
             Runtime.PyTuple_SetItem(real, i, v);
 
             try
@@ -282,11 +282,11 @@ namespace Python.Runtime
             }
             finally
             {
-                Runtime.Decref(real);
+                Runtime.XDecref(real);
 
                 if (free)
                 {
-                    Runtime.Decref(args);
+                    Runtime.XDecref(args);
                 }
             }
 

--- a/src/runtime/constructorbinder.cs
+++ b/src/runtime/constructorbinder.cs
@@ -92,7 +92,7 @@ namespace Python.Runtime
 
                 IntPtr eargs = Runtime.PyTuple_New(0);
                 binding = this.Bind(inst, eargs, kw);
-                Runtime.Decref(eargs);
+                Runtime.XDecref(eargs);
 
                 if (binding == null)
                 {

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -30,7 +30,7 @@ namespace Python.Runtime
         public ConstructorBinding(Type type, IntPtr pyTypeHndl, ConstructorBinder ctorBinder) : base()
         {
             this.type = type;
-            Runtime.Incref(pyTypeHndl);
+            Runtime.XIncref(pyTypeHndl);
             this.pyTypeHndl = pyTypeHndl;
             this.ctorBinder = ctorBinder;
             repr = IntPtr.Zero;
@@ -73,7 +73,7 @@ namespace Python.Runtime
                     return Exceptions.RaiseTypeError("How in the world could that happen!");
                 }
             }*/
-            Runtime.Incref(self.pyHandle); // Decref'd by the interpreter.
+            Runtime.XIncref(self.pyHandle); // Decref'd by the interpreter.
             return self.pyHandle;
         }
 
@@ -121,7 +121,7 @@ namespace Python.Runtime
             ConstructorBinding self = (ConstructorBinding)GetManagedObject(ob);
             if (self.repr != IntPtr.Zero)
             {
-                Runtime.Incref(self.repr);
+                Runtime.XIncref(self.repr);
                 return self.repr;
             }
             MethodBase[] methods = self.ctorBinder.GetMethods();
@@ -136,7 +136,7 @@ namespace Python.Runtime
                 doc += String.Format("{0}{1}", name, str.Substring(idx));
             }
             self.repr = Runtime.PyString_FromString(doc);
-            Runtime.Incref(self.repr);
+            Runtime.XIncref(self.repr);
             return self.repr;
         }
 
@@ -147,9 +147,8 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             ConstructorBinding self = (ConstructorBinding)GetManagedObject(ob);
-            if (self.repr != IntPtr.Zero)
-                Runtime.Decref(self.repr);
-            Runtime.Decref(self.pyTypeHndl);
+            Runtime.XDecref(self.repr);
+            Runtime.XDecref(self.pyTypeHndl);
             ExtensionType.FinalizeObject(self);
         }
     }
@@ -174,7 +173,7 @@ namespace Python.Runtime
             : base()
         {
             this.type = type;
-            Runtime.Incref(pyTypeHndl);
+            Runtime.XIncref(pyTypeHndl);
             this.pyTypeHndl = pyTypeHndl;
             this.ctorBinder = ctorBinder;
             ctorInfo = ci;
@@ -218,7 +217,7 @@ namespace Python.Runtime
             BoundContructor self = (BoundContructor)GetManagedObject(ob);
             if (self.repr != IntPtr.Zero)
             {
-                Runtime.Incref(self.repr);
+                Runtime.XIncref(self.repr);
                 return self.repr;
             }
             string name = self.type.FullName;
@@ -226,7 +225,7 @@ namespace Python.Runtime
             int idx = str.IndexOf("(");
             str = String.Format("returns a new {0}{1}", name, str.Substring(idx));
             self.repr = Runtime.PyString_FromString(str);
-            Runtime.Incref(self.repr);
+            Runtime.XIncref(self.repr);
             return self.repr;
         }
 
@@ -237,9 +236,8 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             BoundContructor self = (BoundContructor)GetManagedObject(ob);
-            if (self.repr != IntPtr.Zero)
-                Runtime.Decref(self.repr);
-            Runtime.Decref(self.pyTypeHndl);
+            Runtime.XDecref(self.repr);
+            Runtime.XDecref(self.pyTypeHndl);
             ExtensionType.FinalizeObject(self);
         }
     }

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -108,7 +108,7 @@ namespace Python.Runtime
             BoundContructor boundCtor = new BoundContructor(self.type, self.pyTypeHndl, self.ctorBinder, ci);
 
             /* Since nothing's chached, do we need the increment???
-            Runtime.Incref(boundCtor.pyHandle);  // Decref'd by the interpreter??? */
+            Runtime.XIncref(boundCtor.pyHandle);  // Decref'd by the interpreter??? */
             return boundCtor.pyHandle;
         }
 

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -147,7 +147,8 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             ConstructorBinding self = (ConstructorBinding)GetManagedObject(ob);
-            Runtime.Decref(self.repr);
+            if (self.repr != IntPtr.Zero)
+                Runtime.Decref(self.repr);
             Runtime.Decref(self.pyTypeHndl);
             ExtensionType.FinalizeObject(self);
         }

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -236,7 +236,8 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             BoundContructor self = (BoundContructor)GetManagedObject(ob);
-            Runtime.Decref(self.repr);
+            if (self.repr != IntPtr.Zero)
+                Runtime.Decref(self.repr);
             Runtime.Decref(self.pyTypeHndl);
             ExtensionType.FinalizeObject(self);
         }

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -489,7 +489,7 @@ namespace Python.Runtime
                         // As of Python 2.3, large ints magically convert :(
                         if (Runtime.PyLong_Check(op))
                         {
-                            Runtime.Decref(op);
+                            Runtime.XDecref(op);
                             goto overflow;
                         }
 
@@ -502,7 +502,7 @@ namespace Python.Runtime
                             goto type_error;
                         }
                         ival = (int)Runtime.PyInt_AsLong(op);
-                        Runtime.Decref(op);
+                        Runtime.XDecref(op);
                         result = ival;
                         return true;
                     }

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -133,7 +133,7 @@ namespace Python.Runtime
             if (value == null)
             {
                 result = Runtime.PyNone;
-                Runtime.Incref(result);
+                Runtime.XIncref(result);
                 return result;
             }
 
@@ -180,10 +180,10 @@ namespace Python.Runtime
                 case TypeCode.Boolean:
                     if ((bool)value)
                     {
-                        Runtime.Incref(Runtime.PyTrue);
+                        Runtime.XIncref(Runtime.PyTrue);
                         return Runtime.PyTrue;
                     }
-                    Runtime.Incref(Runtime.PyFalse);
+                    Runtime.XIncref(Runtime.PyFalse);
                     return Runtime.PyFalse;
 
                 case TypeCode.Byte:
@@ -203,7 +203,7 @@ namespace Python.Runtime
                     string ss = ((float)value).ToString(nfi);
                     IntPtr ps = Runtime.PyString_FromString(ss);
                     IntPtr op = Runtime.PyFloat_FromString(ps, IntPtr.Zero);
-                    Runtime.Decref(ps);
+                    Runtime.XDecref(ps);
                     return op;
 
                 case TypeCode.Double:
@@ -231,7 +231,7 @@ namespace Python.Runtime
                                 using (var p = new PyObject(ToPython(o, o?.GetType())))
                                     resultlist.Append(p);
                             }
-                            Runtime.Incref(resultlist.Handle);
+                            Runtime.XIncref(resultlist.Handle);
                             return resultlist.Handle;
                         }
                     }
@@ -251,7 +251,7 @@ namespace Python.Runtime
             if (value == null)
             {
                 IntPtr result = Runtime.PyNone;
-                Runtime.Incref(result);
+                Runtime.XIncref(result);
                 return result;
             }
 
@@ -299,7 +299,7 @@ namespace Python.Runtime
                             // This is safe because we know that the __dict__ of
                             // value holds a reference to _inner.
                             value = p;
-                            Runtime.Decref(p);
+                            Runtime.XDecref(p);
                             mt = ManagedType.GetManagedObject(value);
                         }
                     }
@@ -307,7 +307,7 @@ namespace Python.Runtime
                     if ((c != IntPtr.Zero) && (c != value))
                     {
                         value = c;
-                        Runtime.Decref(c);
+                        Runtime.XDecref(c);
                         mt = ManagedType.GetManagedObject(value);
                     }
                 }
@@ -523,7 +523,7 @@ namespace Python.Runtime
                             goto type_error;
                         }
                         long ll = (long)Runtime.PyLong_AsLongLong(op);
-                        Runtime.Decref(op);
+                        Runtime.XDecref(op);
                         if ((ll == -1) && Exceptions.ErrorOccurred())
                         {
                             goto overflow;
@@ -575,7 +575,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     ival = (int)Runtime.PyInt_AsLong(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
 
                     if (ival > Byte.MaxValue || ival < Byte.MinValue)
                     {
@@ -618,7 +618,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     ival = (int)Runtime.PyInt_AsLong(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
 
                     if (ival > SByte.MaxValue || ival < SByte.MinValue)
                     {
@@ -678,7 +678,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     ival = Runtime.PyInt_AsLong(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
                     if (ival > Char.MaxValue || ival < Char.MinValue)
                     {
                         goto overflow;
@@ -697,7 +697,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     ival = (int)Runtime.PyInt_AsLong(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
                     if (ival > Int16.MaxValue || ival < Int16.MinValue)
                     {
                         goto overflow;
@@ -717,7 +717,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     long l = (long)Runtime.PyLong_AsLongLong(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
                     if ((l == -1) && Exceptions.ErrorOccurred())
                     {
                         goto overflow;
@@ -736,7 +736,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     ival = (int)Runtime.PyInt_AsLong(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
                     if (ival > UInt16.MaxValue || ival < UInt16.MinValue)
                     {
                         goto overflow;
@@ -759,14 +759,14 @@ namespace Python.Runtime
 
                     if (Exceptions.ErrorOccurred())
                     {
-                        Runtime.Decref(op);
+                        Runtime.XDecref(op);
                         goto overflow;
                     }
 
                     IntPtr check = Runtime.PyLong_FromUnsignedLong(ui);
                     int err = Runtime.PyObject_Compare(check, op);
-                    Runtime.Decref(check);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(check);
+                    Runtime.XDecref(op);
                     if (0 != err || Exceptions.ErrorOccurred())
                     {
                         goto overflow;
@@ -786,7 +786,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     ulong ul = (ulong)Runtime.PyLong_AsUnsignedLongLong(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
                     if (Exceptions.ErrorOccurred())
                     {
                         goto overflow;
@@ -806,7 +806,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     double dd = Runtime.PyFloat_AsDouble(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
                     if (dd > Single.MaxValue || dd < Single.MinValue)
                     {
                         goto overflow;
@@ -821,7 +821,7 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     double d = Runtime.PyFloat_AsDouble(op);
-                    Runtime.Decref(op);
+                    Runtime.XDecref(op);
                     if (d > Double.MaxValue || d < Double.MinValue)
                     {
                         goto overflow;
@@ -859,7 +859,7 @@ namespace Python.Runtime
         {
             IntPtr ob = Runtime.PyObject_Repr(value);
             string src = Runtime.GetManagedString(ob);
-            Runtime.Decref(ob);
+            Runtime.XDecref(ob);
             string error = String.Format(
                 "Cannot convert {0} to {1}", src, target
                 );
@@ -908,12 +908,12 @@ namespace Python.Runtime
 
                 if (!Converter.ToManaged(item, elementType, out obj, true))
                 {
-                    Runtime.Decref(item);
+                    Runtime.XDecref(item);
                     return false;
                 }
 
                 items.SetValue(obj, i);
-                Runtime.Decref(item);
+                Runtime.XDecref(item);
             }
 
             result = items;

--- a/src/runtime/debughelper.cs
+++ b/src/runtime/debughelper.cs
@@ -28,7 +28,7 @@ namespace Python.Runtime
                 }
                 IntPtr ob = Runtime.PyObject_Repr(args[i]);
                 result += Runtime.GetManagedString(ob);
-                Runtime.Decref(ob);
+                Runtime.XDecref(ob);
                 result += " ";
             }
             Console.WriteLine(result);

--- a/src/runtime/delegatemanager.cs
+++ b/src/runtime/delegatemanager.cs
@@ -203,7 +203,7 @@ namespace Python.Runtime
 
         public Dispatcher(IntPtr target, Type dtype)
         {
-            Runtime.Incref(target);
+            Runtime.XIncref(target);
             this.target = target;
             this.dtype = dtype;
         }
@@ -215,7 +215,7 @@ namespace Python.Runtime
             if (Runtime.Py_IsInitialized() > 0)
             {
                 IntPtr gs = PythonEngine.AcquireLock();
-                Runtime.Decref(target);
+                Runtime.XDecref(target);
                 PythonEngine.ReleaseLock(gs);
             }
         }
@@ -255,7 +255,7 @@ namespace Python.Runtime
             }
 
             IntPtr op = Runtime.PyObject_Call(target, pyargs, IntPtr.Zero);
-            Runtime.Decref(pyargs);
+            Runtime.XDecref(pyargs);
 
             if (op == IntPtr.Zero)
             {
@@ -273,11 +273,11 @@ namespace Python.Runtime
             {
                 string s = "could not convert Python result to " +
                            rtype.ToString();
-                Runtime.Decref(op);
+                Runtime.XDecref(op);
                 throw new ConversionException(s);
             }
 
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
             return result;
         }
     }

--- a/src/runtime/delegateobject.cs
+++ b/src/runtime/delegateobject.cs
@@ -106,7 +106,7 @@ namespace Python.Runtime
         public static new IntPtr tp_richcompare(IntPtr ob, IntPtr other, int op) {
             if (op != Runtime.Py_EQ && op != Runtime.Py_NE)
             {
-                Runtime.Incref(Runtime.PyNotImplemented);
+                Runtime.XIncref(Runtime.PyNotImplemented);
                 return Runtime.PyNotImplemented;
             }
 
@@ -124,11 +124,11 @@ namespace Python.Runtime
             Delegate d2 = GetTrueDelegate(other);
             if (d1 == d2)
             {
-                Runtime.Incref(pytrue);
+                Runtime.XIncref(pytrue);
                 return pytrue;
             }
 
-            Runtime.Incref(pyfalse);
+            Runtime.XIncref(pyfalse);
             return pyfalse;
         }
 #else

--- a/src/runtime/eventbinding.cs
+++ b/src/runtime/eventbinding.cs
@@ -13,7 +13,7 @@ namespace Python.Runtime
 
         public EventBinding(EventObject e, IntPtr target) : base()
         {
-            Runtime.Incref(target);
+            Runtime.XIncref(target);
             this.target = target;
             this.e = e;
         }
@@ -40,7 +40,7 @@ namespace Python.Runtime
                 return IntPtr.Zero;
             }
 
-            Runtime.Incref(self.pyHandle);
+            Runtime.XIncref(self.pyHandle);
             return self.pyHandle;
         }
 
@@ -66,7 +66,7 @@ namespace Python.Runtime
                 return IntPtr.Zero;
             }
 
-            Runtime.Incref(self.pyHandle);
+            Runtime.XIncref(self.pyHandle);
             return self.pyHandle;
         }
 
@@ -127,7 +127,7 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             EventBinding self = (EventBinding)GetManagedObject(ob);
-            Runtime.Decref(self.target);
+            Runtime.XDecref(self.target);
             ExtensionType.FinalizeObject(self);
         }
     }

--- a/src/runtime/eventobject.cs
+++ b/src/runtime/eventobject.cs
@@ -160,7 +160,7 @@ namespace Python.Runtime
                     self.unbound = new EventBinding(self, IntPtr.Zero);
                 }
                 binding = self.unbound;
-                Runtime.Incref(binding.pyHandle);
+                Runtime.XIncref(binding.pyHandle);
                 return binding.pyHandle;
             }
 
@@ -218,7 +218,7 @@ namespace Python.Runtime
             EventObject self = (EventObject)GetManagedObject(ob);
             if (self.unbound != null)
             {
-                Runtime.Decref(self.unbound.pyHandle);
+                Runtime.XDecref(self.unbound.pyHandle);
             }
             ExtensionType.FinalizeObject(self);
         }

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -195,12 +195,12 @@ namespace Python.Runtime
                     IntPtr op = (IntPtr)fi.GetValue(type);
                     if (op != IntPtr.Zero)
                     {
-                        Runtime.Decref(op);
+                        Runtime.XDecref(op);
                     }
                 }
-                Runtime.Decref(exceptions_module);
+                Runtime.XDecref(exceptions_module);
                 Runtime.PyObject_HasAttrString(warnings_module, "xx");
-                Runtime.Decref(warnings_module);
+                Runtime.XDecref(warnings_module);
             }
         }
 
@@ -306,7 +306,7 @@ namespace Python.Runtime
 
             IntPtr namestr = Runtime.PyString_FromString("System");
             Runtime.PyDict_SetItemString(dict, "__name__", namestr);
-            Runtime.Decref(namestr);
+            Runtime.XDecref(namestr);
 
             Runtime.PyDict_SetItemString(dict, "__file__", Runtime.PyNone);
             Runtime.PyDict_SetItemString(dict, "__doc__", Runtime.PyNone);
@@ -314,7 +314,7 @@ namespace Python.Runtime
             IntPtr flag = Runtime.Py_file_input;
             IntPtr result = Runtime.PyRun_String(code, flag, dict, dict);
             Exceptions.ErrorCheck(result);
-            Runtime.Decref(result);
+            Runtime.XDecref(result);
 
             os_exc = Runtime.PyDict_GetItemString(dict, "Exception");
             Runtime.PyObject_SetAttrString(os_exc, "_class", ns_exc);
@@ -335,23 +335,23 @@ namespace Python.Runtime
                 throw new SystemException("Invalid __bases__");
             }
             IntPtr nsbase = Runtime.PyTuple_GetItem(nbases, 0);
-            Runtime.Decref(nbases);
+            Runtime.XDecref(nbases);
 
             IntPtr osbase = GetExceptionClassWrapper(nsbase);
             IntPtr baselist = Runtime.PyTuple_New(1);
-            Runtime.Incref(osbase);
+            Runtime.XIncref(osbase);
             Runtime.PyTuple_SetItem(baselist, 0, osbase);
             IntPtr name = Runtime.PyObject_GetAttrString(real, "__name__");
 
             IntPtr dict = Runtime.PyDict_New();
             IntPtr mod = Runtime.PyObject_GetAttrString(real, "__module__");
             Runtime.PyDict_SetItemString(dict, "__module__", mod);
-            Runtime.Decref(mod);
+            Runtime.XDecref(mod);
 
             IntPtr subc = Runtime.PyClass_New(baselist, dict, name);
-            Runtime.Decref(baselist);
-            Runtime.Decref(dict);
-            Runtime.Decref(name);
+            Runtime.XDecref(baselist);
+            Runtime.XDecref(dict);
+            Runtime.XDecref(name);
 
             Runtime.PyObject_SetAttrString(subc, "_class", real);
             return subc;
@@ -392,7 +392,7 @@ namespace Python.Runtime
             IntPtr d = Runtime.PyObject_GetAttrString(op, "__dict__");
             Exceptions.ErrorCheck(d);
             Runtime.PyDict_SetItemString(d, "_inner", real);
-            Runtime.Decref(d);
+            Runtime.XDecref(d);
             return op;
         }
 
@@ -409,7 +409,7 @@ namespace Python.Runtime
                 return IntPtr.Zero;
             }
             IntPtr c = Runtime.PyDict_GetItemString(d, "_class");
-            Runtime.Decref(d);
+            Runtime.XDecref(d);
             if (c == IntPtr.Zero)
             {
                 Exceptions.Clear();
@@ -517,8 +517,8 @@ namespace Python.Runtime
             }
             IntPtr etype = Runtime.PyObject_GetAttrString(op, "__class__");
             Runtime.PyErr_SetObject(etype, op);
-            Runtime.Decref(etype);
-            Runtime.Decref(op);
+            Runtime.XDecref(etype);
+            Runtime.XDecref(op);
         }
 
         /// <summary>
@@ -561,14 +561,14 @@ namespace Python.Runtime
                 Exceptions.RaiseTypeError("Invalid exception");
             }
 
-            Runtime.Incref(warnings_module);
+            Runtime.XIncref(warnings_module);
             IntPtr warn = Runtime.PyObject_GetAttrString(warnings_module, "warn");
-            Runtime.Decref(warnings_module);
+            Runtime.XDecref(warnings_module);
             Exceptions.ErrorCheck(warn);
 
             IntPtr args = Runtime.PyTuple_New(3);
             IntPtr msg = Runtime.PyString_FromString(message);
-            Runtime.Incref(exception); // PyTuple_SetItem steals a reference
+            Runtime.XIncref(exception); // PyTuple_SetItem steals a reference
             IntPtr level = Runtime.PyInt_FromInt32(stacklevel);
             Runtime.PyTuple_SetItem(args, 0, msg);
             Runtime.PyTuple_SetItem(args, 1, exception);
@@ -577,9 +577,9 @@ namespace Python.Runtime
             IntPtr result = Runtime.PyObject_CallObject(warn, args);
             Exceptions.ErrorCheck(result);
 
-            Runtime.Decref(warn);
-            Runtime.Decref(result);
-            Runtime.Decref(args);
+            Runtime.XDecref(warn);
+            Runtime.XDecref(result);
+            Runtime.XDecref(args);
         }
 
         public static void warn(string message, IntPtr exception)

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -52,7 +52,7 @@ namespace Python.Runtime
         public static void FinalizeObject(ManagedType self)
         {
             Runtime.PyObject_GC_Del(self.pyHandle);
-            Runtime.Decref(self.tpHandle);
+            Runtime.XDecref(self.tpHandle);
             self.gcHandle.Free();
         }
 

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -57,7 +57,7 @@ namespace Python.Runtime
             Runtime.PyDict_SetItemString(dict, "CLR", py_clr_module);
             Runtime.PyDict_SetItemString(dict, "clr", py_clr_module);
 #else
-            Runtime.Incref(root.pyHandle); // we are using the module two times
+            Runtime.XIncref(root.pyHandle); // we are using the module two times
             Runtime.PyDict_SetItemString(dict, "CLR", root.pyHandle);
             Runtime.PyDict_SetItemString(dict, "clr", root.pyHandle);
 #endif
@@ -79,8 +79,8 @@ namespace Python.Runtime
 #else
             if (0 != Runtime.Py_IsInitialized())
             {
-                Runtime.Decref(root.pyHandle);
-                Runtime.Decref(root.pyHandle);
+                Runtime.XDecref(root.pyHandle);
+                Runtime.XDecref(root.pyHandle);
             }
 #endif
             if (0 != Runtime.Py_IsInitialized())
@@ -137,7 +137,7 @@ namespace Python.Runtime
             Runtime.XIncref(py_clr_module);
             return py_clr_module;
 #else
-            Runtime.Incref(root.pyHandle);
+            Runtime.XIncref(root.pyHandle);
             return root.pyHandle;
 #endif
         }

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -39,7 +39,7 @@ namespace Python.Runtime
 #endif
             hook = new MethodWrapper(typeof(ImportHook), "__import__", "TernaryFunc");
             Runtime.PyObject_SetAttrString(mod, "__import__", hook.ptr);
-            Runtime.Decref(hook.ptr);
+            Runtime.XDecref(hook.ptr);
 
             root = new CLRModule();
 
@@ -72,8 +72,8 @@ namespace Python.Runtime
         {
 #if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if (0 != Runtime.Py_IsInitialized()) {
-                Runtime.Decref(py_clr_module);
-                Runtime.Decref(root.pyHandle);
+                Runtime.XDecref(py_clr_module);
+                Runtime.XDecref(root.pyHandle);
             }
             ModuleDefOffset.FreeModuleDef(module_def);
 #else
@@ -85,7 +85,7 @@ namespace Python.Runtime
 #endif
             if (0 != Runtime.Py_IsInitialized())
             {
-                Runtime.Decref(py_import);
+                Runtime.XDecref(py_import);
             }
         }
 
@@ -108,9 +108,9 @@ namespace Python.Runtime
             if (fromList != null && fromList != IntPtr.Zero) {
                 if (Runtime.PyTuple_Check(fromList.GetValueOrDefault()))
                 {
-                    Runtime.Incref(py_mod_dict);
+                    Runtime.XIncref(py_mod_dict);
                     using(PyDict mod_dict = new PyDict(py_mod_dict)) {
-                        Runtime.Incref(fromList.GetValueOrDefault());
+                        Runtime.XIncref(fromList.GetValueOrDefault());
                         using (PyTuple from = new PyTuple(fromList.GetValueOrDefault())) {
                             foreach (PyObject item in from) {
                                 if (mod_dict.HasKey(item))
@@ -124,7 +124,7 @@ namespace Python.Runtime
                                 if (null == attr)
                                     continue;
 
-                                Runtime.Incref(attr.pyHandle);
+                                Runtime.XIncref(attr.pyHandle);
                                 using (PyObject obj = new PyObject(attr.pyHandle)) {
                                     mod_dict.SetItem(s, obj);
                                 }
@@ -134,7 +134,7 @@ namespace Python.Runtime
                 }
             }
 
-            Runtime.Incref(py_clr_module);
+            Runtime.XIncref(py_clr_module);
             return py_clr_module;
 #else
             Runtime.Incref(root.pyHandle);
@@ -291,7 +291,7 @@ namespace Python.Runtime
             {
                 if (fromlist)
                 {
-                    Runtime.Incref(module);
+                    Runtime.XIncref(module);
                     return module;
                 }
                 if (clr_prefix != null)
@@ -299,7 +299,7 @@ namespace Python.Runtime
                     return GetCLRModule(fromList);
                 }
                 module = Runtime.PyDict_GetItemString(modules, names[0]);
-                Runtime.Incref(module);
+                Runtime.XIncref(module);
                 return module;
             }
             Exceptions.Clear();
@@ -361,10 +361,10 @@ namespace Python.Runtime
                 {
                     mod.LoadNames();
                 }
-                Runtime.Decref(fp);
+                Runtime.XDecref(fp);
             }
 
-            Runtime.Incref(mod.pyHandle);
+            Runtime.XIncref(mod.pyHandle);
             return mod.pyHandle;
         }
     }

--- a/src/runtime/iterator.cs
+++ b/src/runtime/iterator.cs
@@ -37,7 +37,7 @@ namespace Python.Runtime
 
         public static IntPtr tp_iter(IntPtr ob)
         {
-            Runtime.Incref(ob);
+            Runtime.XIncref(ob);
             return ob;
         }
     }

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -51,7 +51,7 @@ namespace Python.Runtime
                     if ((e != IntPtr.Zero) && (e != ob))
                     {
                         ManagedType m = GetManagedObject(e);
-                        Runtime.Decref(e);
+                        Runtime.XDecref(e);
                         return m;
                     }
                 }

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -92,7 +92,7 @@ namespace Python.Runtime
             // into python.
             if (IntPtr.Zero != dict)
             {
-                Runtime.Incref(dict);
+                Runtime.XIncref(dict);
                 using (PyDict clsDict = new PyDict(dict))
                 {
                     if (clsDict.HasKey("__assembly__") || clsDict.HasKey("__namespace__"))
@@ -171,7 +171,7 @@ namespace Python.Runtime
             IntPtr py__init__ = Runtime.PyString_FromString("__init__");
             IntPtr type = Runtime.PyObject_TYPE(obj);
             IntPtr init = Runtime._PyType_Lookup(type, py__init__);
-            Runtime.Decref(py__init__);
+            Runtime.XDecref(py__init__);
             Runtime.PyErr_Clear();
 
             if (init != IntPtr.Zero)
@@ -179,20 +179,20 @@ namespace Python.Runtime
                 IntPtr bound = Runtime.GetBoundArgTuple(obj, args);
                 if (bound == IntPtr.Zero)
                 {
-                    Runtime.Decref(obj);
+                    Runtime.XDecref(obj);
                     return IntPtr.Zero;
                 }
 
                 IntPtr result = Runtime.PyObject_Call(init, bound, kw);
-                Runtime.Decref(bound);
+                Runtime.XDecref(bound);
 
                 if (result == IntPtr.Zero)
                 {
-                    Runtime.Decref(obj);
+                    Runtime.XDecref(obj);
                     return IntPtr.Zero;
                 }
 
-                Runtime.Decref(result);
+                Runtime.XDecref(result);
             }
 
             return obj;
@@ -264,7 +264,7 @@ namespace Python.Runtime
             }
 
             IntPtr op = Marshal.ReadIntPtr(tp, TypeOffset.ob_type);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
             // Delegate the rest of finalization the Python metatype. Note
             // that the PyType_Type implementation of tp_dealloc will call
@@ -282,7 +282,7 @@ namespace Python.Runtime
             ClassBase cb = GetManagedObject(tp) as ClassBase;
 
             if (cb == null) {
-                Runtime.Incref(Runtime.PyFalse);
+                Runtime.XIncref(Runtime.PyFalse);
                 return Runtime.PyFalse;
             }
 
@@ -299,13 +299,13 @@ namespace Python.Runtime
                     otherType = arg.GetPythonType();
 
                 if (Runtime.PyObject_TYPE(otherType.Handle) != PyCLRMetaType) {
-                    Runtime.Incref(Runtime.PyFalse);
+                    Runtime.XIncref(Runtime.PyFalse);
                     return Runtime.PyFalse;
                 }
 
                 ClassBase otherCb = GetManagedObject(otherType.Handle) as ClassBase;
                 if (otherCb == null) {
-                    Runtime.Incref(Runtime.PyFalse);
+                    Runtime.XIncref(Runtime.PyFalse);
                     return Runtime.PyFalse;
                 }
 

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -337,7 +337,7 @@ namespace Python.Runtime
                                 {
                                     clrtype = Converter.GetTypeByAlias(pyoptype);
                                 }
-                                Runtime.Decref(pyoptype);
+                                Runtime.XDecref(pyoptype);
                             }
 
 
@@ -372,7 +372,7 @@ namespace Python.Runtime
                                             clrtype = pi[n].ParameterType;
                                         }
                                     }
-                                    Runtime.Decref(pyoptype);
+                                    Runtime.XDecref(pyoptype);
                                     if (!typematch)
                                     {
                                         margs = null;
@@ -405,7 +405,7 @@ namespace Python.Runtime
                             {
                                 // GetSlice() creates a new reference but GetItem()
                                 // returns only a borrow reference.
-                                Runtime.Decref(op);
+                                Runtime.XDecref(op);
                             }
                             margs[n] = arg;
                         }
@@ -551,8 +551,8 @@ namespace Python.Runtime
                 if ((binding.outs == 1) && (mi.ReturnType == typeof(void)))
                 {
                     v = Runtime.PyTuple_GetItem(t, 1);
-                    Runtime.Incref(v);
-                    Runtime.Decref(t);
+                    Runtime.XIncref(v);
+                    Runtime.XDecref(t);
                     return v;
                 }
 

--- a/src/runtime/methodbinding.cs
+++ b/src/runtime/methodbinding.cs
@@ -19,10 +19,10 @@ namespace Python.Runtime
 
         public MethodBinding(MethodObject m, IntPtr target, IntPtr targetType) : base()
         {
-            Runtime.Incref(target);
+            Runtime.XIncref(target);
             this.target = target;
 
-            Runtime.Incref(targetType);
+            Runtime.XIncref(targetType);
             if (targetType == IntPtr.Zero)
                 targetType = Runtime.PyObject_Type(target);
             this.targetType = targetType;
@@ -58,7 +58,7 @@ namespace Python.Runtime
 
             MethodBinding mb = new MethodBinding(self.m, self.target);
             mb.info = mi;
-            Runtime.Incref(mb.pyHandle);
+            Runtime.XIncref(mb.pyHandle);
             return mb.pyHandle;
         }
 
@@ -81,7 +81,7 @@ namespace Python.Runtime
             if (name == "__doc__")
             {
                 IntPtr doc = self.m.GetDocString();
-                Runtime.Incref(doc);
+                Runtime.XIncref(doc);
                 return doc;
             }
 
@@ -89,7 +89,7 @@ namespace Python.Runtime
             if (name == "__overloads__" || name == "Overloads")
             {
                 OverloadMapper om = new OverloadMapper(self.m, self.target);
-                Runtime.Incref(om.pyHandle);
+                Runtime.XIncref(om.pyHandle);
                 return om.pyHandle;
             }
 
@@ -140,7 +140,7 @@ namespace Python.Runtime
                         return IntPtr.Zero;
                     }
                     target = Runtime.PyTuple_GetItem(args, 0);
-                    Runtime.Incref(target);
+                    Runtime.XIncref(target);
                     disposeList.Add(target);
 
                     args = Runtime.PyTuple_GetSlice(args, 1, len);
@@ -166,7 +166,7 @@ namespace Python.Runtime
                                 MethodBinding baseSelf = GetManagedObject(baseMethod) as MethodBinding;
                                 if (baseSelf != null)
                                     self = baseSelf;
-                                Runtime.Decref(baseMethod);
+                                Runtime.XDecref(baseMethod);
                             }
                             else
                             {
@@ -181,7 +181,7 @@ namespace Python.Runtime
             finally
             {
                 foreach (IntPtr ptr in disposeList)
-                    Runtime.Decref(ptr);
+                    Runtime.XDecref(ptr);
             }
         }
 
@@ -240,8 +240,8 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             MethodBinding self = (MethodBinding)GetManagedObject(ob);
-            Runtime.Decref(self.target);
-            Runtime.Decref(self.targetType);
+            Runtime.XDecref(self.target);
+            Runtime.XDecref(self.targetType);
             ExtensionType.FinalizeObject(self);
         }
     }

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -127,7 +127,7 @@ namespace Python.Runtime
             if (name == "__doc__")
             {
                 IntPtr doc = self.GetDocString();
-                Runtime.Incref(doc);
+                Runtime.XIncref(doc);
                 return doc;
             }
 
@@ -155,7 +155,7 @@ namespace Python.Runtime
                     self.unbound = new MethodBinding(self, IntPtr.Zero, tp);
                 }
                 binding = self.unbound;
-                Runtime.Incref(binding.pyHandle);
+                Runtime.XIncref(binding.pyHandle);
                 ;
                 return binding.pyHandle;
             }
@@ -202,10 +202,10 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             MethodObject self = (MethodObject)GetManagedObject(ob);
-            Runtime.Decref(self.doc);
+            Runtime.XDecref(self.doc);
             if (self.unbound != null)
             {
-                Runtime.Decref(self.unbound.pyHandle);
+                Runtime.XDecref(self.unbound.pyHandle);
             }
             ExtensionType.FinalizeObject(self);
         }

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -51,9 +51,9 @@ namespace Python.Runtime
             Runtime.PyDict_SetItemString(dict, "__file__", pyfilename);
             Runtime.PyDict_SetItemString(dict, "__doc__", pydocstring);
             Runtime.PyDict_SetItemString(dict, "__class__", pycls);
-            Runtime.Decref(pyname);
-            Runtime.Decref(pyfilename);
-            Runtime.Decref(pydocstring);
+            Runtime.XDecref(pyname);
+            Runtime.XDecref(pyfilename);
+            Runtime.XDecref(pydocstring);
 
             Marshal.WriteIntPtr(this.pyHandle, ObjectOffset.DictOffset(this.pyHandle), dict);
 
@@ -212,7 +212,7 @@ namespace Python.Runtime
                                 IntPtr p = attr.pyHandle;
                                 IntPtr r = Exceptions.GetExceptionClassWrapper(p);
                                 Runtime.PyDict_SetItemString(dict, name, r);
-                                Runtime.Incref(r);
+                                Runtime.XIncref(r);
                             }
                         }
                     }
@@ -288,14 +288,14 @@ namespace Python.Runtime
             IntPtr op = Runtime.PyDict_GetItem(self.dict, key);
             if (op != IntPtr.Zero)
             {
-                Runtime.Incref(op);
+                Runtime.XIncref(op);
                 return op;
             }
 
             string name = Runtime.GetManagedString(key);
             if (name == "__dict__")
             {
-                Runtime.Incref(self.dict);
+                Runtime.XIncref(self.dict);
                 return self.dict;
             }
 
@@ -321,13 +321,13 @@ namespace Python.Runtime
                         IntPtr p = attr.pyHandle;
                         IntPtr r = Exceptions.GetExceptionClassWrapper(p);
                         Runtime.PyDict_SetItemString(self.dict, name, r);
-                        Runtime.Incref(r);
+                        Runtime.XIncref(r);
                         return r;
                     }
                 }
             }
 
-            Runtime.Incref(attr.pyHandle);
+            Runtime.XIncref(attr.pyHandle);
             return attr.pyHandle;
         }
 
@@ -371,7 +371,7 @@ namespace Python.Runtime
                 IntPtr mro = Marshal.ReadIntPtr(type, TypeOffset.tp_mro);
                 IntPtr ext = Runtime.ExtendTuple(mro, Runtime.PyModuleType);
                 Marshal.WriteIntPtr(type, TypeOffset.tp_mro, ext);
-                Runtime.Decref(mro);
+                Runtime.XDecref(mro);
                 hacked = true;
             }
         }

--- a/src/runtime/overload.cs
+++ b/src/runtime/overload.cs
@@ -15,7 +15,7 @@ namespace Python.Runtime
 
         public OverloadMapper(MethodObject m, IntPtr target) : base()
         {
-            Runtime.Incref(target);
+            Runtime.XIncref(target);
             this.target = target;
             this.m = m;
         }
@@ -47,7 +47,7 @@ namespace Python.Runtime
 
             MethodBinding mb = new MethodBinding(self.m, self.target);
             mb.info = mi;
-            Runtime.Incref(mb.pyHandle);
+            Runtime.XIncref(mb.pyHandle);
             return mb.pyHandle;
         }
 
@@ -59,7 +59,7 @@ namespace Python.Runtime
         {
             OverloadMapper self = (OverloadMapper)GetManagedObject(op);
             IntPtr doc = self.m.GetDocString();
-            Runtime.Incref(doc);
+            Runtime.XIncref(doc);
             return doc;
         }
 
@@ -70,7 +70,7 @@ namespace Python.Runtime
         public static new void tp_dealloc(IntPtr ob)
         {
             OverloadMapper self = (OverloadMapper)GetManagedObject(ob);
-            Runtime.Decref(self.target);
+            Runtime.XDecref(self.target);
             ExtensionType.FinalizeObject(self);
         }
     }

--- a/src/runtime/pyansistring.cs
+++ b/src/runtime/pyansistring.cs
@@ -34,7 +34,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not a string");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 

--- a/src/runtime/pydict.cs
+++ b/src/runtime/pydict.cs
@@ -55,7 +55,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not a dict");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 

--- a/src/runtime/pyfloat.cs
+++ b/src/runtime/pyfloat.cs
@@ -38,7 +38,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not a float");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 

--- a/src/runtime/pyint.cs
+++ b/src/runtime/pyint.cs
@@ -38,7 +38,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not an int");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 

--- a/src/runtime/pylist.cs
+++ b/src/runtime/pylist.cs
@@ -37,7 +37,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not a list");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 
@@ -73,7 +73,7 @@ namespace Python.Runtime
             for (int i = 0; i < count; i++)
             {
                 IntPtr ptr = items[i].obj;
-                Runtime.Incref(ptr);
+                Runtime.XIncref(ptr);
                 int r = Runtime.PyList_SetItem(obj, i, ptr);
                 if (r < 0)
                 {

--- a/src/runtime/pylong.cs
+++ b/src/runtime/pylong.cs
@@ -37,7 +37,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not a long");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -73,7 +73,7 @@ namespace Python.Runtime
             // Special case: if ob is null, we return None.
             if (ob == null)
             {
-                Runtime.Incref(Runtime.PyNone);
+                Runtime.XIncref(Runtime.PyNone);
                 return new PyObject(Runtime.PyNone);
             }
             IntPtr op = CLRObject.GetInstHandle(ob);
@@ -119,7 +119,7 @@ namespace Python.Runtime
                 if (Runtime.Py_IsInitialized() > 0)
                 {
                     IntPtr gs = PythonEngine.AcquireLock();
-                    Runtime.Decref(obj);
+                    Runtime.XDecref(obj);
                     obj = IntPtr.Zero;
                     PythonEngine.ReleaseLock(gs);
                 }
@@ -872,7 +872,7 @@ namespace Python.Runtime
         {
             IntPtr strval = Runtime.PyObject_Repr(obj);
             string result = Runtime.GetManagedString(strval);
-            Runtime.Decref(strval);
+            Runtime.XDecref(strval);
             return result;
         }
 
@@ -889,7 +889,7 @@ namespace Python.Runtime
         {
             IntPtr strval = Runtime.PyObject_Unicode(obj);
             string result = Runtime.GetManagedString(strval);
-            Runtime.Decref(strval);
+            Runtime.XDecref(strval);
             return result;
         }
 
@@ -968,7 +968,7 @@ namespace Python.Runtime
                 if (inargs[i] is PyObject)
                 {
                     ptr = ((PyObject)inargs[i]).Handle;
-                    Runtime.Incref(ptr);
+                    Runtime.XIncref(ptr);
                 }
                 else
                 {

--- a/src/runtime/pystring.cs
+++ b/src/runtime/pystring.cs
@@ -38,7 +38,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not a string");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -421,7 +421,7 @@ namespace Python.Runtime
 
             IntPtr flag = (IntPtr)257; /* Py_file_input */
             IntPtr result = Runtime.PyRun_String(code, flag, globals, locals);
-            Runtime.Decref(locals);
+            Runtime.XDecref(locals);
             if (result == IntPtr.Zero)
             {
                 return null;
@@ -491,7 +491,7 @@ namespace Python.Runtime
                 if (Runtime.PyDict_SetItemString(dict.Handle, (string)kv[i], value) != 0)
                     throw new ArgumentException(string.Format("Cannot add key '{0}' to dictionary.", (string)kv[i]));
                 if (!(kv[i + 1] is PyObject))
-                    Runtime.Decref(value);
+                    Runtime.XDecref(value);
             }
             return dict;
         }

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -19,21 +19,21 @@ namespace Python.Runtime
         {
             IntPtr gs = PythonEngine.AcquireLock();
             Runtime.PyErr_Fetch(ref _pyType, ref _pyValue, ref _pyTB);
-            Runtime.Incref(_pyType);
-            Runtime.Incref(_pyValue);
-            Runtime.Incref(_pyTB);
+            Runtime.XIncref(_pyType);
+            Runtime.XIncref(_pyValue);
+            Runtime.XIncref(_pyTB);
             if ((_pyType != IntPtr.Zero) && (_pyValue != IntPtr.Zero))
             {
                 string type;
                 string message;
-                Runtime.Incref(_pyType);
+                Runtime.XIncref(_pyType);
                 using (PyObject pyType = new PyObject(_pyType))
                 using (PyObject pyTypeName = pyType.GetAttr("__name__"))
                 {
                     type = pyTypeName.ToString();
                 }
 
-                Runtime.Incref(_pyValue);
+                Runtime.XIncref(_pyValue);
                 using (PyObject pyValue = new PyObject(_pyValue))
                 {
                     message = pyValue.ToString();
@@ -43,7 +43,7 @@ namespace Python.Runtime
             if (_pyTB != IntPtr.Zero)
             {
                 PyObject tb_module = PythonEngine.ImportModule("traceback");
-                Runtime.Incref(_pyTB);
+                Runtime.XIncref(_pyTB);
                 using (PyObject pyTB = new PyObject(_pyTB))
                 {
                     _tb = tb_module.InvokeMethod("format_tb", pyTB).ToString();
@@ -149,12 +149,12 @@ namespace Python.Runtime
                 if (Runtime.Py_IsInitialized() > 0)
                 {
                     IntPtr gs = PythonEngine.AcquireLock();
-                    Runtime.Decref(_pyType);
-                    Runtime.Decref(_pyValue);
+                    Runtime.XDecref(_pyType);
+                    Runtime.XDecref(_pyValue);
                     // XXX Do we ever get TraceBack? //
                     if (_pyTB != IntPtr.Zero)
                     {
-                        Runtime.Decref(_pyTB);
+                        Runtime.XDecref(_pyTB);
                     }
                     PythonEngine.ReleaseLock(gs);
                 }

--- a/src/runtime/pytuple.cs
+++ b/src/runtime/pytuple.cs
@@ -37,7 +37,7 @@ namespace Python.Runtime
             {
                 throw new ArgumentException("object is not a tuple");
             }
-            Runtime.Incref(o.obj);
+            Runtime.XIncref(o.obj);
             obj = o.obj;
         }
 
@@ -73,7 +73,7 @@ namespace Python.Runtime
             for (int i = 0; i < count; i++)
             {
                 IntPtr ptr = items[i].obj;
-                Runtime.Incref(ptr);
+                Runtime.XIncref(ptr);
                 int r = Runtime.PyTuple_SetItem(obj, i, ptr);
                 if (r < 0)
                 {

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -253,50 +253,50 @@ namespace Python.Runtime
 
             op = Runtime.PyObject_GetAttrString(dict, "keys");
             PyMethodType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
 #if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
-        Runtime.Decref(dict);
-        Runtime.Decref(op);
+        Runtime.XDecref(dict);
+        Runtime.XDecref(op);
 #endif
 
             op = Runtime.PyString_FromString("string");
             PyStringType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
             op = Runtime.PyUnicode_FromString("unicode");
             PyUnicodeType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
 #if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         op = Runtime.PyBytes_FromString("bytes");
         PyBytesType = Runtime.PyObject_Type(op);
-        Runtime.Decref(op);
+        Runtime.XDecref(op);
 #endif
 
             op = Runtime.PyTuple_New(0);
             PyTupleType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
             op = Runtime.PyList_New(0);
             PyListType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
             op = Runtime.PyDict_New();
             PyDictType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
             op = Runtime.PyInt_FromInt32(0);
             PyIntType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
             op = Runtime.PyLong_FromLong(0);
             PyLongType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
             op = Runtime.PyFloat_FromDouble(0);
             PyFloatType = Runtime.PyObject_Type(op);
-            Runtime.Decref(op);
+            Runtime.XDecref(op);
 
 #if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         PyClassType = IntPtr.Zero;
@@ -363,7 +363,7 @@ namespace Python.Runtime
             IntPtr path = Runtime.PySys_GetObject("path");
             IntPtr item = Runtime.PyString_FromString(rtdir);
             Runtime.PyList_Append(path, item);
-            Runtime.Decref(item);
+            Runtime.XDecref(item);
             AssemblyManager.UpdatePath();
         }
 
@@ -435,12 +435,12 @@ namespace Python.Runtime
             int size = Runtime.PyTuple_Size(args);
             IntPtr items = Runtime.PyTuple_New(size + 1);
             Runtime.PyTuple_SetItem(items, 0, obj);
-            Runtime.Incref(obj);
+            Runtime.XIncref(obj);
 
             for (int i = 0; i < size; i++)
             {
                 IntPtr item = Runtime.PyTuple_GetItem(args, i);
-                Runtime.Incref(item);
+                Runtime.XIncref(item);
                 Runtime.PyTuple_SetItem(items, i + 1, item);
             }
 
@@ -458,14 +458,14 @@ namespace Python.Runtime
             for (int i = 0; i < size; i++)
             {
                 item = Runtime.PyTuple_GetItem(t, i);
-                Runtime.Incref(item);
+                Runtime.XIncref(item);
                 Runtime.PyTuple_SetItem(items, i, item);
             }
 
             for (int n = 0; n < add; n++)
             {
                 item = args[n];
-                Runtime.Incref(item);
+                Runtime.XIncref(item);
                 Runtime.PyTuple_SetItem(items, size + n, item);
             }
 
@@ -488,7 +488,7 @@ namespace Python.Runtime
             if (!Runtime.PyTuple_Check(arg))
             {
                 args = Runtime.PyTuple_New(1);
-                Runtime.Incref(arg);
+                Runtime.XIncref(arg);
                 Runtime.PyTuple_SetItem(args, 0, arg);
                 free = true;
             }
@@ -532,7 +532,7 @@ namespace Python.Runtime
             }
             if (free)
             {
-                Runtime.Decref(args);
+                Runtime.XDecref(args);
             }
             return types;
         }
@@ -543,9 +543,10 @@ namespace Python.Runtime
         // (mostly for heavily used methods).
         //===================================================================
 
-        internal unsafe static void Incref(IntPtr op)
+        internal unsafe static void XIncref(IntPtr op)
         {
 #if (Py_DEBUG)
+        // according to Python doc, Py_IncRef() is Py_XINCREF() 
         Py_IncRef(op);
         return;
 #else
@@ -564,14 +565,11 @@ namespace Python.Runtime
 #endif
         }
 
-        internal unsafe static void Decref(IntPtr op)
+        internal static unsafe void XDecref(IntPtr op)
         {
-            if (op == IntPtr.Zero)
-            {
-                DebugUtil.Print("Decref(NULL)");
-            }
 #if (Py_DEBUG)
-    // Py_DecRef calls Python's Py_DECREF
+        // Py_DecRef calls Python's Py_DECREF
+        // according to Python doc, Py_DecRef() is Py_XDECREF()
         Py_DecRef(op);
         return;
 #else
@@ -958,7 +956,7 @@ namespace Python.Runtime
             PyObject_Type(IntPtr op)
         {
             IntPtr tp = PyObject_TYPE(op);
-            Runtime.Incref(tp);
+            Runtime.XIncref(tp);
             return tp;
         }
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -311,10 +311,10 @@ namespace Python.Runtime
             IntPtr i = Runtime.PyInstance_New(c, IntPtr.Zero, IntPtr.Zero);
             PyInstanceType = Runtime.PyObject_Type(i);
 
-            Runtime.Decref(s);
-            Runtime.Decref(i);
-            Runtime.Decref(c);
-            Runtime.Decref(d);
+            Runtime.XDecref(s);
+            Runtime.XDecref(i);
+            Runtime.XDecref(c);
+            Runtime.XDecref(d);
 #endif
 
             Error = new IntPtr(-1);
@@ -347,8 +347,8 @@ namespace Python.Runtime
         if (Runtime.PyObject_TYPE(op) == PyClassType) {
             wrap_exceptions = true;
         }
-        Runtime.Decref(op);
-        Runtime.Decref(m);
+        Runtime.XDecref(op);
+        Runtime.XDecref(m);
 #endif
 
             // Initialize modules that depend on the runtime class.

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -138,7 +138,7 @@ namespace Python.Runtime
             if (clrType == typeof(System.Exception))
             {
                 base_ = Exceptions.Exception;
-                Runtime.Incref(base_);
+                Runtime.XIncref(base_);
             }
             else
 #endif
@@ -151,7 +151,7 @@ namespace Python.Runtime
             IntPtr type = AllocateTypeObject(name);
 
             Marshal.WriteIntPtr(type, TypeOffset.ob_type, Runtime.PyCLRMetaType);
-            Runtime.Incref(Runtime.PyCLRMetaType);
+            Runtime.XIncref(Runtime.PyCLRMetaType);
 
             Marshal.WriteIntPtr(type, TypeOffset.tp_basicsize, (IntPtr)ob_size);
             Marshal.WriteIntPtr(type, TypeOffset.tp_itemsize, IntPtr.Zero);
@@ -162,7 +162,7 @@ namespace Python.Runtime
             if (base_ != IntPtr.Zero)
             {
                 Marshal.WriteIntPtr(type, TypeOffset.tp_base, base_);
-                Runtime.Incref(base_);
+                Runtime.XIncref(base_);
             }
 
             int flags = TypeFlags.Default;
@@ -303,7 +303,7 @@ namespace Python.Runtime
             IntPtr py_type = Runtime.PyTypeType;
 
             Marshal.WriteIntPtr(type, TypeOffset.tp_base, py_type);
-            Runtime.Incref(py_type);
+            Runtime.XIncref(py_type);
 
             // Copy gc and other type slots from the base Python metatype.
 
@@ -376,7 +376,7 @@ namespace Python.Runtime
             //Marshal.WriteIntPtr(type, TypeOffset.tp_dict, dc);
 
             Marshal.WriteIntPtr(type, TypeOffset.tp_base, base_);
-            Runtime.Incref(base_);
+            Runtime.XIncref(base_);
 
             int flags = TypeFlags.Default;
             flags |= TypeFlags.Managed;


### PR DESCRIPTION
self.repr is set in tp_repr() when called (which also increases the reference count). But if it's not populated we should not decrease the reference count 