### PR TITLE
Marshalling fix for 3-IntPtr args cdecl calls.

### DIFF
--- a/src/runtime/nativecall.cs
+++ b/src/runtime/nativecall.cs
@@ -28,9 +28,6 @@ namespace Python.Runtime
         private delegate void Void_1_Delegate(IntPtr a1);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate IntPtr IntPtr_3_Delegate(IntPtr a1, IntPtr a2, IntPtr a3);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int Int_3_Delegate(IntPtr a1, IntPtr a2, IntPtr a3);
 
         public static void Void_Call_1(IntPtr fp, IntPtr a1)
@@ -40,7 +37,8 @@ namespace Python.Runtime
 
         public static IntPtr Call_3(IntPtr fp, IntPtr a1, IntPtr a2, IntPtr a3)
         {
-            return ((IntPtr_3_Delegate)Marshal.GetDelegateForFunctionPointer(fp, typeof(IntPtr_3_Delegate)))(a1, a2, a3);
+            var d = (Interop.TernaryFunc)Marshal.GetDelegateForFunctionPointer(fp, typeof(Interop.TernaryFunc));
+            return d(a1, a2, a3);
         }
 
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Workaround for the DotNet Core 2.0 marshaling bug.
Problem described here https://github.com/pythonnet/pythonnet/issues/96#issuecomment-329542908
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
