### PR TITLE
Assembly load improve: Support forward slashes in sys.path, path with…

### DIFF
--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -157,18 +157,16 @@ namespace Python.Runtime
         /// </summary>
         public static string FindAssembly(string name)
         {
-            char sep = Path.DirectorySeparatorChar;
-
             foreach (string head in pypath)
             {
-                string path;
-                if (head == null || head.Length == 0)
+                //GetFullPath is required to normalize back- and forward- slashes
+                //Combine is prefered way of combining paths
+                string path = Path.GetFullPath(Path.Combine(head ?? "", name));
+
+                //The AddReference can be called with assembly path with extensions
+                if (File.Exists(path))
                 {
-                    path = name;
-                }
-                else
-                {
-                    path = head + sep + name;
+                    return path;
                 }
 
                 string temp = path + ".dll";


### PR DESCRIPTION
… extensions

fixing #614

### What does this implement/fix? Explain your changes.

forward and backward slashes can be mixed in path combined from sys.path and assemblymanager code - Path.GetFullPath is needed to normalize this.
pre-existing extension doesn't need to be reappended

### Does this close any currently open issues?

#614

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
