### PR TITLE
Fix the issue of sys.argv being cleared on import clr.

### DIFF
--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -122,7 +122,12 @@ namespace Python.Runtime
 
         public static void Initialize()
         {
-            Initialize(Enumerable.Empty<string>());
+            Initialize(setSysArgv: true);
+        }
+
+        public static void Initialize(bool setSysArgv = true)
+        {
+            Initialize(Enumerable.Empty<string>(), setSysArgv: setSysArgv);
         }
 
         /// <summary>
@@ -134,7 +139,7 @@ namespace Python.Runtime
         /// first call. It is *not* necessary to hold the Python global
         /// interpreter lock (GIL) to call this method.
         /// </remarks>
-        public static void Initialize(IEnumerable<string> args)
+        public static void Initialize(IEnumerable<string> args, bool setSysArgv = true)
         {
             if (!initialized)
             {
@@ -148,7 +153,8 @@ namespace Python.Runtime
                 initialized = true;
                 Exceptions.Clear();
 
-                Py.SetArgv(args);
+                if (setSysArgv)
+                    Py.SetArgv(args);
 
                 // register the atexit callback (this doesn't use Py_AtExit as the C atexit
                 // callbacks are called after python is fully finalized but the python ones
@@ -213,7 +219,7 @@ namespace Python.Runtime
         {
             try
             {
-                Initialize();
+                Initialize(setSysArgv: false);
 
                 // Trickery - when the import hook is installed into an already
                 // running Python, the standard import machinery is still in

--- a/src/tests/test_sysargv.py
+++ b/src/tests/test_sysargv.py
@@ -4,12 +4,9 @@
 
 import sys
 
-import pytest
-
 from ._compat import check_output
 
 
-@pytest.mark.xfail(reason="argv being reset on import clr. See gh#404")
 def test_sys_argv_state(filepath):
     """Test sys.argv state doesn't change after clr import.
     To better control the arguments being passed, test on a fresh python


### PR DESCRIPTION
Closes #404.

### What does this implement/fix? Explain your changes.

Introduces a `setSysArgv` flag to all `Initialize` functions in `PythonEngine`, defaulting to `true` and set to `false` for `InitExt` such that `import clr` doesn't call `PySys_SetArgvEx`.

### Does this close any currently open issues?

#404.

### Any other comments?

The test should already be in from another PR, from what I understood and since the change introducing this issue has not been released, yet, I don't think it need to go into the changelog.