### PR TITLE
Fix set pythonhome

### DIFF
--- a/src/embed_tests/TestPythonEngineProperties.cs
+++ b/src/embed_tests/TestPythonEngineProperties.cs
@@ -130,5 +130,17 @@ namespace Python.EmbeddingTest
             Assert.AreEqual(pythonHome, PythonEngine.PythonHome);
             PythonEngine.Shutdown();
         }
+
+        [Test]
+        public void SetProgramName()
+        {
+            var programName = "FooBar";
+
+            PythonEngine.ProgramName = programName;
+            PythonEngine.Initialize();
+
+            Assert.AreEqual(programName, PythonEngine.ProgramName);
+            PythonEngine.Shutdown();
+        }
     }
 }

--- a/src/embed_tests/TestPythonEngineProperties.cs
+++ b/src/embed_tests/TestPythonEngineProperties.cs
@@ -105,5 +105,30 @@ namespace Python.EmbeddingTest
             Assert.AreEqual(envPythonHome, enginePythonHome);
             PythonEngine.Shutdown();
         }
+
+        [Test]
+        public void SetPythonHome()
+        {
+            var pythonHome = "/dummypath/";
+
+            PythonEngine.PythonHome = pythonHome;
+            PythonEngine.Initialize();
+
+            Assert.AreEqual(pythonHome, PythonEngine.PythonHome);
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void SetPythonHomeTwice()
+        {
+            var pythonHome = "/dummypath/";
+
+            PythonEngine.PythonHome = "/dummypath2/";
+            PythonEngine.PythonHome = pythonHome;
+            PythonEngine.Initialize();
+
+            Assert.AreEqual(pythonHome, PythonEngine.PythonHome);
+            PythonEngine.Shutdown();
+        }
     }
 }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -15,6 +15,8 @@ namespace Python.Runtime
         private static DelegateManager delegateManager;
         private static bool initialized;
         private static IntPtr _pythonHome = IntPtr.Zero;
+        private static IntPtr _programName = IntPtr.Zero;
+        private static IntPtr _pythonPath = IntPtr.Zero;
 
         public PythonEngine()
         {
@@ -65,7 +67,14 @@ namespace Python.Runtime
 
                 return result ?? "";
             }
-            set { Runtime.Py_SetProgramName(value); }
+            set
+            {
+                Marshal.FreeHGlobal(_programName);
+                _programName = Runtime.IsPython3
+                    ? UcsMarshaler.GetInstance("").MarshalManagedToNative(value)
+                    : Marshal.StringToHGlobalAnsi(value);
+                Runtime.Py_SetProgramName(_programName);
+            }
         }
 
         public static string PythonHome
@@ -81,10 +90,7 @@ namespace Python.Runtime
             }
             set
             {
-                if (_pythonHome != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(_pythonHome);
-                }
+                Marshal.FreeHGlobal(_pythonHome);
                 _pythonHome = Runtime.IsPython3
                     ? UcsMarshaler.GetInstance("").MarshalManagedToNative(value)
                     : Marshal.StringToHGlobalAnsi(value);
@@ -103,7 +109,14 @@ namespace Python.Runtime
 
                 return result ?? "";
             }
-            set { Runtime.Py_SetPath(value); }
+            set
+            {
+                Marshal.FreeHGlobal(_pythonPath);
+                _pythonPath = Runtime.IsPython3
+                    ? UcsMarshaler.GetInstance("").MarshalManagedToNative(value)
+                    : Marshal.StringToHGlobalAnsi(value);
+                Runtime.Py_SetPath(_pythonPath);
+            }
         }
 
         public static string Version
@@ -297,6 +310,11 @@ namespace Python.Runtime
             {
                 Marshal.FreeHGlobal(_pythonHome);
                 _pythonHome = IntPtr.Zero;
+                Marshal.FreeHGlobal(_programName);
+                _programName = IntPtr.Zero;
+                Marshal.FreeHGlobal(_pythonPath);
+                _pythonPath = IntPtr.Zero;
+
                 Runtime.Shutdown();
                 initialized = false;
             }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -694,9 +694,7 @@ namespace Python.Runtime
         internal static extern IntPtr Py_GetPythonHome();
 
         [DllImport(PythonDll)]
-        internal static extern void Py_SetPythonHome(
-            [MarshalAs(UnmanagedType.LPWStr)] string home
-        );
+        internal static extern void Py_SetPythonHome(IntPtr home);
 
         [DllImport(PythonDll)]
         internal static extern IntPtr Py_GetPath();
@@ -716,7 +714,7 @@ namespace Python.Runtime
         internal static extern IntPtr Py_GetPythonHome();
 
         [DllImport(PythonDll)]
-        internal static extern void Py_SetPythonHome(string home);
+        internal static extern void Py_SetPythonHome(IntPtr home);
 
         [DllImport(PythonDll)]
         internal static extern IntPtr Py_GetPath();

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -686,9 +686,7 @@ namespace Python.Runtime
         internal static extern IntPtr Py_GetProgramName();
 
         [DllImport(PythonDll)]
-        internal static extern void Py_SetProgramName(
-            [MarshalAs(UnmanagedType.LPWStr)] string name
-        );
+        internal static extern void Py_SetProgramName(IntPtr name);
 
         [DllImport(PythonDll)]
         internal static extern IntPtr Py_GetPythonHome();
@@ -700,15 +698,13 @@ namespace Python.Runtime
         internal static extern IntPtr Py_GetPath();
 
         [DllImport(PythonDll)]
-        internal static extern void Py_SetPath(
-            [MarshalAs(UnmanagedType.LPWStr)] string home
-        );
+        internal static extern void Py_SetPath(IntPtr home);
 #elif PYTHON2
         [DllImport(PythonDll)]
         internal static extern IntPtr Py_GetProgramName();
 
         [DllImport(PythonDll)]
-        internal static extern void Py_SetProgramName(string name);
+        internal static extern void Py_SetProgramName(IntPtr name);
 
         [DllImport(PythonDll)]
         internal static extern IntPtr Py_GetPythonHome();
@@ -720,7 +716,7 @@ namespace Python.Runtime
         internal static extern IntPtr Py_GetPath();
 
         [DllImport(PythonDll)]
-        internal static extern void Py_SetPath(string home);
+        internal static extern void Py_SetPath(IntPtr home);
 #endif
 
         [DllImport(PythonDll)]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fixes setters for `PythonEngine.PythonHome` `PythonEngine.ProgramName` and `PythonEngine.PythonPath`. 

It extends #279/#186: 
- Fix the issue in Python 2/3 and 32/64bit
- Fix memory leak on multiple `setters`

### Does this close any currently open issues?

Closes #179
Closes #279 (replaces)
Closes #186 (replaces)


### Any other comments?

There's quite a bit of repeated code on this `pr`. I'll perform the clean-up after this `pr` is merged to avoid obscuring how this is being fixed. 

`PythonEngine.PythonPath`, is misleading since it doesn't directly map to `PYTHONPATH` and should be called `Path` instead. `py_set_path` doesn't exist on `PY27` but it was erroneously defined at some point. 
Needs to be removed, but its outside the scope of this `PR`. 

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)

