### PR TITLE
Fix conversion of 'float' and 'double' values

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@
 -   Joe Frayne ([@jfrayne](https://github.com/jfrayne))
 -   John Burnett ([@johnburnett](https://github.com/johnburnett))
 -   Luke Stratman ([@lstratman](https://github.com/lstratman))
+-   Konstantin Posudevskiy ([@konstantin-posudevskiy](https://github.com/konstantin-posudevskiy))
 -   Matthias Dittrich ([@matthid](https://github.com/matthid))
 -   Patrick Stewart ([@patstew](https://github.com/patstew))
 -   Raphael Nestler ([@rnestler](https://github.com/rnestler))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 -   Fixed Visual Studio 2017 compat (#434) for setup.py
 -   Fixed `FooBar` bug
+-   Fixed conversion of 'float' and 'double' values (#486)
 
 ## [2.3.0][] - 2017-03-11
 

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -84,6 +84,7 @@
     <Compile Include="pyimport.cs" />
     <Compile Include="pyinitialize.cs" />
     <Compile Include="pyrunstring.cs" />
+    <Compile Include="TestConverter.cs" />
     <Compile Include="TestCustomMarshal.cs" />
     <Compile Include="TestExample.cs" />
     <Compile Include="TestPyAnsiString.cs" />

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class TestConverter
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void TestConvertSingleToManaged(
+            [Values(float.PositiveInfinity, float.NegativeInfinity, float.MinValue, float.MaxValue, float.NaN,
+                float.Epsilon)] float testValue)
+        {
+            var pyFloat = new PyFloat(testValue);
+
+            object convertedValue;
+            var converted = Converter.ToManaged(pyFloat.Handle, typeof(float), out convertedValue, false);
+
+            Assert.IsTrue(converted);
+            Assert.IsTrue(((float) convertedValue).Equals(testValue));
+        }
+
+        [Test]
+        public void TestConvertDoubleToManaged(
+            [Values(double.PositiveInfinity, double.NegativeInfinity, double.MinValue, double.MaxValue, double.NaN,
+                double.Epsilon)] double testValue)
+        {
+            var pyFloat = new PyFloat(testValue);
+
+            object convertedValue;
+            var converted = Converter.ToManaged(pyFloat.Handle, typeof(double), out convertedValue, false);
+
+            Assert.IsTrue(converted);
+            Assert.IsTrue(((double) convertedValue).Equals(testValue));
+        }
+    }
+}

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -770,10 +770,14 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     double dd = Runtime.PyFloat_AsDouble(op);
+                    Runtime.CheckExceptionOccurred();
                     Runtime.XDecref(op);
                     if (dd > Single.MaxValue || dd < Single.MinValue)
                     {
-                        goto overflow;
+                        if (!double.IsInfinity(dd))
+                        {
+                            goto overflow;
+                        }
                     }
                     result = (float)dd;
                     return true;
@@ -785,11 +789,8 @@ namespace Python.Runtime
                         goto type_error;
                     }
                     double d = Runtime.PyFloat_AsDouble(op);
+                    Runtime.CheckExceptionOccurred();
                     Runtime.XDecref(op);
-                    if (d > Double.MaxValue || d < Double.MinValue)
-                    {
-                        goto overflow;
-                    }
                     result = d;
                     return true;
             }

--- a/src/tests/test_conversion.py
+++ b/src/tests/test_conversion.py
@@ -466,17 +466,6 @@ def test_double_conversion():
     with pytest.raises(TypeError):
         ConversionTest().DoubleField = None
 
-    with pytest.raises(OverflowError):
-        ConversionTest().DoubleField = 1.7976931348623159e308
-
-    with pytest.raises(OverflowError):
-        ConversionTest().DoubleField = -1.7976931348623159e308
-
-    with pytest.raises(OverflowError):
-        _ = System.Double(1.7976931348623159e308)
-
-    with pytest.raises(OverflowError):
-        _ = System.Double(-1.7976931348623159e308)
 
 
 def test_decimal_conversion():


### PR DESCRIPTION
### Fix problem of conversion 'float' and 'double' values in converter.cs.

As there was a range check both for `float` and `double` values, which are less or greater than its `MinValue` and `MaxValue` accordingly,
several values like `float.NegativeInfinity`, `float.PositiveInfinity` and the same 'double' values cannot be converted from Python to .NET values.

### Add error check after `PyFloat_AsDouble` call
Due to Python C API documentation, method `PyFloat_AsDouble` can return `-1.0` upon failure. So it requires error check. This rule forces to check for error and throw exception in case of error.

### Add tests, which cover problem of conversion `float` and `double` values.

Resolves: #486