### PR TITLE
Removing deleted file from project

### DIFF
--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -145,7 +145,6 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(PythonInteropFile)' == '' ">
     <Compile Include="interop27.cs" />
-    <Compile Include="interop33.cs" />
     <Compile Include="interop34.cs" />
     <Compile Include="interop35.cs" />
     <Compile Include="interop36.cs" />


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This change removes the file interop33.cs from the Visual Studio project. In a previous commit, this file was deleted but was not removed from the project file.

### Does this close any currently open issues?

This fixes #688.
