### PR TITLE
Fix numpy array and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ static void Main(string[] args)
 
         double c = np.cos(5) + sin(5);
         Console.WriteLine(c);
-        /* this block is temporarily disabled due to regression #249
+
         dynamic a = np.array(new List<float> { 1, 2, 3 });
         Console.WriteLine(a.dtype);
 
@@ -71,7 +71,6 @@ static void Main(string[] args)
         Console.WriteLine(b.dtype);
 
         Console.WriteLine(a * b);
-        */
         Console.ReadKey();
     }
 }

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -85,6 +85,7 @@
     <Compile Include="pyinitialize.cs" />
     <Compile Include="pyrunstring.cs" />
     <Compile Include="TestCustomMarshal.cs" />
+    <Compile Include="TestExample.cs" />
     <Compile Include="TestPyAnsiString.cs" />
     <Compile Include="TestPyFloat.cs" />
     <Compile Include="TestPyInt.cs" />

--- a/src/embed_tests/TestExample.cs
+++ b/src/embed_tests/TestExample.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class TestExample
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void TestReadme()
+        {
+            dynamic np;
+            try
+            {
+                np = Py.Import("numpy");
+            }
+            catch (PythonException)
+            {
+                Assert.Inconclusive("Numpy or dependency not installed");
+                return;
+            }
+            
+            Assert.AreEqual("1.0", np.cos(np.pi * 2).ToString());
+
+            dynamic sin = np.sin;
+            StringAssert.StartsWith("-0.95892", sin(5).ToString());
+
+            double c = np.cos(5) + sin(5);
+            Assert.AreEqual(-0.675262, c, 0.01);
+
+            dynamic a = np.array(new List<float> { 1, 2, 3 });
+            Assert.AreEqual("float64", a.dtype.ToString());
+
+            dynamic b = np.array(new List<float> { 6, 5, 4 }, Py.kw("dtype", np.int32));
+            Assert.AreEqual("int32", b.dtype.ToString());
+
+            Assert.AreEqual("[  6.  10.  12.]", (a * b).ToString());
+        }
+    }
+}

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -131,6 +132,16 @@ namespace Python.Runtime
                 result = Runtime.PyNone;
                 Runtime.XIncref(result);
                 return result;
+            }
+
+            if (value is IList && value.GetType().IsGenericType)
+            {
+                var resultlist = new PyList();
+                foreach (object o in (IEnumerable)value)
+                {
+                    resultlist.Append(new PyObject(ToPython(o, o.GetType())));
+                }
+                return resultlist.Handle;
             }
 
             // it the type is a python subclass of a managed type then return the

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -136,12 +136,18 @@ namespace Python.Runtime
 
             if (value is IList && value.GetType().IsGenericType)
             {
-                var resultlist = new PyList();
-                foreach (object o in (IEnumerable)value)
+                using (var resultlist = new PyList())
                 {
-                    resultlist.Append(new PyObject(ToPython(o, o.GetType())));
+                    foreach (object o in (IEnumerable)value)
+                    {
+                        using (var p = new PyObject(ToPython(o, o?.GetType())))
+                        {
+                            resultlist.Append(p);
+                        }
+                    }
+                    Runtime.XIncref(resultlist.Handle);
+                    return resultlist.Handle;
                 }
-                return resultlist.Handle;
             }
 
             // it the type is a python subclass of a managed type then return the


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Generic Lists were falling through and being classified as `typecode.Object`
To solve this, adding a specific processing branch for `Generic Lists` only
to avoid breaking the changes from 471673a1fa4691b3becb4d9fee6941308535bb04

### Does this close any currently open issues?

Closes #249

### Any other comments?

`n/a`

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
