### PR TITLE
Assemblymanager thread safety

### DIFF
--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -488,10 +488,22 @@ namespace Python.Runtime
 
             public AssemblyList(int capacity) {
                 _list = new List<Assembly>(capacity);
-                _lock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+                _lock = new ReaderWriterLockSlim();
             }
 
-            public int Count { get { return _list.Count; } }
+            public int Count
+            {
+                get
+                {
+                    _lock.EnterReadLock();
+                    try {
+                        return _list.Count;
+                    }
+                    finally {
+                        _lock.ExitReadLock();
+                    }
+                }
+            }
 
             public void Add(Assembly assembly) {
                 _lock.EnterWriteLock();

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -378,10 +378,9 @@ namespace Python.Runtime
                     }
                 }
 
-                if (ns != null && !namespaces[ns].ContainsKey(assembly))
+                if (ns != null)
                 {
-                    if (!namespaces[ns].TryAdd(assembly, String.Empty))
-                        throw new ArgumentException("Adding duplicate assembly " + assembly);
+                    namespaces[ns].TryAdd(assembly, String.Empty);
                 }
 
                 if (ns != null && t.IsGenericTypeDefinition)

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -535,12 +535,13 @@ namespace Python.Runtime
                 public Enumerator(AssemblyList assemblyList)
                 {
                     _assemblyList = assemblyList;
-                    _listEnumerator = _assemblyList._list.GetEnumerator();
                     _assemblyList._lock.EnterReadLock();
+                    _listEnumerator = _assemblyList._list.GetEnumerator();
                 }
 
                 public void Dispose()
                 {
+                    _listEnumerator.Dispose();
                     _assemblyList._lock.ExitReadLock();
                 }
 

--- a/src/testing/Python.Test.csproj
+++ b/src/testing/Python.Test.csproj
@@ -122,6 +122,7 @@
     <Compile Include="indexertest.cs" />
     <Compile Include="interfacetest.cs" />
     <Compile Include="methodtest.cs" />
+    <Compile Include="moduletest.cs" />
     <Compile Include="propertytest.cs" />
     <Compile Include="threadtest.cs" />
     <Compile Include="doctest.cs" />

