### PR TITLE
Fixing Travis CI for mono 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ class BuildExtPythonnet(build_ext.build_ext):
             _config = "{0}Win".format(CONFIG)
 
         elif DEVTOOLS == "Mono":
-            _xbuild = "msbuild"
+            _xbuild = "xbuild"
             _config = "{0}Mono".format(CONFIG)
         else:
             raise NotImplementedError(

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ class BuildExtPythonnet(build_ext.build_ext):
             _config = "{0}Win".format(CONFIG)
 
         elif DEVTOOLS == "Mono":
-            _xbuild = "xbuild"
+            _xbuild = "msbuild"
             _config = "{0}Mono".format(CONFIG)
         else:
             raise NotImplementedError(
@@ -209,7 +209,7 @@ class BuildExtPythonnet(build_ext.build_ext):
             'pythonnet.sln',
             '/p:Configuration={}'.format(_config),
             '/p:Platform={}'.format(ARCH),
-            '/p:DefineConstants="{}"'.format(','.join(defines)),
+            '/p:DefineConstants="{}"'.format('%3B'.join(defines)),
             '/p:PythonBuildDir="{}"'.format(os.path.abspath(dest_dir)),
             '/p:PythonInteropFile="{}"'.format(os.path.basename(interop_file)),
             '/verbosity:{}'.format(VERBOSITY),

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -115,6 +115,6 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />
-    <Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" />
+    <!--Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" /-->
   </Target>
 </Project>

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -161,6 +161,6 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />
-    <Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" />
+    <!--Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" /-->
   </Target>
 </Project>

--- a/src/testing/Python.Test.csproj
+++ b/src/testing/Python.Test.csproj
@@ -108,6 +108,6 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(TargetAssembly)" DestinationFolder="$(SolutionDir)\src\tests\fixtures" />
-    <Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" />
+    <!--Copy SourceFiles="$(TargetAssemblyPdb)" Condition="Exists('$(TargetAssemblyPdb)')" DestinationFolder="$(PythonBuildDir)" /-->
   </Target>
 </Project>


### PR DESCRIPTION
My attempt to fix Travis CI after the upgrade to mono 5.0. Should fix #464 and let #461 be merged.

I have checked setup.py on osx with mono 5.0, the problem is the escaping of constants to the /p:DefineConstants arguments to msbuild. After trying several things, I'm escaping with %3B (semicolon), should be fine in windows as well. 

I don't have a linux box to test now or a travis setup to verify further, so I'm pushing the PR and will see the results of pythonnet travis. We can take it from there. 