### PR TITLE
Catching exceptions from iterator MoveNext() (related to #475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added `clr.GetClrType` (#432, #433)
 -   Allowed passing `None` for nullable args (#460)
 -   Added keyword arguments based on C# syntax for calling CPython methods (#461)
+-   Catches exceptions thrown in C# iterators (yield returns) and rethrows them in python (#475)
 
 ### Changed
 

--- a/src/runtime/iterator.cs
+++ b/src/runtime/iterator.cs
@@ -23,9 +23,21 @@ namespace Python.Runtime
         public static IntPtr tp_iternext(IntPtr ob)
         {
             var self = GetManagedObject(ob) as Iterator;
-            if (!self.iter.MoveNext())
+            try
             {
-                Exceptions.SetError(Exceptions.StopIteration, Runtime.PyNone);
+                if (!self.iter.MoveNext())
+                {
+                    Exceptions.SetError(Exceptions.StopIteration, Runtime.PyNone);
+                    return IntPtr.Zero;
+                }
+            }
+            catch (Exception e)
+            {
+                if (e.InnerException != null)
+                {
+                    e = e.InnerException;
+                }
+                Exceptions.SetError(e);
                 return IntPtr.Zero;
             }
             object item = self.iter.Current;

--- a/src/testing/exceptiontest.cs
+++ b/src/testing/exceptiontest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Python.Test
 {
@@ -51,6 +53,13 @@ namespace Python.Test
 
         public static bool ThrowException()
         {
+            throw new OverflowException("error");
+        }
+
+        public static IEnumerable<int> ThrowExceptionInIterator()
+        {
+            yield return 1;
+            yield return 2;
             throw new OverflowException("error");
         }
 

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -345,3 +345,17 @@ def test_chained_exceptions():
         assert exc.Message == msg
         assert exc.__cause__ == exc.InnerException
         exc = exc.__cause__
+
+def test_iteration_exception():
+    from Python.Test import ExceptionTest
+    from System import OverflowException
+
+    val = ExceptionTest.ThrowExceptionInIterator().__iter__()
+    assert next(val) == 1
+    assert next(val) == 2
+    with pytest.raises(OverflowException) as cm:
+        next(val)
+
+    exc = cm.value 
+
+    assert isinstance(exc, OverflowException)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Catches exceptions in iterator MoveNext() and throws them in python instead of crashing.

### Does this close any currently open issues?
Issue #475.
### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
