### PR TITLE
PyObject was made IEnumerable

### DIFF
--- a/src/embed_tests/dynamic.cs
+++ b/src/embed_tests/dynamic.cs
@@ -103,7 +103,7 @@ namespace Python.EmbeddingTest
             Assert.AreEqual(sys.testattr3.ToString(), "True");
 
             // Compare in .NET
-            Assert.AreEqual(sys.testattr1, sys.testattr2);
+            Assert.IsTrue(sys.testattr1.Equals(sys.testattr2));
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Python.EmbeddingTest
             Assert.AreEqual(sys.testattr3.ToString(), "True");
 
             // Compare in .NET
-            Assert.AreEqual(sys.testattr1, sys.testattr2);
+            Assert.IsTrue(sys.testattr1.Equals(sys.testattr2));
         }
     }
 }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -12,7 +12,7 @@ namespace Python.Runtime
     /// PY3: https://docs.python.org/3/c-api/object.html
     /// for details.
     /// </summary>
-    public class PyObject : DynamicObject, IDisposable
+    public class PyObject : DynamicObject, IEnumerable, IDisposable
     {
         protected internal IntPtr obj = IntPtr.Zero;
         private bool disposed = false;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
enumerable python object cannot be directly enumerated through PyObject.
```C#
dynamic pyCollectionObj = new PyObject(collectionObjIntPtr);
foreach (dynamic item in pyCollectionObj)
{
    // This code currently does not works.
}
...

### Does this close any currently open issues?
No
...

### Any other comments?
Tests are failed due to NUnit Assert.Equals behavior. When object is IEnumerable Assert.Equals also compares all items.
...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
