### PR TITLE
conda.recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ packages/*
 dist
 pythonnet.egg-info
 *.userprefs
+build/
+tools/nuget/*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,31 +1,85 @@
 os: Windows Server 2012
 
+matrix:
+    fast_finish: true
+
 environment:
   global:
     PYTHONPATH: c:\testdir
     PYTHONWARNINGS: 'ignore:::pip.pep425tags:'
+    CONDA_BLD_VERSION: "3.5"
+
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci\\run_with_env.cmd"
+
 
   matrix:
     # http://www.appveyor.com/docs/installed-software#python
     - PYTHON: "C:\\Python27"
+      CONDA_PY: "27"
+      CONDA_BLD: "C:\\miniconda-32"
+      CONDA_BLD_ARCH: "32"
+
     - PYTHON: "C:\\Python27-x64"
+      CONDA_PY: "27"
+      CONDA_BLD: "C:\\miniconda-64"
+      CONDA_BLD_ARCH: "64"
+
     - PYTHON: "C:\\Python33"
+      CONDA_PY: "33"
+      CONDA_BLD: "C:\\miniconda-32"
+      CONDA_BLD_ARCH: "32"
+
     - PYTHON: "C:\\Python33-x64"
+      CONDA_PY: "33"
+      CONDA_BLD: "C:\\miniconda-64"
+      CONDA_BLD_ARCH: "64"
+
     - PYTHON: "C:\\Python34"
+      CONDA_PY: "34"
+      CONDA_BLD: "C:\\miniconda-32"
+      CONDA_BLD_ARCH: "32"
+
     - PYTHON: "C:\\Python34-x64"
+      CONDA_PY: "34"
+      CONDA_BLD_ARCH: "64"
+      CONDA_BLD: "C:\\miniconda-64"
+
     - PYTHON: "C:\\Python35"
+      CONDA_PY: "35"
+      CONDA_BLD: "C:\\miniconda-32"
+      CONDA_BLD_ARCH: "32"
+
     - PYTHON: "C:\\Python35-x64"
+      CONDA_PY: "35"
+      CONDA_BLD: "C:\\miniconda-64"
+      CONDA_BLD_ARCH: "64"
 
 install:
+# install conda and deps
+- powershell .\ci\install.ps1
+- "%CONDA_BLD%\\Scripts\\conda config --set show_channel_urls true --set always_yes true --set changeps1 false"
+- "%CONDA_BLD%\\Scripts\\conda update -q conda"
+- "%CONDA_BLD%\\Scripts\\conda info -a"
+
+# install for wheels
 - "%PYTHON%\\python.exe -m pip install --upgrade pip"
 - "%PYTHON%\\python.exe -m pip install wheel"
 - "%PYTHON%\\python.exe -m pip install six"
 
 build_script:
+# build wheel
 - "%PYTHON%\\python.exe setup.py bdist_wheel"
 
+# build and dist conda package
+- cmd: "%CMD_IN_ENV% %CONDA_BLD%\\Scripts\\conda build conda.recipe"
+- ps: $CONDA_PKG=(& "$env:CONDA_BLD\\Scripts\\conda" build conda.recipe --output -q)
+- ps: copy-item $CONDA_PKG "$env:APPVEYOR_BUILD_FOLDER\\dist\\"
+
 test_script:
-  - ps: '& "$env:PYTHON\\Scripts\\pip.exe" install --no-cache-dir --force-reinstall --ignore-installed ("dist\\" + (gci dist)[0].Name)'
+  - ps: '& "$env:PYTHON\\Scripts\\pip.exe" install --no-cache-dir --force-reinstall --ignore-installed ("dist\\" + (gci dist\*.whl)[0].Name)'
   - mkdir c:\testdir
   - ps: copy-item (gci -path build -re -include Python.Test.dll)[0].FullName c:\testdir
   - "%PYTHON%\\python.exe src\\tests\\runtests.py"

--- a/ci/install.ps1
+++ b/ci/install.ps1
@@ -1,0 +1,92 @@
+# Sample script to install Miniconda under Windows
+# Authors: Olivier Grisel, Jonathan Helmus and Kyle Kastner, Robert McGibbon
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+
+
+function DownloadMiniconda ($python_version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    $filename = "Miniconda3-latest-Windows-" + $platform_suffix + ".exe"
+    $url = $MINICONDA_URL + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        # return $false
+    }
+    if ($architecture -match "32") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $install_log = $python_home + ".log"
+    $args = "/S /D=$python_home"
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    if (Test-Path $python_home) {
+        Write-Host "Python $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Get-Content -Path $install_log
+        Exit 1
+    }
+}
+
+
+function InstallCondaPackages ($python_home, $spec) {
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    $args = "install --yes " + $spec
+    Write-Host ("conda " + $args)
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+}
+
+function UpdateConda ($python_home) {
+    $conda_path = $python_home + "\Scripts\conda.exe"
+    Write-Host "Updating conda..."
+    $args = "update --yes conda"
+    Write-Host $conda_path $args
+    Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
+}
+
+
+function main () {
+    InstallMiniconda $env:CONDA_BLD_VERSION $env:CONDA_BLD_ARCH $env:CONDA_BLD
+    UpdateConda $env:CONDA_BLD
+    InstallCondaPackages $env:CONDA_BLD "conda-build jinja2 anaconda-client"
+}
+
+main

--- a/ci/run_with_env.cmd
+++ b/ci/run_with_env.cmd
@@ -1,0 +1,95 @@
+:: EXPECTED ENV VARS: PYTHON_ARCH (either x86 or x64)
+::                    CONDA_PY (either 27, 33, 35 etc. - only major version is extracted)
+::
+::
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Phil Elson
+:: Original Author: Olivier Grisel (https://github.com/ogrisel/python-appveyor-demo)
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+:: originally from https://github.com/pelson/Obvious-CI/blob/master/scripts/obvci_appveyor_python_build_env.cmd
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%CONDA_PY:~0,1%
+
+IF "%CONDA_PY:~2,1%" == "" (
+    :: CONDA_PY style, such as 27, 34 etc.
+    SET MINOR_PYTHON_VERSION=%CONDA_PY:~1,1%
+) ELSE (
+    IF "%CONDA_PY:~3,1%" == "." (
+     SET MINOR_PYTHON_VERSION=%CONDA_PY:~2,1%
+    ) ELSE (
+     SET MINOR_PYTHON_VERSION=%CONDA_PY:~2,2%
+    )
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT /B 1
+    )
+)
+
+IF "%PYTHON_ARCH%"=="64" (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT /B 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT /B 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT /B 1
+)

--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,13 @@
+:: build it
+
+:: set path to modern MSBuild
+set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+
+%PYTHON% setup.py install
+
+:: copy our compiled library
+set SRC=%RECIPE_DIR%\..
+set DEST=%SP_DIR%
+
+:: Install step
+copy %SRC%\Python.Runtime.dll.config %DEST%

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,28 @@
+package:
+    name: clr
+    version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('-dev', '.dev') }}
+
+build:
+    skip: True  # [not win]
+    number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+    {% if environ.get('GIT_DESCRIBE_NUMBER', '0') == '0' %}string: py{{ environ.get('PY_VER').replace('.', '') }}_0
+    {% else %}string: py{{ environ.get('PY_VER').replace('.', '') }}_{{ environ.get('GIT_BUILD_STR', 'GIT_STUB') }}{% endif %}
+
+source:
+    git_url: ../
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - clr
+
+about:
+   home: https://github.com/pythonnet/pythonnet
+   license: ZPL


### PR DESCRIPTION
closes #210 

- builds a ``clr`` conda package
- builds for 2.7/3.5 on windows (will simply fail on other platforms), should be easy to extend though
- fixes the non-standard dev tag (-dev is not valid, should be .dev, but no big deal)
- release tags *should* work, but not actually tests (e.g. should generate ``clr-v2.2.0-py35``
- the actual installation should *really* be into a ``site-packages\clr\`` sub-dir in the target, but this just mimics how the wheels work.

- [x] agreement to transition to MIT license
- [x] fix old msbuild without C# 6.0 support for python 3.3 and 3.4 or add C# 6.0 compiler as nuget dependency
- [x] pip 9.0 issues
- [x] keep both python and conda builds by either having two appveyor.yml and two server configuration or merge them into one.