--- a/src/testing/moduletest.cs
+++ b/src/testing/moduletest.cs
@@ -3,15 +3,23 @@ using System.Threading;
 
 namespace Python.Test {
     public class ModuleTest {
-        public static void RunThreads() {
-            var thread = new Thread(() => {
+        private static Thread _thread;
+
+        public static void RunThreads()
+        {
+            _thread = new Thread(() => {
                 var appdomain = AppDomain.CurrentDomain;
                 var assemblies = appdomain.GetAssemblies();
                 foreach (var assembly in assemblies) {
                     assembly.GetTypes();
                 }
             });
-            thread.Start();
+            _thread.Start();
+        }
+
+        public static void JoinThreads()
+        {
+            _thread.Join();
         }
     }
 }

--- a/src/testing/moduletest.cs
+++ b/src/testing/moduletest.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading;
+
+namespace Python.Test {
+    public class ModuleTest {
+        public static void RunThreads() {
+            var thread = new Thread(() => {
+                var appdomain = AppDomain.CurrentDomain;
+                var assemblies = appdomain.GetAssemblies();
+                foreach (var assembly in assemblies) {
+                    assembly.GetTypes();
+                }
+            });
+            thread.Start();
+        }
+    }
+}

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -65,9 +65,11 @@ class ModuleTests(unittest.TestCase):
         import System
         self.assertEquals(type(System.__dict__), type({}))
         self.assertEquals(System.__name__, 'System')
-        # the filename can be any module from the System namespace (eg System.Data.dll or System.dll)
-        self.assertTrue(fnmatch(System.__file__, "*System*.dll"),
-                        "unexpected System.__file__" + System.__file__)
+        # the filename can be any module from the System namespace
+        # (eg System.Data.dll or System.dll, but also mscorlib.dll)
+        system_file = System.__file__
+        self.assertTrue(fnmatch(system_file, "*System*.dll") or fnmatch(system_file, "mscorlib.dll"),
+                        "unexpected System.__file__" + system_file)
         self.assertTrue(System.__doc__.startswith("Namespace containing types from the following assemblies:"))
         self.assertTrue(self.isCLRClass(System.String))
         self.assertTrue(self.isCLRClass(System.Int32))

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -360,9 +360,14 @@ class ModuleTests(unittest.TestCase):
         # spin up .NET thread which loads assemblies and triggers AppDomain.AssemblyLoad event
         ModuleTest.RunThreads()
         time.sleep(1e-5)
-        # call import clr, which in AssemblyManager.GetNames iterates through the loaded types
         for i in range(1, 100):
+            # call import clr, which in AssemblyManager.GetNames iterates through the loaded types
             import clr
+            # import some .NET types
+            from System import DateTime
+            from System import Guid
+            from System.Collections.Generic import Dictionary
+            dict = Dictionary[Guid,DateTime]()
         ModuleTest.JoinThreads()
 
 

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -68,8 +68,8 @@ class ModuleTests(unittest.TestCase):
         # the filename can be any module from the System namespace
         # (eg System.Data.dll or System.dll, but also mscorlib.dll)
         system_file = System.__file__
-        self.assertTrue(fnmatch(system_file, "*System*.dll") or fnmatch(system_file, "mscorlib.dll"),
-                        "unexpected System.__file__" + system_file)
+        self.assertTrue(fnmatch(system_file, "*System*.dll") or fnmatch(system_file, "*mscorlib.dll"),
+                        "unexpected System.__file__: " + system_file)
         self.assertTrue(System.__doc__.startswith("Namespace containing types from the following assemblies:"))
         self.assertTrue(self.isCLRClass(System.String))
         self.assertTrue(self.isCLRClass(System.Int32))

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -353,6 +353,23 @@ class ModuleTests(unittest.TestCase):
         self.assertRaises(FileNotFoundException,
                           AddReference, "somethingtotallysilly")
 
+    def test_ThreadSafety(self):
+        import threading
+
+        def test_fn(i):
+            import time
+            time.sleep(i * 0.001)
+            import clr
+            from System.IO import FileNotFoundException
+
+        threads = [threading.Thread(target=test_fn, args=[i]) for i in range(1, 20)]
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
 
 def test_suite():
     return unittest.makeSuite(ModuleTests)

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -353,22 +353,15 @@ class ModuleTests(unittest.TestCase):
         self.assertRaises(FileNotFoundException,
                           AddReference, "somethingtotallysilly")
 
-    def test_ThreadSafety(self):
-        import threading
-
-        def test_fn(i):
-            import time
-            time.sleep(i * 0.001)
+    def test_AssemblyLoadThreadSafety(self):
+        import time
+        from Python.Test import ModuleTest
+        # spin up .NET thread which loads assemblies and triggers AppDomain.AssemblyLoad event
+        ModuleTest.RunThreads()
+        time.sleep(1e-5)
+        # call import clr, which in AssemblyManager.GetNames iterates through the loaded types
+        for i in range(1, 100):
             import clr
-            from System.IO import FileNotFoundException
-
-        threads = [threading.Thread(target=test_fn, args=[i]) for i in range(1, 20)]
-
-        for thread in threads:
-            thread.start()
-
-        for thread in threads:
-            thread.join()
 
 
 def test_suite():

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -66,7 +66,8 @@ class ModuleTests(unittest.TestCase):
         self.assertEquals(type(System.__dict__), type({}))
         self.assertEquals(System.__name__, 'System')
         # the filename can be any module from the System namespace (eg System.Data.dll or System.dll)
-        self.assertTrue(fnmatch(System.__file__, "*System*.dll"))
+        self.assertTrue(fnmatch(System.__file__, "*System*.dll"),
+                        "unexpected System.__file__" + System.__file__)
         self.assertTrue(System.__doc__.startswith("Namespace containing types from the following assemblies:"))
         self.assertTrue(self.isCLRClass(System.String))
         self.assertTrue(self.isCLRClass(System.Int32))

--- a/src/tests/test_module.py
+++ b/src/tests/test_module.py
@@ -363,6 +363,7 @@ class ModuleTests(unittest.TestCase):
         # call import clr, which in AssemblyManager.GetNames iterates through the loaded types
         for i in range(1, 100):
             import clr
+        ModuleTest.JoinThreads()
 
 
 def test_suite():


### PR DESCRIPTION
We observed a spurious crash when a spawned .NET thread loaded some additional assemblies triggered the AppDomain.AssemblyLoad event handler. This modified the namespaces Dictionary and led to an exception

> System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
>    at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
>    at System.Collections.Generic.Dictionary`2.KeyCollection.Enumerator.MoveNext()
>    at Python.Runtime.AssemblyManager.GetNames(String nsname) in C:\git\pythonnet\src\runtime\assemblymanager.cs:line 442

when we called import clr again from the Python thread. I was able to write a test which reproduces this (most of the time).
As a fix I propose to make namespaces a ConcurrentDictionary. The same issue should also apply to the assemblies list. Unfortunately there is no ConcurrentList, so I added a lock. All the operations under the assemblies lock seem simple enough to not cause any deadlocks by triggering the same codepath on a different thread.
