### PR TITLE
Coverage & CI Setup Improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required
-language: python
+sudo: false
 
+language: python
 python:
   - 2.7
   - 3.3
@@ -8,14 +8,21 @@ python:
   - 3.5
   - 3.6
 
-before_install:
-  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
-  - sudo apt-get install software-properties-common
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-  - echo "deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.2.4.4 main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
-  - echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | sudo tee -a /etc/apt/sources.list.d/mono-xamarin.list
-  - sudo apt-get update
-  - sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install mono-devel mono-complete referenceassemblies-pcl ca-certificates-mono nunit-console
+env:
+  global:
+    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - SEGFAULT_SIGNALS=all
+    - PYTHONUNBUFFERED=True
+
+addons:
+  apt:
+    sources:
+      - mono
+      - mono-libtiff-compat
+    packages:
+      - mono-devel
+      - ca-certificates-mono
+      - nunit-console
 
 install:
   - pip install six

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,20 @@ addons:
       - nunit-console
 
 install:
-  - pip install six
-  - pip install pycparser
-  - python setup.py build_ext --inplace
+  - pip install pycparser coverage codecov six
+  - coverage run setup.py build_ext --inplace
 
 script:
   - export PYTHONPATH=`pwd`:$PYTHONPATH
   - python src/tests/runtests.py
   # - nunit-console src/embed_tests/bin/x64/ReleaseMono/Python.EmbeddingTest.dll
