### PR TITLE
Add pysetargv

### DIFF
--- a/src/embed_tests/InitializeTest.cs
+++ b/src/embed_tests/InitializeTest.cs
@@ -13,40 +13,26 @@ namespace Python.EmbeddingTest
         public static void LoadSpecificArgs()
         {
             var args = new[] { "test1", "test2" };
-            PythonEngine.Initialize(args);
-            try
+            using (new PythonEngine(args))
+            using (var argv = new PyList(Runtime.Runtime.PySys_GetObject("argv")))
             {
-                using (var argv = new PyList(Runtime.Runtime.PySys_GetObject("argv")))
-                {
-                    Assert.That(argv[0].ToString() == args[0]);
-                    Assert.That(argv[1].ToString() == args[1]);
-                }
-            }
-            finally
-            {
-                PythonEngine.Shutdown();
+                Assert.That(argv[0].ToString() == args[0]);
+                Assert.That(argv[1].ToString() == args[1]);
             }
         }
 
         [Test]
         public static void LoadDefaultArgs()
         {
-            PythonEngine.Initialize();
-            try
+            using (new PythonEngine())
+            using (var argv = new PyList(Runtime.Runtime.PySys_GetObject("argv")))
             {
-                using (var argv = new PyList(Runtime.Runtime.PySys_GetObject("argv")))
-                {
-                    Assert.That(argv.Length() != 0);
-                }
-            }
-            finally
-            {
-                PythonEngine.Shutdown();
+                Assert.That(argv.Length() != 0);
             }
         }
 
         [Test]
-        public static void Test()
+        public static void StartAndStopTwice()
         {
             PythonEngine.Initialize();
             PythonEngine.Shutdown();

--- a/src/embed_tests/InitializeTest.cs
+++ b/src/embed_tests/InitializeTest.cs
@@ -10,6 +10,42 @@ namespace Python.EmbeddingTest
     public class InitializeTest
     {
         [Test]
+        public static void LoadSpecificArgs()
+        {
+            var args = new[] { "test1", "test2" };
+            PythonEngine.Initialize(args);
+            try
+            {
+                using (var argv = new PyList(Runtime.Runtime.PySys_GetObject("argv")))
+                {
+                    Assert.That(argv[0].ToString() == args[0]);
+                    Assert.That(argv[1].ToString() == args[1]);
+                }
+            }
+            finally
+            {
+                PythonEngine.Shutdown();
+            }
+        }
+
+        [Test]
+        public static void LoadDefaultArgs()
+        {
+            PythonEngine.Initialize();
+            try
+            {
+                using (var argv = new PyList(Runtime.Runtime.PySys_GetObject("argv")))
+                {
+                    Assert.That(argv.Length() != 0);
+                }
+            }
+            finally
+            {
+                PythonEngine.Shutdown();
+            }
+        }
+
+        [Test]
         public static void Test()
         {
             PythonEngine.Initialize();

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -154,7 +154,6 @@ namespace Python.Runtime
                 Exceptions.Clear();
 
                 Py.SetArgv(args);
-                Py.Throw();
 
                 // register the atexit callback (this doesn't use Py_AtExit as the C atexit
                 // callbacks are called after python is fully finalized but the python ones
@@ -382,10 +381,7 @@ namespace Python.Runtime
         public static PyObject ImportModule(string name)
         {
             IntPtr op = Runtime.PyImport_ImportModule(name);
-            if (op == IntPtr.Zero)
-            {
-                return null;
-            }
+            Py.Throw();
             return new PyObject(op);
         }
 
@@ -401,10 +397,7 @@ namespace Python.Runtime
         public static PyObject ReloadModule(PyObject module)
         {
             IntPtr op = Runtime.PyImport_ReloadModule(module.Handle);
-            if (op == IntPtr.Zero)
-            {
-                throw new PythonException();
-            }
+            Py.Throw();
             return new PyObject(op);
         }
 
@@ -420,15 +413,9 @@ namespace Python.Runtime
         public static PyObject ModuleFromString(string name, string code)
         {
             IntPtr c = Runtime.Py_CompileString(code, "none", (IntPtr)257);
-            if (c == IntPtr.Zero)
-            {
-                throw new PythonException();
-            }
+            Py.Throw();
             IntPtr m = Runtime.PyImport_ExecCodeModule(name, c);
-            if (m == IntPtr.Zero)
-            {
-                throw new PythonException();
-            }
+            Py.Throw();
             return new PyObject(m);
         }
 
@@ -476,10 +463,7 @@ namespace Python.Runtime
                     code, flag, globals.Value, locals.Value
                     );
 
-                if (Runtime.PyErr_Occurred() != 0)
-                {
-                    throw new PythonException();
-                }
+                Py.Throw();
 
                 return new PyObject(result);
             }
@@ -583,6 +567,7 @@ namespace Python.Runtime
             {
                 var arr = argv.ToArray();
                 Runtime.PySys_SetArgvEx(arr.Length, arr, 0);
+                Py.Throw();
             }
         }
 

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -10,10 +10,30 @@ namespace Python.Runtime
     /// <summary>
     /// This class provides the public interface of the Python runtime.
     /// </summary>
