### PR TITLE
Standardize Python.Test fixture location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,13 @@ addons:
       - ca-certificates-mono
 
 before_install:
-  # Set-up location where `Python.Test.dll` will be output
-  - export PYTHONPATH=`pwd`:$PYTHONPATH
-
   # Set-up dll path for embedded tests
   - PY_LIBDIR=$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')
   - export LD_LIBRARY_PATH=$PY_LIBDIR:$LD_LIBRARY_PATH
 
 install:
   - pip install --upgrade -r requirements.txt
-  # `setup.py install` works too, but need to deal with `Python.Test` PATH
-  - coverage run setup.py build_ext --inplace
+  - coverage run setup.py install
 
 script:
   - python -m pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,6 @@ environment:
     - PYTHON_VERSION: 3.6
 
 init:
-  # Prepare Environment
-  - mkdir C:\testdir
-
   # Update Environment Variables based on matrix/platform
   - set PY_VER=%PYTHON_VERSION:.=%
   - set PYTHON=C:\PYTHON%PY_VER%
@@ -44,8 +41,6 @@ build_script:
 
 test_script:
   - pip install --no-index --find-links=.\dist\ pythonnet
-  - ps: Copy-Item .\src\testing\bin\Python.Test.dll C:\testdir\
-
   - ps: .\ci\appveyor_run_tests.ps1
   - ps: .\ci\appveyor_build_recipe.ps1
 

--- a/src/testing/Python.Test.csproj
+++ b/src/testing/Python.Test.csproj
@@ -103,7 +103,7 @@
     <TargetAssemblyPdb>$(TargetDir)$(TargetName).pdb</TargetAssemblyPdb>
   </PropertyGroup>
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />
+    <Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(SolutionDir)\src\tests\fixtures" />
     <Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" />
   </Target>
 </Project>

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -5,13 +5,18 @@
 """Helpers for testing."""
 
 import ctypes
+import os
 import sys
 import sysconfig
 
 import clr
 
-# Add path for Python.Test & Add References
-sys.path.append('C:/testdir/')
+# Add path for `Python.Test`
+cwd = os.path.dirname(__file__)
+fixtures = os.path.join(cwd, 'fixtures')
+sys.path.append(fixtures)
+
+# Add References for tests
 clr.AddReference("Python.Test")
 clr.AddReference("System.Collections")
 clr.AddReference("System.Data")


### PR DESCRIPTION
Ensures that `Python.Test` is output to same location on both Linux and Windows
as part of build.

### What does this implement/fix? Explain your changes.

Remove the need to manually copy or locate `Python.Test.dll` for local testing. 
No longer need that line in the [wiki](https://github.com/pythonnet/pythonnet/wiki/Troubleshooting-on-Windows-and-Linux#tests-passing).

Simplifies CI setup.

### Other Comments
`.gitkeep` to ensure the fixture folder is part of version control (and no need to recreate)
Can be removed if any file is added to it later on. 

