### PR TITLE
Method overload object type

### DIFF
--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -375,7 +375,7 @@ namespace Python.Runtime
                             if (clrtype != null)
                             {
                                 var typematch = false;
-                                if (pi[n].ParameterType != clrtype)
+                                if ((pi[n].ParameterType != typeof(object)) && (pi[n].ParameterType != clrtype))
                                 {
                                     IntPtr pytype = Converter.GetPythonTypeByAlias(pi[n].ParameterType);
                                     pyoptype = Runtime.PyObject_Type(op);

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -131,6 +131,56 @@ namespace Python.Test
             return "Got object";
         }
 
+        public static string TestOverloadedObjectTwo(int a, int b)
+        {
+            return "Got int-int";
+        }
+
+        public static string TestOverloadedObjectTwo(string a, string b)
+        {
+            return "Got string-string";
+        }
+
+        public static string TestOverloadedObjectTwo(string a, int b)
+        {
+            return "Got string-int";
+        }
+
+        public static string TestOverloadedObjectTwo(string a, object b)
+        {
+            return "Got string-object";
+        }
+
+        public static string TestOverloadedObjectTwo(int a, object b)
+        {
+            return "Got int-object";
+        }
+
+        public static string TestOverloadedObjectTwo(object a, int b)
+        {
+            return "Got object-int";
+        }
+
+        public static string TestOverloadedObjectTwo(object a, object b)
+        {
+            return "Got object-object";
+        }
+
+        public static string TestOverloadedObjectTwo(int a, string b)
+        {
+            return "Got int-string";
+        }
+
+        public static string TestOverloadedObjectThree(object a, int b)
+        {
+            return "Got object-int";
+        }
+
+        public static string TestOverloadedObjectThree(int a, object b)
+        {
+            return "Got int-object";
+        }
+
         public static bool TestStringOutParams(string s, out string s1)
         {
             s1 = "output string";

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -116,6 +116,21 @@ namespace Python.Test
             return args;
         }
 
+        public static string TestOverloadedNoObject(int i)
+        {
+            return "Got int";
+        }
+
+        public static string TestOverloadedObject(int i)
+        {
+            return "Got int";
+        }
+
+        public static string TestOverloadedObject(object o)
+        {
+            return "Got object";
+        }
+
         public static bool TestStringOutParams(string s, out string s1)
         {
             s1 = "output string";

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -790,3 +790,32 @@ def test_object_in_param():
 
     res = MethodTest.TestOverloadedObject("test")
     assert res == "Got object"
+
+
+def test_object_in_multiparam():
+    """Test method with object multiparams behaves"""
+
+    res = MethodTest.TestOverloadedObjectTwo(5, 5)
+    assert res == "Got int-int"
+
+    res = MethodTest.TestOverloadedObjectTwo(5, "foo")
+    assert res == "Got int-string"
+
+    res = MethodTest.TestOverloadedObjectTwo("foo", 7.24)
+    assert res == "Got string-object"
+
+    res = MethodTest.TestOverloadedObjectTwo("foo", "bar")
+    assert res == "Got string-string"
+
+    res = MethodTest.TestOverloadedObjectTwo("foo", 5)
+    assert res == "Got string-int"
+
+    res = MethodTest.TestOverloadedObjectTwo(7.24, 7.24)
+    assert res == "Got object-object"
+
+
+def test_object_in_multiparam_exception():
+    """Test method with object multiparams behaves"""
+
+    with pytest.raises(TypeError):
+        MethodTest.TestOverloadedObjectThree("foo", "bar")

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -769,3 +769,25 @@ def test_wrong_overload():
     res = System.Math.Max(System.Double(50.5), 50.1)
     assert res == 50.5
     assert type(res) == float
+
+
+def test_no_object_in_param():
+    """Test that fix for #203 doesn't break behavior w/ no object overload"""
+
+    res = MethodTest.TestOverloadedNoObject(5)
+    assert res == "Got int"
+
+    with pytest.raises(TypeError):
+        MethodTest.TestOverloadedNoObject("test")
+
+
+@pytest.mark.xfail(reason="Needs fixing. #203")
+def test_object_in_param():
+    """Test regression introduced by #151 in which Object method overloads
+    aren't being used. See #203 for issue."""
+
+    res = MethodTest.TestOverloadedObject(5)
+    assert res == "Got int"
+
+    res = MethodTest.TestOverloadedObject("test")
+    assert res == "Got object"

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -781,7 +781,6 @@ def test_no_object_in_param():
         MethodTest.TestOverloadedNoObject("test")
 
 
-@pytest.mark.xfail(reason="Needs fixing. #203")
 def test_object_in_param():
     """Test regression introduced by #151 in which Object method overloads
     aren't being used. See #203 for issue."""


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fixes Method object overloading without breaking changes introduced by #131 and #151.

I added the tests/examples from #131 to the [tests](https://github.com/pythonnet/pythonnet/blob/6afc9e684856fca988c6d5260ee2d6de3735b7cf/src/tests/test_method.py#L748-L771) to ensure that the behavior didn't get reverted.

### Does this close any currently open issues?

Closes #203 

### Any other comments?

This patch fixes the issue from #203, but `MethodBinder.Bind` needs rewriting since its basically been patched over and over again to fix edge cases. I didn't want to do it as part of this `pull_request` since it would affect more than just fixing #203.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
