### PR TITLE
Fix exception pickling

### DIFF
--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -30,6 +30,9 @@ namespace Python.Runtime
             this.pyHandle = py;
             this.gcHandle = gc;
             inst = ob;
+
+            // Fix the BaseException args slot if wrapping a CLR exception
+            Exceptions.SetArgs(py);
         }
 
 

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -55,50 +55,11 @@ namespace Python.Runtime
             {
                 message = e.Message;
             }
-            if ((e.StackTrace != null) && (e.StackTrace != String.Empty))
+            if (!string.IsNullOrEmpty(e.StackTrace))
             {
                 message = message + "\n" + e.StackTrace;
             }
             return Runtime.PyUnicode_FromString(message);
-        }
-
-        //====================================================================
-        // Exceptions __getattribute__ implementation.
-        // handles Python's args and message attributes
-        //====================================================================
-
-        public static IntPtr tp_getattro(IntPtr ob, IntPtr key)
-        {
-            if (!Runtime.PyString_Check(key))
-            {
-                Exceptions.SetError(Exceptions.TypeError, "string expected");
-                return IntPtr.Zero;
-            }
-
-            string name = Runtime.GetManagedString(key);
-            if (name == "args")
-            {
-                Exception e = ToException(ob);
-                IntPtr args;
-                if (e.Message != String.Empty)
-                {
-                    args = Runtime.PyTuple_New(1);
-                    IntPtr msg = Runtime.PyUnicode_FromString(e.Message);
-                    Runtime.PyTuple_SetItem(args, 0, msg);
-                }
-                else
-                {
-                    args = Runtime.PyTuple_New(0);
-                }
-                return args;
-            }
-
-            if (name == "message")
-            {
-                return ExceptionClassObject.tp_str(ob);
-            }
-
-            return Runtime.PyObject_GenericGetAttr(ob, key);
         }
     }
 
@@ -190,10 +151,10 @@ namespace Python.Runtime
                 return;
 
             IntPtr args;
-            if (e.Message != String.Empty)
+            if (!string.IsNullOrEmpty(e.Message))
             {
                 args = Runtime.PyTuple_New(1);
-                IntPtr msg = Runtime.PyUnicode_FromString(e.Message);
+                var msg = Runtime.PyUnicode_FromString(e.Message);
                 Runtime.PyTuple_SetItem(args, 0, msg);
             }
             else

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -89,41 +89,35 @@ namespace Python.Runtime
 
         public static int magic(IntPtr ob)
         {
-#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
             {
                 return ExceptionOffset.ob_data;
             }
-#endif
             return ob_data;
         }
 
         public static int DictOffset(IntPtr ob)
         {
-#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
             {
                 return ExceptionOffset.ob_dict;
             }
-#endif
             return ob_dict;
         }
 
         public static int Size(IntPtr ob)
         {
-#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
             {
                 return ExceptionOffset.Size();
             }
-#endif
 #if (Py_DEBUG)
             return 6 * IntPtr.Size;
 #else
-            return 4*IntPtr.Size;
+            return 4 * IntPtr.Size;
 #endif
         }
 
@@ -137,7 +131,6 @@ namespace Python.Runtime
         private static int ob_data;
     }
 
-#if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
     internal class ExceptionOffset
     {
@@ -161,15 +154,21 @@ namespace Python.Runtime
         // (start after PyObject_HEAD)
         public static int dict = 0;
         public static int args = 0;
+#if (PYTHON25 || PYTHON26 || PYTHON27)
+        public static int message = 0;
+#elif (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
         public static int traceback = 0;
         public static int context = 0;
         public static int cause = 0;
+#if !PYTHON32
+        public static int suppress_context = 0;
+#endif
+#endif
 
         // extra c# data
         public static int ob_dict;
         public static int ob_data;
     }
-#endif
 
 
 #if (PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -41,20 +41,6 @@ namespace Python.Runtime
                     GCHandle gc = (GCHandle)op;
                     return (ManagedType)gc.Target;
                 }
