### PR TITLE
WIP: Combine #546 and #531

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Fixed
 
+-   Fixed interop methods with Py_ssize_t. NetCoreApp 2.0 is more sensitive than net40 and requires this fix. 
 -   Fixed Visual Studio 2017 compat (#434) for setup.py
 -   Fixed crash on exit of the Python interpreter if a python class
     derived from a .NET class has a `__namespace__` or `__assembly__`

--- a/src/embed_tests/TestPySequence.cs
+++ b/src/embed_tests/TestPySequence.cs
@@ -69,10 +69,8 @@ namespace Python.EmbeddingTest
             PyObject actual = t1.Repeat(3);
             Assert.AreEqual("FooFooFoo", actual.ToString());
 
-            // On 32 bit system this argument should be int, but on the 64 bit system this should be long value.
-            // This works on the Framework 4.0 accidentally, it should produce out of memory!
-            // actual = t1.Repeat(-3);
-            // Assert.AreEqual("", actual.ToString());
+            actual = t1.Repeat(-3);
+            Assert.AreEqual("", actual.ToString());
         }
 
         [Test]

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -176,7 +176,7 @@
 
   <Target Name="BeforeBuild" Condition="'$(TargetFramework)'=='net40' AND $(Configuration.Contains('Mono')) AND '$(OS)' != 'Windows_NT'">
     <!--Endless war!-->
-    <Exec Command="cp $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.XML.dll $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.Xml.dll" />
+    <!-- <Exec Command="cp $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.XML.dll $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.Xml.dll"/> -->
   </Target>
   <Target Name="AfterBuild">
     <Copy Condition="'$(TargetFramework)'=='net40'" SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -32,6 +32,7 @@
     <DefineConstants Condition="'$(TargetFramework)'=='netstandard2.0'">$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(CustomDefineConstants)' != '' AND $(Configuration.Contains('Debug'))">$(DefineConstants);TRACE;DEBUG</DefineConstants>
     <FrameworkPathOverride Condition="'$(TargetFramework)'=='net40' AND $(Configuration.Contains('Mono'))">$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.5\1.0.1\lib\net45\</FrameworkPathOverride>
+<<<<<<< HEAD
     <Python2Version>$(PYTHONNET_PY2_VERSION)</Python2Version>
     <Python2Version Condition="'$(Python2Version)'==''">PYTHON27</Python2Version>
     <Python3Version>$(PYTHONNET_PY3_VERSION)</Python3Version>
@@ -40,6 +41,8 @@
     <PythonWinDefineConstants Condition="'$(PythonWinDefineConstants)'==''">UCS2</PythonWinDefineConstants>
     <PythonMonoDefineConstants>$(PYTHONNET_MONO_DEFINE_CONSTANTS)</PythonMonoDefineConstants>
     <PythonMonoDefineConstants Condition="'$(PythonMonoDefineConstants)'==''">UCS4;MONO_LINUX;PYTHON_WITH_PYMALLOC</PythonMonoDefineConstants>
+=======
+>>>>>>> PYTHONNET_INTEROP_FILE env var introduced to allow working with custom interop*.cs file inside IDE.
     <PythonInteropFile Condition="'$(PythonInteropFile)'==''">$(PYTHONNET_INTEROP_FILE)</PythonInteropFile>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Debug')) AND '$(TargetFramework)'=='net40'">

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -48,6 +48,7 @@
   <PropertyGroup Condition="$(Configuration.Contains('Debug')) AND '$(TargetFramework)'=='net40'">
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
+<<<<<<< HEAD
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Release')) AND '$(TargetFramework)'=='net40'">
     <Optimize>true</Optimize>
@@ -87,6 +88,47 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
     <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;$(Python3Version);$(PythonWinDefineConstants);TRACE;DEBUG</DefineConstants>
