### PR TITLE
Adds method name to "no method matches" error

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,7 @@
 
 ## Contributors
 
+-   Alexandre Catarino([@AlexCatarino](https://github.com/AlexCatarino))
 -   Arvid JB ([@ArvidJB](https://github.com/ArvidJB))
 -   Bradley Friedman ([@leith-bartrich](https://github.com/leith-bartrich))
 -   Christian Heimes ([@tiran](https://github.com/tiran))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Fixed conversion of 'float' and 'double' values (#486)
 -   Fixed 'clrmethod' for python 2 (#492)
 -   Fixed double calling of constructor when deriving from .NET class (#495)
+-   Fixed missing information on 'No method matches given arguments' by adding the method name
 
 
 ## [2.3.0][] - 2017-03-11

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -507,7 +507,7 @@ namespace Python.Runtime
 
             if (binding == null)
             {
-                Exceptions.SetError(Exceptions.TypeError, "No method matches given arguments");
+                Exceptions.SetError(Exceptions.TypeError, "No method matches given arguments for " + methodinfo[0].Name);
                 return IntPtr.Zero;
             }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
When a method does not find a match for given arguments, the thrown runtime error message does not informs us which method call failed

### Does this close any currently open issues?
No.

### Any other comments?
No.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
