### PR TITLE
Passing an arbitrary .NET object as the value of an attribute of PyObject

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,6 +29,7 @@
 -   Sean Freitag ([@cowboygneox](https://github.com/cowboygneox))
 -   Serge Weinstock ([@sweinst](https://github.com/sweinst))
 -   Virgil Dupras ([@hsoft](https://github.com/hsoft))
+-   Wenguang Yang ([@yagweb](https://github.com/yagweb))
 -   Xavier Dupré ([@sdpython](https://github.com/sdpython))
 -   Zane Purvis ([@zanedp](https://github.com/zanedp))
 -   ([@ArvidJB](https://github.com/ArvidJB))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added Embedded tests on Appveyor (#353)
 -   Added PY3 settings to configuration-manager (#346)
 -   Added `Slack` chat (#384)(#383)(#386)
+-   Added function of passing an arbitrary .NET object as the value
+    of an attribute of PyObject (#370)(#373)
 
 ### Changed
 

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -65,6 +65,7 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.6.0\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
@@ -76,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="pyinitialize.cs" />
+    <Compile Include="dynamic.cs" />
     <Compile Include="pyimport.cs" />
     <Compile Include="pyiter.cs" />
     <Compile Include="pylong.cs" />

--- a/src/embed_tests/dynamic.cs
+++ b/src/embed_tests/dynamic.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Text;
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    [TestFixture]
+    public class dynamicTest
+    {
+        private Py.GILState gil;
+
+        [SetUp]
+        public void SetUp()
+        {
+            gil = Py.GIL();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            gil.Dispose();
+        }
+
+        /// <summary>
+        /// Set the attribute of a pyobject with a .NET object.
+        /// </summary>
+        [Test]
+        public void AssignObject()
+        {
+            StringBuilder stream = new StringBuilder();
+            dynamic sys = Py.Import("sys");
+            sys.testattr = stream;
+            // Check whether there are the same object.
+            var _stream = sys.testattr.AsManagedObject(typeof(StringBuilder));
+            Assert.AreEqual(_stream, stream);
+
+            PythonEngine.RunSimpleString(
+                "import sys\n" +
+                "sys.testattr.Append('Hello!')\n");
+            Assert.AreEqual(stream.ToString(), "Hello!");
+        }
+
+        /// <summary>
+        /// Set the attribute of a pyobject to null.
+        /// </summary>
+        [Test]
+        public void AssignNone()
+        {
+            dynamic sys = Py.Import("sys");
+            sys.testattr = new StringBuilder();
+            Assert.IsNotNull(sys.testattr);
+
+            sys.testattr = null;
+            Assert.IsNull(sys.testattr);
+        }
+
+        /// <summary>
+        /// Check whether we can get the attr of a python object when the
+        /// value of attr is a PyObject.
+        /// </summary>
+        [Test]
+        public void AssignPyObject()
+        {
+            dynamic sys = Py.Import("sys");
+            dynamic io = Py.Import("io");
+            sys.testattr = io.StringIO();
+            dynamic bb = sys.testattr; //Get the PyObject
+            bb.write("Hello!");
+            Assert.AreEqual(bb.getvalue().ToString(), "Hello!");
+        }
+
+        /// <summary>
+        /// Pass the .NET object in Python side.
+        /// </summary>
+        [Test]
+        public void PassObjectInPython()
+        {
+            StringBuilder stream = new StringBuilder();
+            dynamic sys = Py.Import("sys");
+            sys.testattr1 = stream;
+
+            //Pass the .NET object in Python side
+            PythonEngine.RunSimpleString(
+                "import sys\n" +
+                "sys.testattr2 = sys.testattr1\n"
+            );
+
+            //Compare in Python
+            PythonEngine.RunSimpleString(
+                "import sys\n" +
+                "sys.testattr3 = sys.testattr1 is sys.testattr2\n"
+            );
+            Assert.AreEqual(sys.testattr3.ToString(), "True");
+
+            //Compare in .NET
+            Assert.AreEqual(sys.testattr1, sys.testattr2);
+        }
+
+        /// <summary>
+        /// Pass the PyObject in .NET side
+        /// </summary>
+        [Test]
+        public void PassPyObjectInNet()
+        {
+            StringBuilder stream = new StringBuilder();
+            dynamic sys = Py.Import("sys");
+            sys.testattr1 = stream;
+            sys.testattr2 = sys.testattr1;
+
+            //Compare in Python
+            PyObject res = PythonEngine.RunString(
+                "import sys\n" +
+                "sys.testattr3 = sys.testattr1 is sys.testattr2\n"
+            );
+            Assert.AreEqual(sys.testattr3.ToString(), "True");
+
+            //Compare in .NET
+            Assert.AreEqual(sys.testattr1, sys.testattr2);
+        }
+    }
+}


### PR DESCRIPTION
This implement the function of passing an arbitrary .NET object as attribute of PyObject by dynamic type. 

Four modifications are located at file pyobject.cs, the methods for dynamic type TryGetMember and TrySetMember were modified, a new method GetAttrDynamic was added for TryGetMember, and a new method SetAttrDynamic was added for TrySetMember.

Unit tests were given in a new file "src/embed_tests/dynamic.cs".

An Example was given in the discussion of issue [#370](https://github.com/pythonnet/pythonnet/issues/370) , the Solution 4.

/***********Information below is outdated and can be removed*************/

However this doesn't fix the issue [why sys.stdout returned null #370](https://github.com/pythonnet/pythonnet/issues/370)
...
...

I don't know where to put the test, so I put it here. If needed, it can be added to Embedded tests with some work.

```
    class dynamicTest
    {
        public void Test()
        {
            var output = new Output();
            using (Py.GIL())
            {
                dynamic sys = Py.Import("sys");
                sys.stdout = output; //Now it's working

                //function test, print in python
                PythonEngine.RunSimpleString("print('Hello!')");

                //Check whether there are the same object
                var result1 = sys.stdout == output;
                Console.WriteLine($"Compare in .NET: {result1}");  //Output True   

                //Check whether we can get the attr of a python object 
                //when the value of attr is not a .NET object
                PythonEngine.RunSimpleString("import sys\n" +
                "from io import StringIO\n" +
                "sys.stderr = StringIO()\n");
                var bb = sys.stderr;
                bb.write("Hello!\n");
                Console.Write(bb.getvalue());

                /********Pass the .NET object in Python side*********/
                PythonEngine.RunSimpleString("import sys\n" +
                "from io import StringIO\n" +
                "sys.stderr = sys.stdout\n");
                //Compare in Python
                PythonEngine.RunSimpleString("import sys\n" +
                "print('Compare in Python: %s' % (sys.stderr is sys.stdout))\n");  //Output False

                //compare in .NET
                var result2 = sys.stdout == sys.stderr;
                Console.WriteLine($"Compare in .NET: {result2}");  //Output True

                /*********Pass the .NET object in .NET side********/
                sys.stdout = sys.stderr;
                //Compare in Python
                PythonEngine.RunSimpleString("import sys\n" +
                "print('Compare in Python: %s' % (sys.stderr is sys.stdout))\n");  //Output False

                //compare in .NET
                var result3 = sys.stdout == sys.stderr;
                Console.WriteLine($"Compare in .NET: {result3}");  //Output True    

                /*********When the .NET object was created in Python side*****************/
                PythonEngine.RunSimpleString(@"
import sys
from Test import Output
sys.stderr = Output()
");
                var aa = sys.stderr; //Return the .NET object, not a PyObject with an IntPtr
                aa.write("Hello!\n");            
            }
        }
    }
    public class Output
    {
        public void write(String str)
        {
            //str = str.Replace("\n", Environment.NewLine);
            Console.Write(str);
        }

        public void writelines(String[] str)
        {
            foreach (String line in str)
            {
                Console.Write(str);
            }
        }
        public void flush() { }
        public void close() { }
    }
```