### PR TITLE
fixed bug of Exec method #591

### DIFF
--- a/src/embed_tests/pyrunstring.cs
+++ b/src/embed_tests/pyrunstring.cs
@@ -57,5 +57,20 @@ namespace Python.EmbeddingTest
             object c = locals.GetItem("c").AsManagedObject(typeof(int));
             Assert.AreEqual(111, c);
         }
+
+        [Test]
+        public void TestExec2()
+        {
+            string code = @"
+class Test1():
+   pass
+
+class Test2():
+   def __init__(self):
+       Test1()
+
+Test2()";
+            PythonEngine.Exec(code);
+        }
     }
 }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -496,12 +496,10 @@ namespace Python.Runtime
                     borrowedGlobals = false;
                 }
             }
-
-            var borrowedLocals = true;
+            
             if (locals == null)
             {
-                locals = Runtime.PyDict_New();
-                borrowedLocals = false;
+                locals = globals;
             }
 
             try
@@ -516,10 +514,6 @@ namespace Python.Runtime
             }
             finally
             {
-                if (!borrowedLocals)
-                {
-                    Runtime.XDecref(locals.Value);
-                }
                 if (!borrowedGlobals)
                 {
                     Runtime.XDecref(globals.Value);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This PR makes the RunString method acts just like the exec/eval method in CPython.  

In CPython, the default value of parameter 'locals' of  exec/eval method is obtained by calling the method locals() when its given value is None.  So only when the exec/eval method is called in a function, the default value of parameter 'locals' is different from the value of  'globals'. 

Since in pythonnet the Eval/Exce method can only be called from the global/module scope, it meaningful to directly set the value of locals to the value of globals when it is null.

...

### Does this close any currently open issues?
[#591](https://github.com/pythonnet/pythonnet/issues/591)

...

### Any other comments?
No.

...

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
