### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# config files
+[*.{ini,yaml,yml}]
+indent_size = 2
+
+# Xml project files
+[*.{csproj,config,build,config}]
+indent_size = 2
+
+# Solution
+[*.sln]
+indent_style = tab


### PR DESCRIPTION
We previously discussed adding .editorconfig during the [whitespace cleanup](https://github.com/pythonnet/pythonnet/issues/184#issuecomment-199300630) and its [pr](https://github.com/pythonnet/pythonnet/pull/205#issuecomment-211529787).

Visual Studio 2017 is coming with built-in editorconfig support.

## Resources
https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
https://github.com/dotnet/roslyn/blob/master/.editorconfig
https://github.com/dotnet/coreclr/blob/master/.editorconfig
https://github.com/dotnet/corefx/blob/master/.editorconfig