### PR TITLE
Rename the conda package to pythonnet.

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,5 +1,5 @@
 package:
-    name: clr
+    name: pythonnet
     version: {{ environ.get('GIT_DESCRIBE_TAG', '').replace('-dev', '.dev') }}
 
 build:


### PR DESCRIPTION
This matches the project and (more importantly) pypi name.