+
+after_success:
+  # Uncomment if need to geninterop, ie. py37 final
+  # - python tools/geninterop/geninterop.py
+
+  # Waiting on mono-cov support or SharpCover
+  - codecov
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![appveyor shield][]](https://ci.appveyor.com/project/pythonnet/pythonnet/branch/master)
 [![travis shield][]](https://travis-ci.org/pythonnet/pythonnet)
+[![codecov shield][]](https://codecov.io/github/pythonnet/pythonnet)
 [![license shield][]](./LICENSE)
 [![pypi package version][]](https://pypi.python.org/pypi/pythonnet)
 [![python supported shield][]](https://pypi.python.org/pypi/pythonnet)
@@ -79,6 +80,8 @@ int32
 ```
 
 [appveyor shield]: https://img.shields.io/appveyor/ci/pythonnet/pythonnet/master.svg?label=AppVeyor
+
+[codecov shield]: https://img.shields.io/codecov/c/github/pythonnet/pythonnet/pytest.svg?label=codecov
 
 [license shield]: https://img.shields.io/badge/license-MIT-blue.svg
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ environment:
     PYTHONUNBUFFERED: True
     PYTHONWARNINGS: 'ignore:::wheel.pep425tags:'
     PYTHONPATH: C:\testdir
-    NUNIT: nunit-console
     CONDA_BLD: C:\conda
     CONDA_BLD_VERSION: 3.5
 
@@ -35,7 +34,6 @@ init:
   - set CONDA_BLD_ARCH=%PLATFORM:x=%
   - set PYTHON=C:\PYTHON%PYTHON_VERSION:.=%
   - if %PLATFORM%==x86 (set CONDA_BLD_ARCH=32)
-  - if %PLATFORM%==x86 (set NUNIT=%NUNIT%-x86)
   - if %PLATFORM%==x64 (set PYTHON=%PYTHON%-x64)
 
   # Prepend newly installed Python to the PATH of this build
@@ -47,21 +45,29 @@ init:
   - python -c "import ctypes; print(ctypes.sizeof(ctypes.c_wchar))"
 
 install:
-  # install for wheels
-  - pip install --upgrade pip wheel six
+  # install for wheels & coverage
+  - pip install --upgrade pip wheel coverage codecov six
+
+  # Install OpenCover. Can't put on packages.config; not Linux/Mono compatible
+  - .\tools\nuget\nuget.exe install OpenCover -OutputDirectory packages
 
 build_script:
-  # build clean sdist & wheel
-  - python setup.py sdist bdist_wheel
+  # build clean sdist & wheel with coverage of setup.py, install local wheel
+  - coverage run setup.py sdist bdist_wheel
 
 test_script:
   - pip install --no-index --find-links=.\dist\ pythonnet
   - ps: Copy-Item (Resolve-Path .\build\*\Python.Test.dll) C:\testdir
-  - python src\tests\runtests.py
-  # - "%NUNIT% src/embed_tests/bin/%PLATFORM%/ReleaseWin/Python.EmbeddingTest.dll"
+
+  # Test runner
+  - ps: .\ci\appveyor_run_tests.ps1
 
   # Build conda-recipe on Pull Requests
   - ps: .\ci\appveyor_build_recipe.ps1
+
+on_finish:
+  # Upload coverage
+  - codecov
 
 artifacts:
   - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,9 +47,6 @@ init:
   - python -c "import ctypes; print(ctypes.sizeof(ctypes.c_wchar))"
 
 install:
-  # install conda and deps
-  - ps: .\ci\install_miniconda.ps1
-
   # install for wheels
   - pip install --upgrade pip wheel six
 
@@ -57,16 +54,14 @@ build_script:
   # build clean sdist & wheel
   - python setup.py sdist bdist_wheel
 
-  # build and dist conda package
-  - '%CMD_IN_ENV% %CONDA_BLD%\Scripts\conda build conda.recipe'
-  - ps: $CONDA_PKG=(&"$env:CONDA_BLD\Scripts\conda" build conda.recipe --output -q)
-  - ps: Copy-Item $CONDA_PKG "$env:APPVEYOR_BUILD_FOLDER\dist\"
-
 test_script:
   - pip install --no-index --find-links=.\dist\ pythonnet
   - ps: Copy-Item (Resolve-Path .\build\*\Python.Test.dll) C:\testdir
   - python src\tests\runtests.py
   # - "%NUNIT% src/embed_tests/bin/%PLATFORM%/ReleaseWin/Python.EmbeddingTest.dll"
+
+  # Build conda-recipe on Pull Requests
+  - ps: .\ci\appveyor_build_recipe.ps1
 
 artifacts:
   - path: dist\*

--- a/ci/appveyor_build_recipe.ps1
+++ b/ci/appveyor_build_recipe.ps1
@@ -1,0 +1,6 @@
+if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+    Invoke-Expression .\ci\install_miniconda.ps1
+    &"$env:CONDA_BLD\Scripts\conda" build conda.recipe --dirty -q
+    $CONDA_PKG=(&"$env:CONDA_BLD\Scripts\conda" build conda.recipe --output -q)
+    Copy-Item $CONDA_PKG "$env:APPVEYOR_BUILD_FOLDER\dist\"
+}

--- a/ci/appveyor_run_tests.ps1
+++ b/ci/appveyor_run_tests.ps1
@@ -1,0 +1,33 @@
+# Script to simplify appveyor configuration and resolve path to tools
+
+# Executable paths for OpenCover
+# Note if OpenCover fails, it won't affect the exit codes.
+$OPENCOVER = Resolve-Path .\packages\OpenCover.*\tools\OpenCover.Console.exe
+$NUNIT = Resolve-Path .\packages\NUnit.ConsoleRunner*\tools\nunit3-console.exe
+$PY = Get-Command python
+
+# Can't use ".\build\*\Python.EmbeddingTest.dll". Missing framework files.
+$CS_TESTS = Resolve-Path .\src\embed_tests\bin\*\*\Python.EmbeddingTest.dll
+$RUNTIME_DIR = Resolve-Path .\src\runtime\bin\*\ReleaseWin\
+
+# Run python tests with C# coverage
+# why `2>&1 | %{ "$_" }`? see: http://stackoverflow.com/a/20950421/5208670
+.$OPENCOVER -register:user -searchdirs:"$RUNTIME_DIR" -output:py.coverage -target:"$PY" -targetargs:src\tests\runtests.py -returntargetcode 2>&1 | %{ "$_" }
+$PYTHON_STATUS = $LastExitCode
+if ($PYTHON_STATUS -ne 0) {
+    Write-Host "Python tests failed, continuing to embedded tests" -ForegroundColor "Red"
+}
+
+# Run Embedded tests with C# coverage
+# .$OPENCOVER -register:user -searchdirs:"$RUNTIME_DIR" -output:cs.coverage -target:"$NUNIT" -targetargs:"$CS_TESTS" -returntargetcode
+# $NUNIT_STATUS = $LastExitCode
+# if ($NUNIT_STATUS -ne 0) {
+#     Write-Host "Embedded tests failed" -ForegroundColor "Red"
+# }
+
+# Embedded tests failing due to open issues, pass/fail only on Python exit code
+# if ($PYTHON_STATUS -ne 0 -or $NUNIT_STATUS -ne 0) {
+if ($PYTHON_STATUS -ne 0) {
+    Write-Host "Tests failed" -ForegroundColor "Red"
+    $host.SetShouldExit(1)
+}

--- a/conda.recipe/README.md
+++ b/conda.recipe/README.md
@@ -1,0 +1,5 @@
+# Conda Recipe
+
+The files here are needed to build Python.Net with conda
+
+http://conda.pydata.org/docs/building/recipe.html

--- a/src/embed_tests/packages.config
+++ b/src/embed_tests/packages.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.5.0" targetFramework="net40" />
+  <package id="NUnit.ConsoleRunner" version="3.5.0" targetFramework="net40" />
 </packages>

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,42 @@
+[tox]
+skipsdist=True
+skip_missing_interpreters=True
+envlist =
+  py27
+  py33
+  py34
+  py35
+  py36
+  check
+
+[testenv]
+recreate=True
+basepython =
+  py27: {env:TOXPYTHON:python2.7}
+  py33: {env:TOXPYTHON:python3.3}
+  py34: {env:TOXPYTHON:python3.4}
+  py35: {env:TOXPYTHON:python3.5}
+  py36: {env:TOXPYTHON:python3.6}
+  check: python3.5
+setenv =
+  PYTHONUNBUFFERED=True
+  DISTUTILS_DEBUG=
+passenv =
+  *
+commands =
+  python --version
+  python -c "import struct; print('ARCH: %d' % (struct.calcsize('P') * 8))"
+  python -c "import ctypes; print('UCS%d' % ctypes.sizeof(ctypes.c_wchar))"
+  python setup.py bdist_wheel
+  pip install --no-index --find-links=dist/ pythonnet
+  {posargs:python src\tests\runtests.py}
+
+[testenv:check]
+ignore_errors=True
+deps =
+  check-manifest
+  flake8
+commands =
+  check-manifest {toxinidir}
+  flake8 src setup.py
+  python setup.py check --strict --metadata


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
- Add coverage (cs code limited to windows, no mature coverage tools for mono)
- Speed up AppVeyor by 50%, conda recipes built only when `pull_request`
- Speeds up Travis ~30% by using containers
- Simplifies and unfreezes mono setup

### Does this close any currently open issues?

#237 
#334

### Any other comments?

Redid the previous pull request. (#335)

Sample [coverage](https://codecov.io/gh/vmuriart/pythonnet/tree/1cfe592ae8806847bfb9c2581cef5ebac771c7c3) report.

