### PR TITLE
fix for "handle is not inialized" crash on `clr.GetClrType(System.__class__)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Fixed conversion of 'float' and 'double' values (#486)
 -   Fixed 'clrmethod' for python 2 (#492)
 -   Fixed double calling of constructor when deriving from .NET class (#495)
+-   Fixed `clr.GetClrType` when iterating over `System` members (#607) 
 
 
 ## [2.3.0][] - 2017-03-11

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace Python.Runtime
@@ -34,6 +34,10 @@ namespace Python.Runtime
                     IntPtr op = tp == ob
                         ? Marshal.ReadIntPtr(tp, TypeOffset.magic())
                         : Marshal.ReadIntPtr(ob, ObjectOffset.magic(ob));
+                    if (op == IntPtr.Zero)
+                    {
+                        return null;
+                    }
                     var gc = (GCHandle)op;
                     return (ManagedType)gc.Target;
                 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

fix for "handle is not initalized" crash on `clr.GetClrType(System.__class__)`

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/606

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
