### PR TITLE
Added branching for ldd command in OSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,16 +162,15 @@ class BuildExtPythonnet(build_ext.build_ext):
             defines.extend(["DEBUG", "TRACE"])
 
         if sys.platform != "win32" and DEVTOOLS == "Mono":
-            if sys.platform == "darwin":
-                defines.append("MONO_OSX")
-            else:
-                defines.append("MONO_LINUX")
+            on_darwin = sys.platform == "darwin"
+            defines.append("MONO_OSX" if on_darwin else "MONO_LINUX")
 
             # Check if --enable-shared was set when Python was built
             enable_shared = sysconfig.get_config_var("Py_ENABLE_SHARED")
             if enable_shared:
                 # Double-check if libpython is linked dynamically with python
-                lddout = _check_output(["ldd", sys.executable])
+                ldd_cmd = ["otool", "-L"] if on_darwin else ["ldd"]
+                lddout = _check_output(ldd_cmd + [sys.executable])
                 if 'libpython' not in lddout:
                     enable_shared = False
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Following #392, an OSX native `ldd` equivalent command (`otool -L`)

### Does this close any currently open issues?

No, still have to manually add the symbolic links (see again #392) for import to work.
```
(py36) vasilios@exumas: /usr/local/anaconda/envs/py36/lib
└─ $ ln -s /Library/Frameworks/Mono.framework/Versions/4.6.2/lib/mono mono
```

### Any other comments?

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)