### PR TITLE
[WIP] Drop tp_call implementation from metatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
     attribute (#481)
 -   Fixed conversion of 'float' and 'double' values (#486)
 -   Fixed 'clrmethod' for python 2 (#492)
+-   Fixed double calling of constructor when deriving from .NET class (#495)
 
 
 ## [2.3.0][] - 2017-03-11

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -828,8 +828,6 @@ namespace Python.Runtime
 
         public static void InvokeCtor(IPythonDerivedType obj, string origCtorName, object[] args)
         {
-            Console.Error.WriteLine($"{origCtorName}: {string.Join(", ", args)}");
-
             // call the base constructor
             obj.GetType().InvokeMember(origCtorName,
                 BindingFlags.InvokeMethod,

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace Python.Runtime
@@ -136,57 +136,6 @@ namespace Python.Runtime
         {
             Runtime.PyObject_GC_Del(tp);
         }
-
-
-        /// <summary>
-        /// Metatype __call__ implementation. This is needed to ensure correct
-        /// initialization (__init__ support), because the tp_call we inherit
-        /// from PyType_Type won't call __init__ for metatypes it doesn't know.
-        /// </summary>
-        public static IntPtr tp_call(IntPtr tp, IntPtr args, IntPtr kw)
-        {
-            IntPtr func = Marshal.ReadIntPtr(tp, TypeOffset.tp_new);
-            if (func == IntPtr.Zero)
-            {
-                return Exceptions.RaiseTypeError("invalid object");
-            }
-
-            IntPtr obj = NativeCall.Call_3(func, tp, args, kw);
-            if (obj == IntPtr.Zero)
-            {
-                return IntPtr.Zero;
-            }
-
-            IntPtr py__init__ = Runtime.PyString_FromString("__init__");
-            IntPtr type = Runtime.PyObject_TYPE(obj);
-            IntPtr init = Runtime._PyType_Lookup(type, py__init__);
-            Runtime.XDecref(py__init__);
-            Runtime.PyErr_Clear();
-
-            if (init != IntPtr.Zero)
-            {
-                IntPtr bound = Runtime.GetBoundArgTuple(obj, args);
-                if (bound == IntPtr.Zero)
-                {
-                    Runtime.XDecref(obj);
-                    return IntPtr.Zero;
-                }
-
-                IntPtr result = Runtime.PyObject_Call(init, bound, kw);
-                Runtime.XDecref(bound);
-
-                if (result == IntPtr.Zero)
-                {
-                    Runtime.XDecref(obj);
-                    return IntPtr.Zero;
-                }
-
-                Runtime.XDecref(result);
-            }
-
-            return obj;
-        }
-
 
         /// <summary>
         /// Type __setattr__ implementation for reflected types. Note that this

--- a/src/tests/test_subclass.py
+++ b/src/tests/test_subclass.py
@@ -192,19 +192,15 @@ def test_isinstance_check():
         assert isinstance(x, System.String)
 
 
-_derived_cons_calls = 0
-
 def test_derived_constructor_only_called_once():
-    global _derived_cons_calls
-    _derived_cons_calls = 0
+    calls = []
 
     class X(System.Object):
         __namespace__ = "PyTest"
 
-        def __init__(self):
-            global _derived_cons_calls
-            _derived_cons_calls += 1
+        def __init__(self, *args):
+            calls.append(args)
 
-    x = X()
+    x = X(1, 2)
 
-    assert _derived_cons_calls == 1
+    assert calls == [(1, 2)]

--- a/src/tests/test_subclass.py
+++ b/src/tests/test_subclass.py
@@ -190,3 +190,21 @@ def test_isinstance_check():
     for x in b:
         assert isinstance(x, System.Object)
         assert isinstance(x, System.String)
+
+
+_derived_cons_calls = 0
+
+def test_derived_constructor_only_called_once():
+    global _derived_cons_calls
+    _derived_cons_calls = 0
+
+    class X(System.Object):
+        __namespace__ = "PyTest"
+
+        def __init__(self):
+            global _derived_cons_calls
+            _derived_cons_calls += 1
+
+    x = X()
+
+    assert _derived_cons_calls == 1


### PR DESCRIPTION
This seems to be a patch for broken behaviour in Python. Removing it
should solve #495 (`__init__` called twice on construction).

### What does this implement/fix? Explain your changes.

#495

### Does this close any currently open issues?

#495

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