-
-                // In certain situations, we need to recognize a wrapped
-                // exception class and be willing to unwrap the class :(
-
-                if (Runtime.wrap_exceptions)
-                {
-                    IntPtr e = Exceptions.UnwrapExceptionClass(ob);
-                    if ((e != IntPtr.Zero) && (e != ob))
-                    {
-                        ManagedType m = GetManagedObject(e);
-                        Runtime.XDecref(e);
-                        return m;
-                    }
-                }
             }
             return null;
         }

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -202,20 +202,6 @@ namespace Python.Runtime
                 if (m == null)
                 {
                     ManagedType attr = this.GetAttribute(name, true);
-                    if (Runtime.wrap_exceptions)
-                    {
-                        if (attr is ExceptionClassObject)
-                        {
-                            ExceptionClassObject c = attr as ExceptionClassObject;
-                            if (c != null)
-                            {
-                                IntPtr p = attr.pyHandle;
-                                IntPtr r = Exceptions.GetExceptionClassWrapper(p);
-                                Runtime.PyDict_SetItemString(dict, name, r);
-                                Runtime.XIncref(r);
-                            }
-                        }
-                    }
                 }
             }
         }
@@ -305,26 +291,6 @@ namespace Python.Runtime
             {
                 Exceptions.SetError(Exceptions.AttributeError, name);
                 return IntPtr.Zero;
-            }
-
-            // XXX - hack required to recognize exception types. These types
-            // may need to be wrapped in old-style class wrappers in versions
-            // of Python where new-style classes cannot be used as exceptions.
-
-            if (Runtime.wrap_exceptions)
-            {
-                if (attr is ExceptionClassObject)
-                {
-                    ExceptionClassObject c = attr as ExceptionClassObject;
-                    if (c != null)
-                    {
-                        IntPtr p = attr.pyHandle;
-                        IntPtr r = Exceptions.GetExceptionClassWrapper(p);
-                        Runtime.PyDict_SetItemString(self.dict, name, r);
-                        Runtime.XIncref(r);
-                        return r;
-                    }
-                }
             }
 
             Runtime.XIncref(attr.pyHandle);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -212,7 +212,6 @@ namespace Python.Runtime
         internal static Object IsFinalizingLock = new Object();
         internal static bool IsFinalizing = false;
 
-        internal static bool wrap_exceptions;
         internal static bool is32bit;
 
         /// <summary>
@@ -330,25 +329,6 @@ namespace Python.Runtime
             NativeMethods.FreeLibrary(dll);
         }
 #endif
-#endif
-
-
-            // Determine whether we need to wrap exceptions for versions of
-            // of the Python runtime that do not allow new-style classes to
-            // be used as exceptions (Python versions 2.4 and lower).
-
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
-            wrap_exceptions = false;
-#else
-        IntPtr m = PyImport_ImportModule("exceptions");
-        Exceptions.ErrorCheck(m);
-        op = Runtime.PyObject_GetAttrString(m, "Exception");
-        Exceptions.ErrorCheck(op);
-        if (Runtime.PyObject_TYPE(op) == PyClassType) {
-            wrap_exceptions = true;
-        }
-        Runtime.XDecref(op);
-        Runtime.XDecref(m);
 #endif
 
             // Initialize modules that depend on the runtime class.

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -128,25 +128,21 @@ namespace Python.Runtime
             // XXX Hack, use a different base class for System.Exception
             // Python 2.5+ allows new style class exceptions but they *must*
             // subclass BaseException (or better Exception).
