### PR TITLE
Fix OverflowException on 64bit due to bad cast

### DIFF
--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -11,7 +11,7 @@ namespace Python.Runtime
         {
             IntPtr py = Runtime.PyType_GenericAlloc(tp, 0);
 
-            var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+            var flags = (long)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
             if ((flags & TypeFlags.Subclass) != 0)
             {
                 IntPtr dict = Marshal.ReadIntPtr(py, ObjectOffset.DictOffset(tp));

--- a/src/runtime/debughelper.cs
+++ b/src/runtime/debughelper.cs
@@ -89,7 +89,7 @@ namespace Python.Runtime
         internal static void DumpInst(IntPtr ob)
         {
             IntPtr tp = Runtime.PyObject_TYPE(ob);
-            var sz = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_basicsize);
+            var sz = (long)Marshal.ReadIntPtr(tp, TypeOffset.tp_basicsize);
 
             for (var i = 0; i < sz; i += IntPtr.Size)
             {

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -28,7 +28,7 @@ namespace Python.Runtime
                     tp = ob;
                 }
 
-                var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+                var flags = (long)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
                 if ((flags & TypeFlags.Managed) != 0)
                 {
                     IntPtr op = tp == ob
@@ -63,7 +63,7 @@ namespace Python.Runtime
                     tp = ob;
                 }
 
-                var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+                var flags = (long)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
                 if ((flags & TypeFlags.Managed) != 0)
                 {
                     return true;

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -247,7 +247,7 @@ namespace Python.Runtime
         {
             // Fix this when we dont cheat on the handle for subclasses!
 
-            var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+            var flags = (long)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
             if ((flags & TypeFlags.Subclass) == 0)
             {
                 IntPtr gc = Marshal.ReadIntPtr(tp, TypeOffset.magic());


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fix OverflowException on 64bit due to bad cast

Error message was `OverflowException occurred. Arithmetic operation resulted in an overflow.`
Link below explains in more detail the issue. This fixes the issue in both 32/64bit.

https://www.codeproject.com/Answers/899343/How-to-fix-OverflowException-occurred-Arithmetic-o#answer2

### Does this close any currently open issues?

Issue found while working on #373. 
