### PR TITLE
Enable Embedded Unit Tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     PYTHONUNBUFFERED: True
     PYTHONWARNINGS: 'ignore:::wheel.pep425tags:'
     PYTHONPATH: C:\testdir
+    NUNIT: nunit-console
     CONDA_BLD: C:\conda
     CONDA_BLD_VERSION: 3.5
 
@@ -34,6 +35,7 @@ init:
   - set CONDA_BLD_ARCH=%PLATFORM:x=%
   - set PYTHON=C:\PYTHON%PYTHON_VERSION:.=%
   - if %PLATFORM%==x86 (set CONDA_BLD_ARCH=32)
+  - if %PLATFORM%==x86 (set NUNIT=%NUNIT%-x86)
   - if %PLATFORM%==x64 (set PYTHON=%PYTHON%-x64)
 
   # Prepend newly installed Python to the PATH of this build

--- a/ci/appveyor_run_tests.ps1
+++ b/ci/appveyor_run_tests.ps1
@@ -3,7 +3,7 @@
 # Executable paths for OpenCover
 # Note if OpenCover fails, it won't affect the exit codes.
 $OPENCOVER = Resolve-Path .\packages\OpenCover.*\tools\OpenCover.Console.exe
-$NUNIT = Resolve-Path .\packages\NUnit.ConsoleRunner*\tools\nunit3-console.exe
+$NUNIT = Resolve-Path .\packages\NUnit.Runners*\tools\"$env:NUNIT".exe
 $PY = Get-Command python
 
 # Can't use ".\build\*\Python.EmbeddingTest.dll". Missing framework files.
@@ -19,11 +19,11 @@ if ($PYTHON_STATUS -ne 0) {
 }
 
 # Run Embedded tests with C# coverage
-# .$OPENCOVER -register:user -searchdirs:"$RUNTIME_DIR" -output:cs.coverage -target:"$NUNIT" -targetargs:"$CS_TESTS" -returntargetcode
-# $NUNIT_STATUS = $LastExitCode
-# if ($NUNIT_STATUS -ne 0) {
-#     Write-Host "Embedded tests failed" -ForegroundColor "Red"
-# }
+.$OPENCOVER -register:user -searchdirs:"$RUNTIME_DIR" -output:cs.coverage -target:"$NUNIT" -targetargs:"$CS_TESTS" -returntargetcode
+$NUNIT_STATUS = $LastExitCode
+if ($NUNIT_STATUS -ne 0) {
+    Write-Host "Embedded tests failed" -ForegroundColor "Red"
+}
 
 # Embedded tests failing due to open issues, pass/fail only on Python exit code
 # if ($PYTHON_STATUS -ne 0 -or $NUNIT_STATUS -ne 0) {

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -150,9 +150,8 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.5.0\lib\net40\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/src/embed_tests/packages.config
+++ b/src/embed_tests/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.5.0" targetFramework="net40" />
-  <package id="NUnit.ConsoleRunner" version="3.5.0" targetFramework="net40" />
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="NUnit.Runners" version="2.6.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Enables embedded unit tests on AppVeyor

### Does this close any currently open issues?

Shows failing tests on python3 during finalization but can't reproduce locally. It isn't consistent on AppVeyor either.

### Any other comments?

Downgrades nunit to 2.6.4. It can deal better with exceptions that occur during finalize, unit3 just freezes and holds the ci worker until AppVeyor times it out.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