-    public class PythonEngine
+    public class PythonEngine : IDisposable
     {
         private static DelegateManager delegateManager;
         private static bool initialized;
+
+        public PythonEngine()
+        {
+            Initialize();
+        }
+
+        public PythonEngine(params string[] args)
+        {
+            Initialize(args);
+        }
+
+        public PythonEngine(IEnumerable<string> args)
+        {
+            Initialize(args);
+        }
+
+        public void Dispose()
+        {
+            Shutdown();
+        }
 
         #region Properties
 
@@ -197,7 +217,8 @@ namespace Python.Runtime
         // when it is imported by the CLR extension module.
         //====================================================================
 #if PYTHON3
-        public static IntPtr InitExt() {
+        public static IntPtr InitExt()
+        {
 #elif PYTHON2
         public static void InitExt()
         {
@@ -549,6 +570,11 @@ namespace Python.Runtime
                     Environment.GetCommandLineArgs().Skip(1)
                 )
             );
+        }
+
+        public static void SetArgv(params string[] argv)
+        {
+            SetArgv(argv as IEnumerable<string>);
         }
 
         public static void SetArgv(IEnumerable<string> argv)

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -500,7 +500,7 @@ namespace Python.Runtime
         public static KeywordArguments kw(params object[] kv)
         {
             var dict = new KeywordArguments();
-            if (kv.Length%2 != 0)
+            if (kv.Length % 2 != 0)
                 throw new ArgumentException("Must have an equal number of keys and values");
             for (int i = 0; i < kv.Length; i += 2)
             {
@@ -520,6 +520,34 @@ namespace Python.Runtime
         public static PyObject Import(string name)
         {
             return PythonEngine.ImportModule(name);
+        }
+
+        public static void SetArgv()
+        {
+            IEnumerable<string> args;
+            try
+            {
+                args = Environment.GetCommandLineArgs();
+            }
+            catch (NotSupportedException)
+            {
+                args = Enumerable.Empty<string>();
+            }
+
+            SetArgv(
+                new[] { "" }.Concat(
+                    Environment.GetCommandLineArgs().Skip(1)
+                )
+            );
+        }
+
+        public static void SetArgv(IEnumerable<string> argv)
+        {
+            using (GIL())
+            {
+                var arr = argv.ToArray();
+                Runtime.PySys_SetArgvEx(arr.Length, arr, 0);
+            }
         }
     }
 }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -549,5 +549,13 @@ namespace Python.Runtime
                 Runtime.PySys_SetArgvEx(arr.Length, arr, 0);
             }
         }
+
+        internal static void Throw()
+        {
+            if (Runtime.PyErr_Occurred() != 0)
+            {
+                throw new PythonException();
+            }
+        }
     }
 }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -2027,11 +2027,26 @@ namespace Python.Runtime
         internal unsafe static extern IntPtr
             PyImport_GetModuleDict();
 
-
+#if PYTHON3
         [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
             ExactSpelling = true, CharSet = CharSet.Ansi)]
         internal unsafe static extern void
-            PySys_SetArgv(int argc, IntPtr argv);
+            PySys_SetArgvEx(
+                int argc,
+                [MarshalAsAttribute(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)]
+                string[] argv,
+                int updatepath
+                );
+#elif PYTHON2
+        [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
+            ExactSpelling = true, CharSet = CharSet.Ansi)]
+        internal unsafe static extern void
+            PySys_SetArgvEx(
+                int argc,
+                string[] argv,
+                int updatepath
+                );
+#endif
 
         [DllImport(Runtime.dll, CallingConvention = CallingConvention.Cdecl,
             ExactSpelling = true, CharSet = CharSet.Ansi)]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Implements an overload of `Initialize` and a `Py.SetArgv` function that allow the user to issue a `PySys_SetArgvEx` call. By default, this call is done on `Initialize` with a list that contains a single empty string (`['']`), using the arguments supplied to the .NET process if available.

### Does this close any currently open issues?

#299.

### Any other comments?

Based on the `fix-shutdown` branch as otherwise I'm not able to run the unit-tests reliably..