-#if (PYTHON25 || PYTHON26 || PYTHON27 || PYTHON32 || PYTHON33 || PYTHON34 || PYTHON35)
             if (typeof(System.Exception).IsAssignableFrom(clrType))
             {
-                ob_size = ObjectOffset.Size(Exceptions.BaseException);
-                tp_dictoffset = ObjectOffset.DictOffset(Exceptions.BaseException);
+                ob_size = ObjectOffset.Size(Exceptions.Exception);
+                tp_dictoffset = ObjectOffset.DictOffset(Exceptions.Exception);
             }
 
             if (clrType == typeof(System.Exception))
             {
                 base_ = Exceptions.Exception;
-                Runtime.XIncref(base_);
             }
-            else
-#endif
-                if (clrType.BaseType != null)
-                {
-                    ClassBase bc = ClassManager.GetClass(clrType.BaseType);
-                    base_ = bc.pyHandle;
-                }
+            else if (clrType.BaseType != null)
+            {
+                ClassBase bc = ClassManager.GetClass(clrType.BaseType);
+                base_ = bc.pyHandle;
+            }
 
             IntPtr type = AllocateTypeObject(name);
 

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -334,7 +334,10 @@ class ExceptionTests(unittest.TestCase):
 
     def testPicklingExceptions(self):
         from System import Exception
-        import pickle
+        try
+            import cPickle as pickle
+        except ImportError:
+            import pickle
 
         exc = Exception("test")
         dumped = pickle.dumps(exc)

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -6,11 +6,6 @@ if six.PY3:
     unicode = str
 
 
-# Note: all of these tests are known to fail because Python currently
-# doesn't allow new-style classes to be used as exceptions. I'm leaving
-# the tests in place in to document 'how it ought to work' in the hopes
-# that they'll all pass one day...
-
 class ExceptionTests(unittest.TestCase):
     """Test exception support."""
 
@@ -335,6 +330,16 @@ class ExceptionTests(unittest.TestCase):
             self.assertTrue(isinstance(o, Object))
         else:
             self.assertFalse(isinstance(o, Object))
+
+    def testPicklingExceptions(self):
+        from System import Exception
+        import pickle
+
+        exc = Exception("test")
+        dumped = pickle.dumps(exc)
+        loaded = pickle.loads(dumped)
+
+        self.assertEqual(repr(exc), repr(loaded))
 
 
 def test_suite():

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -295,14 +295,15 @@ class ExceptionTests(unittest.TestCase):
         msg = "A simple message"
 
         e = OverflowException(msg)
-        self.assertEqual(e.message, msg)
-        self.assertTrue(isinstance(e.message, unicode))  # ???
         self.assertEqual(str(e), msg)
         self.assertEqual(unicode(e), msg)
 
         self.assertEqual(e.args, (msg,))
         self.assertTrue(isinstance(e.args, tuple))
-        self.assertEqual(repr(e), "OverflowException('A simple message',)")
+        if six.PY2:
+            self.assertEqual(repr(e), "OverflowException(u'A simple message',)")
+        else:
+            self.assertEqual(repr(e), "OverflowException('A simple message',)")
 
     def testExceptionIsInstanceOfSystemObject(self):
         """Test behavior of isinstance(<managed exception>, System.Object)."""
@@ -339,7 +340,7 @@ class ExceptionTests(unittest.TestCase):
         dumped = pickle.dumps(exc)
         loaded = pickle.loads(dumped)
 
-        self.assertEqual(repr(exc), repr(loaded))
+        self.assertEqual(exc.args, loaded.args)
 
 
 def test_suite():

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -334,7 +334,7 @@ class ExceptionTests(unittest.TestCase):
 
     def testPicklingExceptions(self):
         from System import Exception
-        try
+        try:
             import cPickle as pickle
         except ImportError:
             import pickle


### PR DESCRIPTION
Fixes #284.

This PR contains 3 componenents:

1. Remove all of the Py<2.5 workarounds that wrap exceptions in old-style class instances
2. Fix #284 by moving the exception args into the corresponding slot in the `BaseException` object instead of faking the functionality by overloading `__getattr__`
3. Remove the `__getattr__` overload altogether since the only functionality it provides (lookup of `.message`) is deprecated in Python >= 2.6