### PR TITLE
Fix missing Incref for Namespace and Assembly

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -43,3 +43,5 @@
 -   ([@rico-chet](https://github.com/rico-chet))
 -   ([@rmadsen-ks](https://github.com/rmadsen-ks))
 -   ([@stonebig](https://github.com/stonebig))
+-   ([@testrunner123](https://github.com/testrunner123))
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,17 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ## [unreleased][]
 
 ### Added
--   Added clr.GetClrType (#432)(#433)
--   Added `Foo` feature
--   Allowed passing None for nullable args (#460)
+-   Added `clr.GetClrType` (#432, #433)
+-   Allowed passing `None` for nullable args (#460)
 
 ### Changed
-
--   Changed `Bar` feature
 
 ### Fixed
 
 -   Fixed Visual Studio 2017 compat (#434) for setup.py
--   Fixed `FooBar` bug
--   Fixed crash on exit of python interpreter if python class derived from .NET class has `__namespace__` or `__assembly__` attribute
+-   Fixed crash on exit of the Python interpreter if a python class
+    derived from a .NET class has a `__namespace__` or `__assembly__`
+    attribute (#481)
 
 ## [2.3.0][] - 2017-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 -   Fixed Visual Studio 2017 compat (#434) for setup.py
 -   Fixed `FooBar` bug
+-   Fixed crash on exit of python interpreter if python class derived from .NET class has `__namespace__` or `__assembly__` attribute
 
 ## [2.3.0][] - 2017-03-11
 

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -206,6 +206,7 @@ namespace Python.Runtime
                 if (0 != Runtime.PyMapping_HasKey(py_dict, assemblyKey.Handle))
                 {
                     var pyAssembly = new PyObject(Runtime.PyDict_GetItem(py_dict, assemblyKey.Handle));
+                    Runtime.XIncref(pyAssembly.Handle);
                     disposeList.Add(pyAssembly);
                     if (!Converter.ToManagedValue(pyAssembly.Handle, typeof(string), out assembly, false))
                     {
@@ -218,6 +219,7 @@ namespace Python.Runtime
                 if (0 != Runtime.PyMapping_HasKey(py_dict, namespaceKey.Handle))
                 {
                     var pyNamespace = new PyObject(Runtime.PyDict_GetItem(py_dict, namespaceKey.Handle));
+                    Runtime.XIncref(pyNamespace.Handle);
                     disposeList.Add(pyNamespace);
                     if (!Converter.ToManagedValue(pyNamespace.Handle, typeof(string), out namespaceStr, false))
                     {

--- a/src/tests/test_subclass.py
+++ b/src/tests/test_subclass.py
@@ -85,7 +85,6 @@ def derived_event_test_class_fixture():
     return DerivedEventTest
 
 
-@pytest.mark.skip(reason="FIXME: test randomly pass/fails")
 def test_base_class():
     """Test base class managed type"""
     ob = SubClassTest()
@@ -98,7 +97,6 @@ def test_base_class():
     assert list(SubClassTest.test_list(ob)) == ["a", "b", "c"]
 
 
-@pytest.mark.skip(reason="FIXME: test randomly pass/fails")
 def test_interface():
     """Test python classes can derive from C# interfaces"""
     InterfaceTestClass = interface_test_class_fixture()
@@ -112,7 +110,6 @@ def test_interface():
     assert id(x) == id(ob)
 
 
-@pytest.mark.skip(reason="FIXME: test randomly pass/fails")
 def test_derived_class():
     """Test python class derived from managed type"""
     DerivedClass = derived_class_fixture()


### PR DESCRIPTION
Fix crash of python interpreter 3.5 64-bit in garbage collector

### What does this implement/fix? Explain your changes.

If Python class is derived from .NET class and __namespace__ or __assembly__ attributes are set then python interpreter crashes in garbage collector. Provoke garbage collector run by:
```
import gc
gc.collect()
```

### Does this close any currently open issues?

#481 and may be others

### Any other comments?

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
