### PR TITLE
Add PythonEngine Eval and Exec

### DIFF
--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -86,6 +86,7 @@
     <Compile Include="pyiter.cs" />
     <Compile Include="pylong.cs" />
     <Compile Include="pyobject.cs" />
+    <Compile Include="pyrunstring.cs" />
     <Compile Include="pythonexception.cs" />
     <Compile Include="pytuple.cs" />
   </ItemGroup>

--- a/src/embed_tests/pyrunstring.cs
+++ b/src/embed_tests/pyrunstring.cs
@@ -1,0 +1,61 @@
+using System;
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class RunStringTest
+    {
+        private Py.GILState gil;
+
+        [SetUp]
+        public void SetUp()
+        {
+            gil = Py.GIL();
+        }
+
+        [TearDown]
+        public void Dispose()
+        {
+            gil.Dispose();
+        }
+
+        [Test]
+        public void TestRunSimpleString()
+        {
+            int aa = PythonEngine.RunSimpleString("import sys");
+            Assert.AreEqual(aa, 0);
+
+            int bb = PythonEngine.RunSimpleString("import 1234");
+            Assert.AreEqual(bb, -1);
+        }
+
+        [Test]
+        public void TestEval()
+        {
+            dynamic sys = Py.Import("sys");
+            sys.attr1 = 100;
+            var locals = new PyDict();
+            locals.SetItem("sys", sys);
+            locals.SetItem("a", new PyInt(10));
+
+            object b = PythonEngine.Eval("sys.attr1 + a + 1", null, locals.Handle)
+                .AsManagedObject(typeof(Int32));
+            Assert.AreEqual(b, 111);
+        }
+
+        [Test]
+        public void TestExec()
+        {
+            dynamic sys = Py.Import("sys");
+            sys.attr1 = 100;
+            var locals = new PyDict();
+            locals.SetItem("sys", sys);
+            locals.SetItem("a", new PyInt(10));
+
+            PythonEngine.Exec("c = sys.attr1 + a + 1", null, locals.Handle);
+            object c = locals.GetItem("c").AsManagedObject(typeof(Int32));
+            Assert.AreEqual(c, 111);
+        }
+    }
+}

--- a/src/embed_tests/pyrunstring.cs
+++ b/src/embed_tests/pyrunstring.cs
@@ -24,10 +24,10 @@ namespace Python.EmbeddingTest
         public void TestRunSimpleString()
         {
             int aa = PythonEngine.RunSimpleString("import sys");
-            Assert.AreEqual(aa, 0);
+            Assert.AreEqual(0, aa);
 
             int bb = PythonEngine.RunSimpleString("import 1234");
-            Assert.AreEqual(bb, -1);
+            Assert.AreEqual(-1, bb);
         }
 
         [Test]
@@ -40,8 +40,8 @@ namespace Python.EmbeddingTest
             locals.SetItem("a", new PyInt(10));
 
             object b = PythonEngine.Eval("sys.attr1 + a + 1", null, locals.Handle)
-                .AsManagedObject(typeof(Int32));
-            Assert.AreEqual(b, 111);
+                .AsManagedObject(typeof(int));
+            Assert.AreEqual(111, b);
         }
 
         [Test]
@@ -54,8 +54,8 @@ namespace Python.EmbeddingTest
             locals.SetItem("a", new PyInt(10));
 
             PythonEngine.Exec("c = sys.attr1 + a + 1", null, locals.Handle);
-            object c = locals.GetItem("c").AsManagedObject(typeof(Int32));
-            Assert.AreEqual(c, 111);
+            object c = locals.GetItem("c").AsManagedObject(typeof(int));
+            Assert.AreEqual(111, c);
         }
     }
 }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -432,7 +432,7 @@ namespace Python.Runtime
         /// executing the code string as a PyObject instance, or null if
         /// an exception was raised.
         /// </remarks>
