### PR TITLE
Handle C long size on Windows.

### DIFF
--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -136,6 +136,7 @@
     <Compile Include="runtime.cs" />
     <Compile Include="typemanager.cs" />
     <Compile Include="typemethod.cs" />
+    <Compile Include="Util.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PythonInteropFile)' != '' ">
     <Compile Include="$(PythonInteropFile)" />

--- a/src/runtime/Util.cs
+++ b/src/runtime/Util.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Python.Runtime
+{
+    internal class Util
+    {
+        internal static Int64 ReadCLong(IntPtr tp, int offset)
+        {
+            // On Windows, a C long is always 32 bits.
+            if (Runtime.IsWindows || Runtime.Is32Bit)
+            {
+                return Marshal.ReadInt32(tp, offset);
+            }
+            else
+            {
+                return Marshal.ReadInt64(tp, offset);
+            }
+        }
+
+        internal static void WriteCLong(IntPtr type, int offset, Int64 flags)
+        {
+            if (Runtime.IsWindows || Runtime.Is32Bit)
+            {
+                Marshal.WriteInt32(type, offset, (Int32)(flags & 0xffffffffL));
+            }
+            else
+            {
+                Marshal.WriteInt64(type, offset, flags);
+            }
+        }
+    }
+}

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace Python.Runtime
@@ -11,7 +11,7 @@ namespace Python.Runtime
         {
             IntPtr py = Runtime.PyType_GenericAlloc(tp, 0);
 
-            var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+            long flags = Util.ReadCLong(tp, TypeOffset.tp_flags);
             if ((flags & TypeFlags.Subclass) != 0)
             {
                 IntPtr dict = Marshal.ReadIntPtr(py, ObjectOffset.DictOffset(tp));

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace Python.Runtime
@@ -28,7 +28,7 @@ namespace Python.Runtime
                     tp = ob;
                 }
 
-                var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+                var flags = Util.ReadCLong(tp, TypeOffset.tp_flags);
                 if ((flags & TypeFlags.Managed) != 0)
                 {
                     IntPtr op = tp == ob
@@ -63,7 +63,7 @@ namespace Python.Runtime
                     tp = ob;
                 }
 
-                var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+                var flags = Util.ReadCLong(tp, TypeOffset.tp_flags);
                 if ((flags & TypeFlags.Managed) != 0)
                 {
                     return true;

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace Python.Runtime
@@ -105,7 +105,7 @@ namespace Python.Runtime
             flags |= TypeFlags.BaseType;
             flags |= TypeFlags.Subclass;
             flags |= TypeFlags.HaveGC;
-            Marshal.WriteIntPtr(type, TypeOffset.tp_flags, (IntPtr)flags);
+            Util.WriteCLong(type, TypeOffset.tp_flags, flags);
 
             TypeManager.CopySlot(base_type, type, TypeOffset.tp_dealloc);
 
@@ -247,7 +247,7 @@ namespace Python.Runtime
         {
             // Fix this when we dont cheat on the handle for subclasses!
 
-            var flags = (int)Marshal.ReadIntPtr(tp, TypeOffset.tp_flags);
+            var flags = Util.ReadCLong(tp, TypeOffset.tp_flags);
             if ((flags & TypeFlags.Subclass) == 0)
             {
                 IntPtr gc = Marshal.ReadIntPtr(tp, TypeOffset.magic());

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -152,6 +152,10 @@ namespace Python.Runtime
         internal static bool IsFinalizing;
 
         internal static bool Is32Bit = IntPtr.Size == 4;
+
+        // .NET core: System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        internal static bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
         internal static bool IsPython2 = pyversionnumber < 30;
         internal static bool IsPython3 = pyversionnumber >= 30;
 
@@ -785,7 +789,7 @@ namespace Python.Runtime
         {
             var ob_type = Marshal.ReadIntPtr(pointer, ObjectOffset.ob_type);
 #if PYTHON2
-            long tp_flags = Marshal.ReadInt64(ob_type, TypeOffset.tp_flags);
+            long tp_flags = Util.ReadCLong(ob_type, TypeOffset.tp_flags);
             if ((tp_flags & TypeFlags.HaveIter) == 0)
                 return false;
 #endif
@@ -1442,7 +1446,7 @@ namespace Python.Runtime
         {
             var ob_type = Marshal.ReadIntPtr(pointer, ObjectOffset.ob_type);
 #if PYTHON2
-            long tp_flags = Marshal.ReadInt64(ob_type, TypeOffset.tp_flags);
+            long tp_flags = Util.ReadCLong(ob_type, TypeOffset.tp_flags);
             if ((tp_flags & TypeFlags.HaveIter) == 0)
                 return false;
 #endif

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -86,7 +86,7 @@ namespace Python.Runtime
 
             int flags = TypeFlags.Default | TypeFlags.Managed |
                         TypeFlags.HeapType | TypeFlags.HaveGC;
-            Marshal.WriteIntPtr(type, TypeOffset.tp_flags, (IntPtr)flags);
+            Util.WriteCLong(type, TypeOffset.tp_flags, flags);
 
             Runtime.PyType_Ready(type);
 
@@ -160,7 +160,7 @@ namespace Python.Runtime
             flags |= TypeFlags.HeapType;
             flags |= TypeFlags.BaseType;
             flags |= TypeFlags.HaveGC;
-            Marshal.WriteIntPtr(type, TypeOffset.tp_flags, (IntPtr)flags);
+            Util.WriteCLong(type, TypeOffset.tp_flags, flags);
 
             // Leverage followup initialization from the Python runtime. Note
             // that the type of the new type must PyType_Type at the time we
@@ -323,7 +323,7 @@ namespace Python.Runtime
             flags |= TypeFlags.Managed;
             flags |= TypeFlags.HeapType;
             flags |= TypeFlags.HaveGC;
-            Marshal.WriteIntPtr(type, TypeOffset.tp_flags, (IntPtr)flags);
+            Util.WriteCLong(type, TypeOffset.tp_flags, flags);
 
             // We need space for 3 PyMethodDef structs, each of them
             // 4 int-ptrs in size.
@@ -380,7 +380,7 @@ namespace Python.Runtime
             flags |= TypeFlags.Managed;
             flags |= TypeFlags.HeapType;
             flags |= TypeFlags.HaveGC;
-            Marshal.WriteIntPtr(type, TypeOffset.tp_flags, (IntPtr)flags);
+            Util.WriteCLong(type, TypeOffset.tp_flags, flags);
 
             CopySlot(base_, type, TypeOffset.tp_traverse);
             CopySlot(base_, type, TypeOffset.tp_clear);


### PR DESCRIPTION
On Windows 64bit systems, a C `long` is a 32 bit integer while the rest
of the world has agreed on making `sizeof(long) == sizeof(void*)`.

### What does this implement/fix? Explain your changes.

New attempt on #376

### Any other comments?

@vmuriart Do you have a test-case for PR #376?

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