+=======
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('Release')) AND '$(TargetFramework)'=='net40'">
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('Debug')) AND '$(TargetFramework)'=='netstandard2.0'">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('Release')) AND '$(TargetFramework)'=='netstandard2.0'">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>true</Optimize>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMono'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS4</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMonoPY3'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS4</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'DebugMono'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'DebugMonoPY3'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS4;TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWin'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS2</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWinPY3'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS2</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'DebugWin'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
+    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS2;TRACE;DEBUG</DefineConstants>
+>>>>>>> pdb generation improved for all conditions Net 4.0/NetStandard 2.0 x Debug/Release.
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(PythonInteropFile)' != '' ">

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -32,7 +32,6 @@
     <DefineConstants Condition="'$(TargetFramework)'=='netstandard2.0'">$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(CustomDefineConstants)' != '' AND $(Configuration.Contains('Debug'))">$(DefineConstants);TRACE;DEBUG</DefineConstants>
     <FrameworkPathOverride Condition="'$(TargetFramework)'=='net40' AND $(Configuration.Contains('Mono'))">$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.5\1.0.1\lib\net45\</FrameworkPathOverride>
-<<<<<<< HEAD
     <Python2Version>$(PYTHONNET_PY2_VERSION)</Python2Version>
     <Python2Version Condition="'$(Python2Version)'==''">PYTHON27</Python2Version>
     <Python3Version>$(PYTHONNET_PY3_VERSION)</Python3Version>
@@ -41,14 +40,11 @@
     <PythonWinDefineConstants Condition="'$(PythonWinDefineConstants)'==''">UCS2</PythonWinDefineConstants>
     <PythonMonoDefineConstants>$(PYTHONNET_MONO_DEFINE_CONSTANTS)</PythonMonoDefineConstants>
     <PythonMonoDefineConstants Condition="'$(PythonMonoDefineConstants)'==''">UCS4;MONO_LINUX;PYTHON_WITH_PYMALLOC</PythonMonoDefineConstants>
-=======
->>>>>>> PYTHONNET_INTEROP_FILE env var introduced to allow working with custom interop*.cs file inside IDE.
     <PythonInteropFile Condition="'$(PythonInteropFile)'==''">$(PYTHONNET_INTEROP_FILE)</PythonInteropFile>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Debug')) AND '$(TargetFramework)'=='net40'">
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
-<<<<<<< HEAD
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Release')) AND '$(TargetFramework)'=='net40'">
     <Optimize>true</Optimize>
@@ -88,47 +84,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
     <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;$(Python3Version);$(PythonWinDefineConstants);TRACE;DEBUG</DefineConstants>
-=======
-  </PropertyGroup>
-  <PropertyGroup Condition="$(Configuration.Contains('Release')) AND '$(TargetFramework)'=='net40'">
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(Configuration.Contains('Debug')) AND '$(TargetFramework)'=='netstandard2.0'">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
-    <DebugType>full</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(Configuration.Contains('Release')) AND '$(TargetFramework)'=='netstandard2.0'">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>true</Optimize>
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMono'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS4</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMonoPY3'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS4</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'DebugMono'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'DebugMonoPY3'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS4;TRACE;DEBUG</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWin'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS2</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWinPY3'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS2</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'DebugWin'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
-    <DefineConstants Condition="'$(CustomDefineConstants)' == ''">$(DefineConstants);PYTHON3;PYTHON36;UCS2;TRACE;DEBUG</DefineConstants>
->>>>>>> pdb generation improved for all conditions Net 4.0/NetStandard 2.0 x Debug/Release.
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(PythonInteropFile)' != '' ">
@@ -176,7 +131,7 @@
 
   <Target Name="BeforeBuild" Condition="'$(TargetFramework)'=='net40' AND $(Configuration.Contains('Mono')) AND '$(OS)' != 'Windows_NT'">
     <!--Endless war!-->
