### PR TITLE
Adds method name to "no method matches" error

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,7 @@
 
 ## Contributors
 
+-   Alexandre Catarino([@AlexCatarino](https://github.com/AlexCatarino))
 -   Arvid JB ([@ArvidJB](https://github.com/ArvidJB))
 -   Bradley Friedman ([@leith-bartrich](https://github.com/leith-bartrich))
 -   Callum Noble ([@callumnoble](https://github.com/callumnoble))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Fixed `Python.Runtime.dll.config` on macOS ([#120][i120])
 -   Fixed crash on `PythonEngine.Version` ([#413][i413])
 -   Fixed `PythonEngine.PythonPath` issues ([#179][i179])([#414][i414])([#415][p415])
+-   Fixed missing information on 'No method matches given arguments' by adding the method name
 
 ### Removed
 

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -507,7 +507,12 @@ namespace Python.Runtime
 
             if (binding == null)
             {
-                Exceptions.SetError(Exceptions.TypeError, "No method matches given arguments");
+                var value = "No method matches given arguments";
+                if (methodinfo != null && methodinfo.Length > 0)
+                {
+                    value += $" for {methodinfo[0].Name}";
+                }
+                Exceptions.SetError(Exceptions.TypeError, value);
                 return IntPtr.Zero;
             }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
When a method does not find a match for given arguments, the thrown runtime error message does not informs us which method call failed.

### Does this close any currently open issues?
No.

### Any other comments?
No.

### Checklist

Check all those that are applicable and complete.
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)