### PR TITLE
Upgrade NUnit to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 script:
   - export PYTHONPATH=`pwd`:$PYTHONPATH
   - python -m pytest
-  # - mono ./packages/NUnit.*/tools/nunit-console.exe src/embed_tests/bin/Python.EmbeddingTest.dll
+  # - mono ./packages/NUnit.*/tools/nunit3-console.exe src/embed_tests/bin/Python.EmbeddingTest.dll
 
 after_success:
   # Uncomment if need to geninterop, ie. py37 final

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     PYTHONUNBUFFERED: True
     PYTHONWARNINGS: 'ignore:::wheel.pep425tags:'
     PYTHONPATH: C:\testdir
-    NUNIT: nunit-console
+    NUNIT: nunit3-console
     CONDA_BLD: C:\conda
     CONDA_BLD_VERSION: 3.5
 
@@ -35,7 +35,7 @@ init:
   - set CONDA_BLD_ARCH=%PLATFORM:x=%
   - set PYTHON=C:\PYTHON%PYTHON_VERSION:.=%
   - if %PLATFORM%==x86 (set CONDA_BLD_ARCH=32)
-  - if %PLATFORM%==x86 (set NUNIT=%NUNIT%-x86)
+  # - if %PLATFORM%==x86 (set NUNIT=%NUNIT%-x86)
   - if %PLATFORM%==x64 (set PYTHON=%PYTHON%-x64)
 
   # Prepend newly installed Python to the PATH of this build

--- a/ci/appveyor_run_tests.ps1
+++ b/ci/appveyor_run_tests.ps1
@@ -28,6 +28,7 @@ if ($PYTHON_STATUS -ne 0) {
 Write-Host ("Starting embedded tests") -ForegroundColor "Green"
 .$OPENCOVER -register:user -searchdirs:"$RUNTIME_DIR" -output:cs.coverage `
             -target:"$NUNIT" -targetargs:"$CS_TESTS" `
+            -filter:"+[*]Python.Runtime*" `
             -returntargetcode
 $NUNIT_STATUS = $LastExitCode
 if ($NUNIT_STATUS -ne 0) {

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -65,8 +65,8 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/embed_tests/packages.config
+++ b/src/embed_tests/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
-  <package id="NUnit.Runners" version="2.6.4" targetFramework="net40" />
+  <package id="NUnit" version="3.6.0" targetFramework="net40" />
+  <package id="NUnit.ConsoleRunner" version="3.6.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Since the embedded unit tests have been patched we can re-upgrade to `NUnit3` from @filmor .

### Does this close any currently open issues?

`N/A`

### Any other comments?

On `v.2.x` of NUnit I'm noticing that the tests finish and hang for ~40 seconds before releasing control. on `v3.x` it gives some warnings but I'm not sure if thats related. 

Personally I'm indifferent to prefer `v2.x` since it released control and occasionally print the traceback that was key to figuring the old problem out. But since that looks to be solved, I don't have a strong argument.