-    <!-- <Exec Command="cp $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.XML.dll $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.Xml.dll"/> -->
+    <Exec Command="cp $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.XML.dll $(NuGetPackageRoot)/microsoft.targetingpack.netframework.v4.5/1.0.1/lib/net45/System.Xml.dll" />
   </Target>
   <Target Name="AfterBuild">
     <Copy Condition="'$(TargetFramework)'=='net40'" SourceFiles="$(TargetAssembly)" DestinationFolder="$(PythonBuildDir)" />

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -276,7 +276,7 @@ namespace Python.Runtime
         /// </remarks>
         public static bool ErrorOccurred()
         {
-            return Runtime.PyErr_Occurred() != 0;
+            return Runtime.PyErr_Occurred() != IntPtr.Zero;
         }
 
         /// <summary>

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -420,7 +420,7 @@ namespace Python.Runtime
         /// </remarks>
         internal static void CheckExceptionOccurred()
         {
-            if (PyErr_Occurred() != 0)
+            if (PyErr_Occurred() != IntPtr.Zero)
             {
                 throw new PythonException();
             }
@@ -902,8 +902,13 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyObject_Not(IntPtr pointer);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyObject_Size(IntPtr pointer);
+        internal static int PyObject_Size(IntPtr pointer)
+        {
+            return (int) _PyObject_Size(pointer);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyObject_Size")]
+        private static extern IntPtr _PyObject_Size(IntPtr pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyObject_Hash(IntPtr op);
@@ -1133,26 +1138,61 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool PySequence_Check(IntPtr pointer);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PySequence_GetItem(IntPtr pointer, int index);
+        internal static IntPtr PySequence_GetItem(IntPtr pointer, int index)
+        {
+            return PySequence_GetItem(pointer, (IntPtr) index);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PySequence_SetItem(IntPtr pointer, int index, IntPtr value);
+        private static extern IntPtr PySequence_GetItem(IntPtr pointer, IntPtr index);
+
+        internal static int PySequence_SetItem(IntPtr pointer, int index, IntPtr value)
+        {
+            return PySequence_SetItem(pointer, (IntPtr)index, value);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PySequence_DelItem(IntPtr pointer, int index);
+        private static extern int PySequence_SetItem(IntPtr pointer, IntPtr index, IntPtr value);
+
+        internal static int PySequence_DelItem(IntPtr pointer, int index)
+        {
+            return PySequence_DelItem(pointer, (IntPtr)index);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PySequence_GetSlice(IntPtr pointer, int i1, int i2);
+        private static extern int PySequence_DelItem(IntPtr pointer, IntPtr index);
+
+        internal static IntPtr PySequence_GetSlice(IntPtr pointer, int i1, int i2)
+        {
+            return PySequence_GetSlice(pointer, (IntPtr)i1, (IntPtr)i2);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PySequence_SetSlice(IntPtr pointer, int i1, int i2, IntPtr v);
+        private static extern IntPtr PySequence_GetSlice(IntPtr pointer, IntPtr i1, IntPtr i2);
+
+        internal static int PySequence_SetSlice(IntPtr pointer, int i1, int i2, IntPtr v)
+        {
+            return PySequence_SetSlice(pointer, (IntPtr) i1, (IntPtr) i2, v);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PySequence_DelSlice(IntPtr pointer, int i1, int i2);
+        private static extern int PySequence_SetSlice(IntPtr pointer, IntPtr i1, IntPtr i2, IntPtr v);
+
+        internal static int PySequence_DelSlice(IntPtr pointer, int i1, int i2)
+        {
+            return PySequence_DelSlice(pointer, (IntPtr) i1, (IntPtr) i2);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PySequence_Size(IntPtr pointer);
+        private static extern int PySequence_DelSlice(IntPtr pointer, IntPtr i1, IntPtr i2);
+
+        internal static int PySequence_Size(IntPtr pointer)
+        {
+            return (int) _PySequence_Size(pointer);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PySequence_Size")]
+        private static extern IntPtr _PySequence_Size(IntPtr pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PySequence_Contains(IntPtr pointer, IntPtr item);
@@ -1160,14 +1200,24 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PySequence_Concat(IntPtr pointer, IntPtr other);
 
+        internal static IntPtr PySequence_Repeat(IntPtr pointer, int count)
+        {
+            return PySequence_Repeat(pointer, (IntPtr) count);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PySequence_Repeat(IntPtr pointer, int count);
+        private static extern IntPtr PySequence_Repeat(IntPtr pointer, IntPtr count);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PySequence_Index(IntPtr pointer, IntPtr item);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PySequence_Count(IntPtr pointer, IntPtr value);
+        internal static int PySequence_Count(IntPtr pointer, IntPtr value)
+        {
+            return (int) _PySequence_Count(pointer, value);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PySequence_Count")]
+        private static extern IntPtr _PySequence_Count(IntPtr pointer, IntPtr value);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PySequence_Tuple(IntPtr pointer);
@@ -1200,26 +1250,46 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyBytes_FromString(string op);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyBytes_Size(IntPtr op);
+        internal static int PyBytes_Size(IntPtr op)
+        {
+            return (int) _PyBytes_Size(op);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyBytes_Size")]
+        private static extern IntPtr _PyBytes_Size(IntPtr op);
 
         internal static IntPtr PyBytes_AS_STRING(IntPtr ob)
         {
             return ob + BytesOffset.ob_sval;
         }
 
+        internal static IntPtr PyString_FromStringAndSize(string value, int size)
+        {
+            return _PyString_FromStringAndSize(value, (IntPtr) size);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
             EntryPoint = "PyUnicode_FromStringAndSize")]
-        internal static extern IntPtr PyString_FromStringAndSize(
+        internal static extern IntPtr _PyString_FromStringAndSize(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string value,
-            int size
+            IntPtr size
         );
 
+        internal static IntPtr PyUnicode_FromStringAndSize(IntPtr value, int size)
+        {
+            return PyUnicode_FromStringAndSize(value, (IntPtr) size);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyUnicode_FromStringAndSize(IntPtr value, int size);
+        private static extern IntPtr PyUnicode_FromStringAndSize(IntPtr value, IntPtr size);
 #elif PYTHON2
+        internal static IntPtr PyString_FromStringAndSize(string value, int size)
+        {
+            return PyString_FromStringAndSize(value, (IntPtr) size);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyString_FromStringAndSize(string value, int size);
+        private static extern IntPtr PyString_FromStringAndSize(string value, IntPtr size);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyString_AsString(IntPtr op);
@@ -1240,11 +1310,16 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyUnicode_FromEncodedObject(IntPtr ob, IntPtr enc, IntPtr err);
 
+        internal static IntPtr PyUnicode_FromKindAndData(int kind, string s, int size)
+        {
+            return PyUnicode_FromKindAndData(kind, s, (IntPtr) size);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyUnicode_FromKindAndData(
+        private static extern IntPtr PyUnicode_FromKindAndData(
             int kind,
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UcsMarshaler))] string s,
-            int size
+            IntPtr size
         );
 
         internal static IntPtr PyUnicode_FromUnicode(string s, int size)
@@ -1252,8 +1327,13 @@ namespace Python.Runtime
             return PyUnicode_FromKindAndData(_UCS, s, size);
         }
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyUnicode_GetSize(IntPtr ob);
+        internal static int PyUnicode_GetSize(IntPtr ob)
+        {
+            return (int)_PyUnicode_GetSize(ob);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyUnicode_GetSize")]
+        private static extern IntPtr _PyUnicode_GetSize(IntPtr ob);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyUnicode_AsUnicode(IntPtr ob);
@@ -1269,16 +1349,26 @@ namespace Python.Runtime
             EntryPoint = PyUnicodeEntryPoint + "FromEncodedObject")]
         internal static extern IntPtr PyUnicode_FromEncodedObject(IntPtr ob, IntPtr enc, IntPtr err);
 
+        internal static IntPtr PyUnicode_FromUnicode(string s, int size)
+        {
+            return PyUnicode_FromUnicode(s, (IntPtr) size);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
             EntryPoint = PyUnicodeEntryPoint + "FromUnicode")]
-        internal static extern IntPtr PyUnicode_FromUnicode(
+        private static extern IntPtr PyUnicode_FromUnicode(
             [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UcsMarshaler))] string s,
-            int size
+            IntPtr size
         );
+
+        internal static int PyUnicode_GetSize(IntPtr ob)
+        {
+            return (int) _PyUnicode_GetSize(ob);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
             EntryPoint = PyUnicodeEntryPoint + "GetSize")]
-        internal static extern int PyUnicode_GetSize(IntPtr ob);
+        internal static extern IntPtr _PyUnicode_GetSize(IntPtr ob);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
             EntryPoint = PyUnicodeEntryPoint + "AsUnicode")]
@@ -1387,8 +1477,13 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyDict_Clear(IntPtr pointer);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyDict_Size(IntPtr pointer);
+        internal static int PyDict_Size(IntPtr pointer)
+        {
+            return (int) _PyDict_Size(pointer);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyDict_Size")]
+        internal static extern IntPtr _PyDict_Size(IntPtr pointer);
 
 
         //====================================================================
@@ -1400,20 +1495,40 @@ namespace Python.Runtime
             return PyObject_TYPE(ob) == PyListType;
         }
 
+        internal static IntPtr PyList_New(int size)
+        {
+            return PyList_New((IntPtr) size);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyList_New(int size);
+        private static extern IntPtr PyList_New(IntPtr size);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyList_AsTuple(IntPtr pointer);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyList_GetItem(IntPtr pointer, int index);
+        internal static IntPtr PyList_GetItem(IntPtr pointer, int index)
+        {
+            return PyList_GetItem(pointer, (IntPtr) index);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyList_SetItem(IntPtr pointer, int index, IntPtr value);
+        private static extern IntPtr PyList_GetItem(IntPtr pointer, IntPtr index);
+
+        internal static int PyList_SetItem(IntPtr pointer, int index, IntPtr value)
+        {
+            return PyList_SetItem(pointer, (IntPtr) index, value);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyList_Insert(IntPtr pointer, int index, IntPtr value);
+        private static extern int PyList_SetItem(IntPtr pointer, IntPtr index, IntPtr value);
+
+        internal static int PyList_Insert(IntPtr pointer, int index, IntPtr value)
+        {
+            return PyList_Insert(pointer, (IntPtr)index, value);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int PyList_Insert(IntPtr pointer, IntPtr index, IntPtr value);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyList_Append(IntPtr pointer, IntPtr value);
@@ -1424,15 +1539,29 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyList_Sort(IntPtr pointer);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyList_GetSlice(IntPtr pointer, int start, int end);
+        internal static IntPtr PyList_GetSlice(IntPtr pointer, int start, int end)
+        {
+            return PyList_GetSlice(pointer, (IntPtr) start, (IntPtr) end);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyList_SetSlice(IntPtr pointer, int start, int end, IntPtr value);
+        private static extern IntPtr PyList_GetSlice(IntPtr pointer, IntPtr start, IntPtr end);
+
+        internal static int PyList_SetSlice(IntPtr pointer, int start, int end, IntPtr value)
+        {
+            return PyList_SetSlice(pointer, (IntPtr) start, (IntPtr) end, value);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyList_Size(IntPtr pointer);
+        private static extern int PyList_SetSlice(IntPtr pointer, IntPtr start, IntPtr end, IntPtr value);
 
+        internal static int PyList_Size(IntPtr pointer)
+        {
+            return (int) _PyList_Size(pointer);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyList_Size")]
+        private static extern IntPtr _PyList_Size(IntPtr pointer);
 
         //====================================================================
         // Python tuple API
@@ -1443,20 +1572,45 @@ namespace Python.Runtime
             return PyObject_TYPE(ob) == PyTupleType;
         }
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyTuple_New(int size);
+        internal static IntPtr PyTuple_New(int size)
+        {
+            return PyTuple_New((IntPtr) size);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyTuple_GetItem(IntPtr pointer, int index);
+        private static extern IntPtr PyTuple_New(IntPtr size);
+
+        internal static IntPtr PyTuple_GetItem(IntPtr pointer, int index)
+        {
+            return PyTuple_GetItem(pointer, (IntPtr) index);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyTuple_SetItem(IntPtr pointer, int index, IntPtr value);
+        private static extern IntPtr PyTuple_GetItem(IntPtr pointer, IntPtr index);
+
+        internal static int PyTuple_SetItem(IntPtr pointer, int index, IntPtr value)
+        {
+            return PyTuple_SetItem(pointer, (IntPtr) index, value);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyTuple_GetSlice(IntPtr pointer, int start, int end);
+        private static extern int PyTuple_SetItem(IntPtr pointer, IntPtr index, IntPtr value);
+
+        internal static IntPtr PyTuple_GetSlice(IntPtr pointer, int start, int end)
+        {
+            return PyTuple_GetSlice(pointer, (IntPtr)start, (IntPtr)end);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyTuple_Size(IntPtr pointer);
+        private static extern IntPtr PyTuple_GetSlice(IntPtr pointer, IntPtr start, IntPtr end);
+
+        internal static int PyTuple_Size(IntPtr pointer)
+        {
+            return (int) _PyTuple_Size(pointer);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyTuple_Size")]
+        private static extern IntPtr _PyTuple_Size(IntPtr pointer);
 
 
         //====================================================================
@@ -1562,8 +1716,13 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyType_GenericNew(IntPtr type, IntPtr args, IntPtr kw);
 
+        internal static IntPtr PyType_GenericAlloc(IntPtr type, int n)
+        {
+            return PyType_GenericAlloc(type, (IntPtr) n);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyType_GenericAlloc(IntPtr type, int n);
+        private static extern IntPtr PyType_GenericAlloc(IntPtr type, IntPtr n);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyType_Ready(IntPtr type);
@@ -1597,11 +1756,21 @@ namespace Python.Runtime
         // Python memory API
         //====================================================================
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyMem_Malloc(int size);
+        internal static IntPtr PyMem_Malloc(int size)
+        {
+            return PyMem_Malloc((IntPtr) size);
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyMem_Realloc(IntPtr ptr, int size);
+        private static extern IntPtr PyMem_Malloc(IntPtr size);
+
+        internal static IntPtr PyMem_Realloc(IntPtr ptr, int size)
+        {
+            return PyMem_Realloc(ptr, (IntPtr) size);
+        }
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr PyMem_Realloc(IntPtr ptr, IntPtr size);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyMem_Free(IntPtr ptr);
@@ -1633,7 +1802,7 @@ namespace Python.Runtime
         internal static extern void PyErr_NormalizeException(IntPtr ob, IntPtr val, IntPtr tb);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyErr_Occurred();
+        internal static extern IntPtr PyErr_Occurred();
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyErr_Fetch(ref IntPtr ob, ref IntPtr val, ref IntPtr tb);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -21,7 +21,7 @@ namespace Python.Runtime
         }
 #elif MONO_OSX
         private static int RTLD_GLOBAL = 0x8;
-        private const string NativeDll = "/usr/lib/libSystem.dylib"
+        private const string NativeDll = "/usr/lib/libSystem.dylib";
         private static IntPtr RTLD_DEFAULT = new IntPtr(-2);
 
         public static IntPtr LoadLibrary(string fileName)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- Supersedes two PRs by merging #546 and #531 as suggested by @dmitriyse in the discussion of #531.
- Fixed a typo in [runtime.cs](https://github.com/fractus/pythonnet/commit/6c3f31d7c087314cfc0fcad327f9a55eb6246459)
- Commented a case-sensitive copy that break the build on macOS in [Python.Runtime.15.csproj](https://github.com/fractus/pythonnet/commit/4cb92d449fcd9b8d60d63d3f6d0b95f26bfe73ee)

### Does this close any currently open issues?

No, it just now builds without problems on macOS.

### Any other comments?

- Versions used: python=3.6.3, mono=5.2.0.224, dotnet=2.0.0 on High Sierra (10.13).
- Build with `--xplat` and tested on Mono/DotNetCore projects. 
- @dmitriyse if this not appropriate; I can submit the minor fixes in a new PR

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)