### PR TITLE
Fix attribute setting

### DIFF
--- a/src/tests/test_class.py
+++ b/src/tests/test_class.py
@@ -198,6 +198,17 @@ class ClassTests(unittest.TestCase):
 
         self.assertTrue(table.Count == 3)
 
+    def testAddAndRemoveClassAttribute(self):
+        
+        from System import TimeSpan
+
+        for i in range(100):
+            TimeSpan.new_method = lambda self: self.TotalMinutes
+            ts = TimeSpan.FromHours(1)
+            self.assertTrue(ts.new_method() == 60)
+            del TimeSpan.new_method
+            self.assertFalse(hasattr(ts, "new_method"))
+
 
 class ClassicClass:
     def kind(self):


### PR DESCRIPTION
- When modifying attributes on a class, PyType_Modified has to be called
- The result of a lookup may be non-NULL without being a descriptor (e.g. if we
  set it manually using `Class.attribute = 1`)

Fixes issue #292 