### PR TITLE
Fix PythonException GC -  no thread-state for this thread

### DIFF
--- a/src/embed_tests/pytuple.cs
+++ b/src/embed_tests/pytuple.cs
@@ -7,29 +7,6 @@ namespace Python.EmbeddingTest
     public class PyTupleTest
     {
         /// <summary>
-        /// Tests set-up. Being used to skip class on Travis/PY27
-        /// </summary>
-        /// <remarks>
-        /// FIXME: Fails on Travis/PY27: All tests below (unless otherwise stated)
-        /// Fatal Python error: auto-releasing thread-state, but no thread-state for this thread
-        /// Stacktrace:
-        /// at (wrapper managed-to-native) Python.Runtime.Runtime.PyGILState_Release (intptr)
-        /// at Python.Runtime.PythonEngine.ReleaseLock (intptr)
-        /// at Python.Runtime.PythonException.Dispose ()
-        /// at Python.Runtime.PythonException.Finalize ()
-        /// at (wrapper runtime-invoke) object.runtime_invoke_virtual_void__this__ (object,intptr,intptr,intptr)
-        /// </remarks>
-        [SetUp]
-        public void SetUp()
-        {
-            if (Environment.GetEnvironmentVariable("TRAVIS") == "true" &&
-                Environment.GetEnvironmentVariable("TRAVIS_PYTHON_VERSION") == "2.7")
-            {
-                Assert.Ignore("Fails on Travis/PY27: Fatal Python error: auto-releasing thread-state, but no thread-state for this thread");
-            }
-        }
-
-        /// <summary>
         /// Test IsTupleType without having to Initialize a tuple.
         /// PyTuple constructor use IsTupleType. This decouples the tests.
         /// </summary>

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -140,7 +140,7 @@ namespace Python.Runtime
         {
             if (!disposed)
             {
-                if (Runtime.Py_IsInitialized() > 0)
+                if (Runtime.Py_IsInitialized() > 0 && !Runtime.IsFinalizing)
                 {
                     IntPtr gs = PythonEngine.AcquireLock();
                     Runtime.XDecref(_pyType);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Re-enable most `PyTuple` tests on PY27/Travis.
Prevent GC trying to deref values after python has been closed.

### Does this close any currently open issues?

`Fails on Travis/PY27: Fatal Python error: auto-releasing thread-state, but no thread-state for this thread`
Seen mostly on PY27/Travis on PyTuple tests during GC of tests.

```
Fatal Python error: auto-releasing thread-state, but no thread-state for this thread
Stacktrace:
at (wrapper managed-to-native) Python.Runtime.Runtime.PyGILState_Release (intptr)
at Python.Runtime.PythonEngine.ReleaseLock (intptr)
at Python.Runtime.PythonException.Dispose ()
at Python.Runtime.PythonException.Finalize ()
at (wrapper runtime-invoke) object.runtime_invoke_virtual_void__this__ (object,intptr,intptr,intptr)
```

### Any other comments?

Similar fix to #365.
Since `PythonException` doesn't inherit from `PyObject`, need to reapply fix.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
