### PR TITLE
Simplify Embedded tests & Add new tests

### DIFF
--- a/ci/appveyor_run_tests.ps1
+++ b/ci/appveyor_run_tests.ps1
@@ -12,6 +12,7 @@ $RUNTIME_DIR = ".\src\runtime\bin\"
 
 # Run python tests with C# coverage
 # why `2>&1 | %{ "$_" }`? see: http://stackoverflow.com/a/20950421/5208670
+Write-Host ("Starting Python tests") -ForegroundColor "Green"
 .$OPENCOVER -register:user -searchdirs:"$RUNTIME_DIR" -output:py.coverage -target:"$PY" -targetargs:src\tests\runtests.py -returntargetcode 2>&1 | %{ "$_" }
 $PYTHON_STATUS = $LastExitCode
 if ($PYTHON_STATUS -ne 0) {
@@ -19,13 +20,14 @@ if ($PYTHON_STATUS -ne 0) {
 }
 
 # Run Embedded tests with C# coverage
+Write-Host ("Starting embedded tests") -ForegroundColor "Green"
 .$OPENCOVER -register:user -searchdirs:"$RUNTIME_DIR" -output:cs.coverage -target:"$NUNIT" -targetargs:"$CS_TESTS" -returntargetcode
 $NUNIT_STATUS = $LastExitCode
 if ($NUNIT_STATUS -ne 0) {
     Write-Host "Embedded tests failed" -ForegroundColor "Red"
 }
 
-# Embedded tests failing due to open issues, pass/fail only on Python exit code
+# Set exit code to fail if either Python or Embedded tests failed
 if ($PYTHON_STATUS -ne 0 -or $NUNIT_STATUS -ne 0) {
     Write-Host "Tests failed" -ForegroundColor "Red"
     $host.SetShouldExit(1)

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -81,6 +81,7 @@
     <Compile Include="pylong.cs" />
     <Compile Include="pyobject.cs" />
     <Compile Include="pythonexception.cs" />
+    <Compile Include="pytuple.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\runtime\Python.Runtime.csproj">

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -75,7 +75,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="InitializeTest.cs" />
+    <Compile Include="pyinitialize.cs" />
     <Compile Include="pyimport.cs" />
     <Compile Include="pyiter.cs" />
     <Compile Include="pylong.cs" />

--- a/src/embed_tests/pyimport.cs
+++ b/src/embed_tests/pyimport.cs
@@ -5,6 +5,18 @@ using Python.Runtime;
 
 namespace Python.EmbeddingTest
 {
+    /// <summary>
+    /// Test Import unittests and regressions
+    /// </summary>
+    /// <remarks>
+    /// Keeping in old-style SetUp/TearDown due to required SetUp.
+    /// The required directory structure was added to .\pythonnet\src\tests\ directory:
+    /// + PyImportTest/
+    /// | - __init__.py
+    /// | + test/
+    /// | | - __init__.py
+    /// | | - one.py
+    /// </remarks>
     [TestFixture]
     public class PyImportTest
     {
@@ -18,10 +30,8 @@ namespace Python.EmbeddingTest
 
             /* Append the tests directory to sys.path
              * using reflection to circumvent the private
-             * modifiers placed on most Runtime methods.
-             */
-            const string s = @"../../tests";
-
+             * modifiers placed on most Runtime methods. */
+            const string s = "../../tests";
             string testPath = Path.Combine(TestContext.CurrentContext.TestDirectory, s);
 
             IntPtr str = Runtime.Runtime.PyString_FromString(testPath);
@@ -39,19 +49,11 @@ namespace Python.EmbeddingTest
         /// <summary>
         /// Test subdirectory import
         /// </summary>
-        /// <remarks>
-        /// The required directory structure was added to .\pythonnet\src\tests\ directory:
-        /// + PyImportTest/
-        /// | - __init__.py
-        /// | + test/
-        /// | | - __init__.py
-        /// | | - one.py
-        /// </remarks>
         [Test]
         public void TestDottedName()
         {
             PyObject module = PythonEngine.ImportModule("PyImportTest.test.one");
-            Assert.IsNotNull(module, ">>>  import PyImportTest.test.one  # FAILED");
+            Assert.IsNotNull(module);
         }
 
         /// <summary>
@@ -61,7 +63,7 @@ namespace Python.EmbeddingTest
         public void TestSysArgsImportException()
         {
             PyObject module = PythonEngine.ImportModule("PyImportTest.sysargv");
-            Assert.IsNotNull(module, ">>>  import PyImportTest.sysargv  # FAILED");
+            Assert.IsNotNull(module);
         }
     }
 }

--- a/src/embed_tests/pyinitialize.cs
+++ b/src/embed_tests/pyinitialize.cs
@@ -1,13 +1,9 @@
 using NUnit.Framework;
 using Python.Runtime;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Python.EmbeddingTest
 {
-    public class InitializeTest
+    public class PyInitializeTest
     {
         [Test]
         public static void LoadSpecificArgs()

--- a/src/embed_tests/pyiter.cs
+++ b/src/embed_tests/pyiter.cs
@@ -1,45 +1,30 @@
-using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Python.Runtime;
 
 namespace Python.EmbeddingTest
 {
-    [TestFixture]
     public class PyIterTest
     {
-        private IntPtr gs;
-
-        [SetUp]
-        public void SetUp()
-        {
-            PythonEngine.Initialize();
-            gs = PythonEngine.AcquireLock();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            PythonEngine.ReleaseLock(gs);
-            PythonEngine.Shutdown();
-        }
-
         [Test]
         public void TestOnPyList()
         {
-            var list = new PyList();
-            list.Append(new PyString("foo"));
-            list.Append(new PyString("bar"));
-            list.Append(new PyString("baz"));
-            var result = new List<string>();
-            foreach (PyObject item in list)
+            using (Py.GIL())
             {
-                result.Add(item.ToString());
+                var list = new PyList();
+                list.Append(new PyString("foo"));
+                list.Append(new PyString("bar"));
+                list.Append(new PyString("baz"));
+                var result = new List<string>();
+                foreach (PyObject item in list)
+                {
+                    result.Add(item.ToString());
+                }
+                Assert.AreEqual(3, result.Count);
+                Assert.AreEqual("foo", result[0]);
+                Assert.AreEqual("bar", result[1]);
+                Assert.AreEqual("baz", result[2]);
             }
-            Assert.AreEqual(3, result.Count);
-            Assert.AreEqual("foo", result[0]);
-            Assert.AreEqual("bar", result[1]);
-            Assert.AreEqual("baz", result[2]);
         }
     }
 }

--- a/src/embed_tests/pylong.cs
+++ b/src/embed_tests/pylong.cs
@@ -1,34 +1,19 @@
-using System;
 using NUnit.Framework;
 using Python.Runtime;
 
 namespace Python.EmbeddingTest
 {
-    [TestFixture]
     public class PyLongTest
     {
-        private IntPtr gs;
-
-        [SetUp]
-        public void SetUp()
-        {
-            PythonEngine.Initialize();
-            gs = PythonEngine.AcquireLock();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            PythonEngine.ReleaseLock(gs);
-            PythonEngine.Shutdown();
-        }
-
         [Test]
         public void TestToInt64()
         {
-            long largeNumber = 8L * 1024L * 1024L * 1024L; // 8 GB
-            var pyLargeNumber = new PyLong(largeNumber);
-            Assert.AreEqual(largeNumber, pyLargeNumber.ToInt64());
+            using (Py.GIL())
+            {
+                long largeNumber = 8L * 1024L * 1024L * 1024L; // 8 GB
+                var pyLargeNumber = new PyLong(largeNumber);
+                Assert.AreEqual(largeNumber, pyLargeNumber.ToInt64());
+            }
         }
     }
 }

--- a/src/embed_tests/pyobject.cs
+++ b/src/embed_tests/pyobject.cs
@@ -1,33 +1,18 @@
-using System;
 using NUnit.Framework;
 using Python.Runtime;
 
 namespace Python.EmbeddingTest
 {
-    [TestFixture]
     public class PyObjectTest
     {
-        private IntPtr gs;
-
-        [SetUp]
-        public void SetUp()
-        {
-            PythonEngine.Initialize();
-            gs = PythonEngine.AcquireLock();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            PythonEngine.ReleaseLock(gs);
-            PythonEngine.Shutdown();
-        }
-
         [Test]
         public void TestUnicode()
         {
-            PyObject s = new PyString("foo\u00e9");
-            Assert.AreEqual("foo\u00e9", s.ToString());
+            using (Py.GIL())
+            {
+                PyObject s = new PyString("foo\u00e9");
+                Assert.AreEqual("foo\u00e9", s.ToString());
+            }
         }
     }
 }

--- a/src/embed_tests/pythonexception.cs
+++ b/src/embed_tests/pythonexception.cs
@@ -4,6 +4,13 @@ using Python.Runtime;
 
 namespace Python.EmbeddingTest
 {
+    /// <summary>
+    /// Test Python Exceptions
+    /// </summary>
+    /// <remarks>
+    /// Keeping this in the old-style SetUp/TearDown
+    /// to ensure that setup still works.
+    /// </remarks>
     [TestFixture]
     public class PythonExceptionTest
     {

--- a/src/embed_tests/pytuple.cs
+++ b/src/embed_tests/pytuple.cs
@@ -1,0 +1,94 @@
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class PyTupleTest
+    {
+        [Test]
+        public void TestPyTupleEmpty()
+        {
+            using (Py.GIL())
+            {
+                var t = new PyTuple();
+                Assert.AreEqual(0, t.Length());
+            }
+        }
+
+        [Test]
+        [ExpectedException("Python.Runtime.PythonException")]
+        public void TestPyTupleInvalidAppend()
+        {
+            using (Py.GIL())
+            {
+                PyObject s = new PyString("foo");
+                var t = new PyTuple();
+                t.Concat(s);
+            }
+        }
+
+        [Test]
+        public void TestPyTupleValidAppend()
+        {
+            using (Py.GIL())
+            {
+                var t0 = new PyTuple();
+                var t = new PyTuple();
+                t.Concat(t0);
+                Assert.IsNotNull(t);
+                Assert.IsInstanceOf(typeof(PyTuple), t);
+            }
+        }
+
+        [Test]
+        public void TestPyTupleIsTupleType()
+        {
+            using (Py.GIL())
+            {
+                var s = new PyString("foo");
+                var t = new PyTuple();
+                Assert.IsTrue(PyTuple.IsTupleType(t));
+                Assert.IsFalse(PyTuple.IsTupleType(s));
+            }
+        }
+
+        [Test]
+        public void TestPyTupleStringConvert()
+        {
+            using (Py.GIL())
+            {
+                PyObject s = new PyString("foo");
+                PyTuple t = PyTuple.AsTuple(s);
+                Assert.IsNotNull(t);
+                Assert.IsInstanceOf(typeof(PyTuple), t);
+                Assert.AreEqual("f", t[0].ToString());
+                Assert.AreEqual("o", t[1].ToString());
+                Assert.AreEqual("o", t[2].ToString());
+            }
+        }
+
+        [Test]
+        public void TestPyTupleValidConvert()
+        {
+            using (Py.GIL())
+            {
+                var l = new PyList();
+                PyTuple t = PyTuple.AsTuple(l);
+                Assert.IsNotNull(t);
+                Assert.IsInstanceOf(typeof(PyTuple), t);
+            }
+        }
+
+        [Test]
+        public void TestNewPyTupleFromPyTuple()
+        {
+            using (Py.GIL())
+            {
+                var t0 = new PyTuple();
+                var t = new PyTuple(t0);
+                Assert.IsNotNull(t);
+                Assert.IsInstanceOf(typeof(PyTuple), t);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- Simplifies multiple tests to use a simpler setup.
- Adds tests to `PyTuple` based on where coverage wasn't being exercised.
- Renames `InitializeTest` to `pyinitialize` since thats the naming style all other tests use.

### Does this close any currently open issues?

`n/a`

### Any other comments?

Increases coverage

