### PR TITLE
[POC] Replace build directives with runtime checks

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -613,17 +613,20 @@ namespace Python.Runtime
                         if (Runtime.PyUnicode_GetSize(value) == 1)
                         {
                             op = Runtime.PyUnicode_AS_UNICODE(value);
-#if UCS2
-                            // 2011-01-02: Marshal as character array because the cast
-                            // result = (char)Marshal.ReadInt16(op); throws an OverflowException
-                            // on negative numbers with Check Overflow option set on the project
-                            Char[] buff = new Char[1];
-                            Marshal.Copy(op, buff, 0, 1);
-                            result = buff[0];
-#elif UCS4
-                            // XXX this is probably NOT correct?
-                            result = (char)Marshal.ReadInt32(op);
-#endif
+                            if (Runtime.UCS == 2) // Don't trust linter, statement not always true.
+                            {
+                                // 2011-01-02: Marshal as character array because the cast
+                                // result = (char)Marshal.ReadInt16(op); throws an OverflowException
+                                // on negative numbers with Check Overflow option set on the project
+                                Char[] buff = new Char[1];
+                                Marshal.Copy(op, buff, 0, 1);
+                                result = buff[0];
+                            }
+                            else // UCS4
+                            {
+                                // XXX this is probably NOT correct?
+                                result = (char)Marshal.ReadInt32(op);
+                            }
                             return true;
                         }
                         goto type_error;

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -82,14 +82,14 @@ namespace Python.Runtime
             {
                 return Runtime.PyUnicodeType;
             }
-#if PYTHON3
-            else if ((op == int16Type) ||
-                     (op == int32Type) ||
-                     (op == int64Type))
+
+            else if (Runtime.IsPython3 && ((op == int16Type) ||
+                                           (op == int32Type) ||
+                                           (op == int64Type)))
             {
                 return Runtime.PyIntType;
             }