-        internal static PyObject RunString(
+        public static PyObject RunString(
             string code, IntPtr? globals = null, IntPtr? locals = null, RunFlagType _flag = RunFlagType.File
         )
         {

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -156,11 +156,7 @@ namespace Python.Runtime
                 string code =
                     "import atexit, clr\n" +
                     "atexit.register(clr._AtExit)\n";
-                PyObject r = PythonEngine.RunString(code);
-                if (r != null)
-                {
-                    r.Dispose();
-                }
+                PythonEngine.Exec(code);
 
                 // Load the clr.py resource into the clr module
                 IntPtr clr = Python.Runtime.ImportHook.GetCLRModule();
@@ -180,12 +176,7 @@ namespace Python.Runtime
                     {
                         // add the contents of clr.py to the module
                         string clr_py = reader.ReadToEnd();
-                        PyObject result = RunString(clr_py, module_globals, locals.Handle);
-                        if (null == result)
-                        {
-                            throw new PythonException();
-                        }
-                        result.Dispose();
+                        Exec(clr_py, module_globals, locals.Handle);
                     }
 
                     // add the imported module to the clr module, and copy the API functions
@@ -253,11 +244,7 @@ namespace Python.Runtime
                     "            exec(line)\n" +
                     "            break\n";
 
-                PyObject r = PythonEngine.RunString(code);
-                if (r != null)
-                {
-                    r.Dispose();
-                }
+                PythonEngine.Exec(code);
             }
             catch (PythonException e)
             {
@@ -406,6 +393,38 @@ namespace Python.Runtime
 
 
         /// <summary>
+        /// Eval Method
+        /// </summary>
+        /// <remarks>
+        /// Evaluate a Python expression and returns the result.
+        /// It's a subset of Python eval function.
+        /// </remarks>
+        public static PyObject Eval(string code, IntPtr? globals = null, IntPtr? locals = null)
+        {
+            PyObject result = RunString(code, globals, locals, RunFlagType.Eval);
+            return result;
+        }
+
+
+        /// <summary>
+        /// Exec Method
+        /// </summary>
+        /// <remarks>
+        /// Run a string containing Python code.
+        /// It's a subset of Python exec function.
+        /// </remarks>
+        public static void Exec(string code, IntPtr? globals = null, IntPtr? locals = null)
+        {
+            PyObject result = RunString(code, globals, locals, RunFlagType.File);
+            if (result.obj != Runtime.PyNone)
+            {
+                throw new PythonException();
+            }
+            result.Dispose();
+        }
+
+
+        /// <summary>
         /// RunString Method
         /// </summary>
         /// <remarks>
@@ -413,8 +432,8 @@ namespace Python.Runtime
         /// executing the code string as a PyObject instance, or null if
         /// an exception was raised.
         /// </remarks>
-        public static PyObject RunString(
-            string code, IntPtr? globals = null, IntPtr? locals = null
+        internal static PyObject RunString(
+            string code, IntPtr? globals = null, IntPtr? locals = null, RunFlagType _flag = RunFlagType.File
         )
         {
             var borrowedGlobals = true;
@@ -439,7 +458,7 @@ namespace Python.Runtime
                 borrowedLocals = false;
             }
 
-            var flag = (IntPtr)257; /* Py_file_input */
+            var flag = (IntPtr)_flag;
 
             try
             {
@@ -463,6 +482,13 @@ namespace Python.Runtime
                 }
             }
         }
+    }
+
+    public enum RunFlagType
+    {
+        Single = 256,
+        File = 257, /* Py_file_input */
+        Eval = 258
     }
 
     public static class Py


### PR DESCRIPTION
"eval" and "exec" are two of the most frequently used methods when interacting with Python. However, I found there is not "eval" provided currently, this statement var flag = (IntPtr)257; in PythonEngine.RunString method makes this method can only be used as "exec".

Two .NET functions equivalent to the Python “evel” and “exec” are implemented by wrapping the PyRun_String function just like the CPython does. PythonEngine.RunString method became internal.

All the modifications located in pythonengine.cs.  All the places using  PythonEngine.RunString are replaced with the new PythonEngine.Exec method.

Unit tests are given in the new file "src/embed_tests/pyrunstring.cs", They can also be used as examples. List one of them below.

Eval the python expression "sys.attr1 + a + 1" and obtain its value.
```
dynamic sys = Py.Import("sys");
sys.attr1 = 100;
PyDict locals = new PyDict();
locals.SetItem("sys", sys);
locals.SetItem("a", new PyInt(10));

var b = PythonEngine.Eval("sys.attr1 + a + 1", null, locals.Handle)
     .AsManagedObject(typeof(Int32));

Console.WriteLine("sys.attr1 + a + 1 = {0}", b);
```

CHANGELOG.md will be updated later.