### PR TITLE
Use PyPI published version of codecov

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@
 pytest
 coverage
 
+# Coverage upload
+codecov
+
 # Platform specific requirements
 pip; sys_platform == 'win32'
 wheel; sys_platform == 'win32'
 pycparser; sys_platform != 'win32'
-
-# Coverage upload
-# codecov v2.0.6 isn't on PyPi
-https://github.com/codecov/codecov-python/tarball/v2.0.6


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Currently, a github tag is used for the codecov requirement in requirements.txt. This PR replaces that with the regular PyPI version.

### Does this close any currently open issues?
No.
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.