-#endif
+
             else if ((op == int16Type) ||
                      (op == int32Type))
             {
@@ -435,9 +435,8 @@ namespace Python.Runtime
                     return true;
 
                 case TypeCode.Int32:
-#if PYTHON2 // Trickery to support 64-bit platforms.
-
-                    if (Runtime.Is32Bit)
+                    // Trickery to support 64-bit platforms.
+                    if (Runtime.IsPython2 && Runtime.Is32Bit)
                     {
                         op = Runtime.PyNumber_Int(value);
 
@@ -461,11 +460,8 @@ namespace Python.Runtime
                         result = ival;
                         return true;
                     }
-                    else
+                    else // Python3 always use PyLong API
                     {
-#elif PYTHON3 // When using Python3 always use the PyLong API
-                {
-#endif
                         op = Runtime.PyNumber_Long(value);
                         if (op == IntPtr.Zero)
                         {

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -437,7 +437,7 @@ namespace Python.Runtime
                 case TypeCode.Int32:
 #if PYTHON2 // Trickery to support 64-bit platforms.
 
-                    if (Runtime.is32bit)
+                    if (Runtime.Is32Bit)
                     {
                         op = Runtime.PyNumber_Int(value);
 

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -81,17 +81,14 @@ namespace Python.Runtime
         /// </summary>
         internal static void Initialize()
         {
-#if PYTHON3
-            exceptions_module = Runtime.PyImport_ImportModule("builtins");
-#elif PYTHON2
-            exceptions_module = Runtime.PyImport_ImportModule("exceptions");
-#endif
+            string exceptionsModuleName = Runtime.IsPython3 ? "builtins" : "exceptions";
+            exceptions_module = Runtime.PyImport_ImportModule(exceptionsModuleName);
+
             Exceptions.ErrorCheck(exceptions_module);
             warnings_module = Runtime.PyImport_ImportModule("warnings");
             Exceptions.ErrorCheck(warnings_module);
             Type type = typeof(Exceptions);
-            foreach (FieldInfo fi in type.GetFields(BindingFlags.Public |
-                                                    BindingFlags.Static))
+            foreach (FieldInfo fi in type.GetFields(BindingFlags.Public | BindingFlags.Static))
             {
                 IntPtr op = Runtime.PyObject_GetAttrString(exceptions_module, fi.Name);
                 if (op != IntPtr.Zero)
@@ -116,8 +113,7 @@ namespace Python.Runtime
             if (Runtime.Py_IsInitialized() != 0)
             {
                 Type type = typeof(Exceptions);
-                foreach (FieldInfo fi in type.GetFields(BindingFlags.Public |
-                                                        BindingFlags.Static))
+                foreach (FieldInfo fi in type.GetFields(BindingFlags.Public | BindingFlags.Static))
                 {
                     var op = (IntPtr)fi.GetValue(type);
                     if (op != IntPtr.Zero)

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -171,6 +171,8 @@ namespace Python.Runtime
         internal static bool IsFinalizing = false;
 
         internal static bool Is32Bit;
+        internal static bool IsPython2;
+        internal static bool IsPython3;
 
         /// <summary>
         /// Initialize the runtime...
@@ -178,6 +180,8 @@ namespace Python.Runtime
         internal static void Initialize()
         {
             Is32Bit = IntPtr.Size == 4;
+            IsPython2 = pyversionnumber < 30;
+            IsPython3 = pyversionnumber >= 30;
 
             if (Runtime.Py_IsInitialized() == 0)
             {
@@ -189,13 +193,19 @@ namespace Python.Runtime
                 Runtime.PyEval_InitThreads();
             }
 
-#if PYTHON3
-            IntPtr op = Runtime.PyImport_ImportModule("builtins");
-            IntPtr dict = Runtime.PyObject_GetAttrString(op, "__dict__");
-#elif PYTHON2
-            IntPtr dict = Runtime.PyImport_GetModuleDict();
-            IntPtr op = Runtime.PyDict_GetItemString(dict, "__builtin__");
-#endif
+            IntPtr op;
+            IntPtr dict;
+            if (IsPython3)
+            {
+                op = Runtime.PyImport_ImportModule("builtins");
+                dict = Runtime.PyObject_GetAttrString(op, "__dict__");
+
+            }
+            else // Python2
+            {
+                dict = Runtime.PyImport_GetModuleDict();
+                op = Runtime.PyDict_GetItemString(dict, "__builtin__");
+            }
             PyNotImplemented = Runtime.PyObject_GetAttrString(op, "NotImplemented");
             PyBaseObjectType = Runtime.PyObject_GetAttrString(op, "object");
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -170,14 +170,14 @@ namespace Python.Runtime
         internal static Object IsFinalizingLock = new Object();
         internal static bool IsFinalizing = false;
 
-        internal static bool is32bit;
+        internal static bool Is32Bit;
 
         /// <summary>
         /// Initialize the runtime...
         /// </summary>
         internal static void Initialize()
         {
-            is32bit = IntPtr.Size == 4;
+            Is32Bit = IntPtr.Size == 4;
 
             if (Runtime.Py_IsInitialized() == 0)
             {
@@ -501,7 +501,7 @@ namespace Python.Runtime
             void* p = (void*)op;
             if ((void*)0 != p)
             {
-                if (is32bit)
+                if (Is32Bit)
                 {
                     (*(int*)p)++;
                 }
@@ -524,7 +524,7 @@ namespace Python.Runtime
             void* p = (void*)op;
             if ((void*)0 != p)
             {
-                if (is32bit)
+                if (Is32Bit)
                 {
                     --(*(int*)p);
                 }
@@ -535,11 +535,11 @@ namespace Python.Runtime
                 if ((*(int*)p) == 0)
                 {
                     // PyObject_HEAD: struct _typeobject *ob_type
-                    void* t = is32bit
+                    void* t = Is32Bit
                         ? (void*)(*((uint*)p + 1))
                         : (void*)(*((ulong*)p + 1));
                     // PyTypeObject: destructor tp_dealloc
-                    void* f = is32bit
+                    void* f = Is32Bit
                         ? (void*)(*((uint*)t + 6))
                         : (void*)(*((ulong*)t + 6));
                     if ((void*)0 == f)
@@ -558,7 +558,7 @@ namespace Python.Runtime
             void* p = (void*)op;
             if ((void*)0 != p)
             {
-                if (is32bit)
+                if (Is32Bit)
                 {
                     return (*(int*)p);
                 }
@@ -887,7 +887,7 @@ namespace Python.Runtime
 #else
             int n = 1;
 #endif
-            if (is32bit)
+            if (Is32Bit)
             {
                 return new IntPtr((void*)(*((uint*)p + n)));
             }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Proof of concept to separate build directives from runtime to make it Python version agnostic.
Replaces some build directives with runtime `if` statements. 

Ideally continuing down this path would allow us to move the build directives to a few files and allow pythonnet to be mostly python version agnostic. 

### Does this close any currently open issues?

Maybe lays the ground for #165.

### Any other comments?

Based on some of the work from @dmitriyse.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
