### PR TITLE
Implementing GetDynamicMemberNames() for PyObject

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -28,6 +28,7 @@
 -   Jeff Reback ([@jreback](https://github.com/jreback))
 -   Joe Frayne ([@jfrayne](https://github.com/jfrayne))
 -   John Burnett ([@johnburnett](https://github.com/johnburnett))
+-   John Wilkes ([@jbw3](https://github.com/jbw3))
 -   Luke Stratman ([@lstratman](https://github.com/lstratman))
 -   Konstantin Posudevskiy ([@konstantin-posudevskiy](https://github.com/konstantin-posudevskiy))
 -   Matthias Dittrich ([@matthid](https://github.com/matthid))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added `clr.GetClrType` (#432, #433)
 -   Allowed passing `None` for nullable args (#460)
 -   Added keyword arguments based on C# syntax for calling CPython methods (#461)
+-   Implemented GetDynamicMemberNames() for PyObject to allow dynamic object members to be visible in the debugger (#443)
 
 ### Changed
 

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -26,41 +26,45 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMono'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMono'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWin'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWin'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMonoPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMonoPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS2;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWinPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS2</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">
+    </DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -93,6 +93,7 @@
     <Compile Include="TestPyList.cs" />
     <Compile Include="TestPyLong.cs" />
     <Compile Include="TestPyNumber.cs" />
+    <Compile Include="TestPyObject.cs" />
     <Compile Include="TestPySequence.cs" />
     <Compile Include="TestPyString.cs" />
     <Compile Include="TestPythonException.cs" />

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -26,45 +26,41 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMono'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMono'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">
-    </DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWin'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWin'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">
-    </DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMonoPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS4;TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMonoPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">
-    </DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS4</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">DEBUG;TRACE</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS2;TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWinPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">
-    </DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON36;UCS2</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>

--- a/src/embed_tests/TestPyObject.cs
+++ b/src/embed_tests/TestPyObject.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class TestPyObject
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void TestGetDynamicMemberNames()
+        {
+            List<string> expectedMemberNames = new List<string>
+            {
+                "__class__",
+                "__delattr__",
+                "__dict__",
+                "__dir__",
+                "__doc__",
+                "__eq__",
+                "__format__",
+                "__ge__",
+                "__getattribute__",
+                "__gt__",
+                "__hash__",
+                "__init__",
+                "__init_subclass__",
+                "__le__",
+                "__lt__",
+                "__module__",
+                "__ne__",
+                "__new__",
+                "__reduce__",
+                "__reduce_ex__",
+                "__repr__",
+                "__setattr__",
+                "__sizeof__",
+                "__str__",
+                "__subclasshook__",
+                "__weakref__",
+                "add",
+                "getNumber",
+                "member1",
+                "member2"
+            };
+
+            PyDict locals = new PyDict();
+
+            PythonEngine.Exec(@"
+class MemberNamesTest:
+    def __init__(self):
+        self.member1 = 123
+        self.member2 = 'Test string'
+
+    def getNumber(self):
+        return 123
+
+    def add(self, x, y):
+        return x + y
+
+a = MemberNamesTest()
+", null, locals.Handle);
+
+            PyObject a = locals.GetItem("a");
+
+            IEnumerable<string> membernames = a.GetDynamicMemberNames();
+
+            Assert.AreEqual(expectedMemberNames.Count, membernames.Count(), "Unexpected number of members.");
+
+            IEnumerable<Tuple<string, string>> results = expectedMemberNames.Zip(membernames, (x, y) => new Tuple<string, string>(x, y));
+            foreach (Tuple<string, string> result in results)
+            {
+                Assert.AreEqual(result.Item1, result.Item2, "Unexpected member name.");
+            }
+        }
+    }
+}

--- a/src/embed_tests/TestPyObject.cs
+++ b/src/embed_tests/TestPyObject.cs
@@ -28,20 +28,34 @@ namespace Python.EmbeddingTest
                 "__class__",
                 "__delattr__",
                 "__dict__",
+#if PYTHON3
                 "__dir__",
+#endif
                 "__doc__",
+#if PYTHON3
                 "__eq__",
+#endif
                 "__format__",
+#if PYTHON3
                 "__ge__",
+#endif
                 "__getattribute__",
+#if PYTHON3
                 "__gt__",
+#endif
                 "__hash__",
                 "__init__",
+#if PYTHON36
                 "__init_subclass__",
+#endif
+#if PYTHON3
                 "__le__",
                 "__lt__",
+#endif
                 "__module__",
+#if PYTHON3
                 "__ne__",
+#endif
                 "__new__",
                 "__reduce__",
                 "__reduce_ex__",
@@ -60,7 +74,7 @@ namespace Python.EmbeddingTest
             PyDict locals = new PyDict();
 
             PythonEngine.Exec(@"
-class MemberNamesTest:
+class MemberNamesTest(object):
     def __init__(self):
         self.member1 = 123
         self.member2 = 'Test string'

--- a/src/embed_tests/TestPyObject.cs
+++ b/src/embed_tests/TestPyObject.cs
@@ -25,46 +25,6 @@ namespace Python.EmbeddingTest
         {
             List<string> expectedMemberNames = new List<string>
             {
-                "__class__",
-                "__delattr__",
-                "__dict__",
-#if PYTHON3
-                "__dir__",
-#endif
-                "__doc__",
-#if PYTHON3
-                "__eq__",
-#endif
-                "__format__",
-#if PYTHON3
-                "__ge__",
-#endif
-                "__getattribute__",
-#if PYTHON3
-                "__gt__",
-#endif
-                "__hash__",
-                "__init__",
-#if PYTHON36
-                "__init_subclass__",
-#endif
-#if PYTHON3
-                "__le__",
-                "__lt__",
-#endif
-                "__module__",
-#if PYTHON3
-                "__ne__",
-#endif
-                "__new__",
-                "__reduce__",
-                "__reduce_ex__",
-                "__repr__",
-                "__setattr__",
-                "__sizeof__",
-                "__str__",
-                "__subclasshook__",
-                "__weakref__",
                 "add",
                 "getNumber",
                 "member1",
@@ -90,14 +50,11 @@ a = MemberNamesTest()
 
             PyObject a = locals.GetItem("a");
 
-            IEnumerable<string> membernames = a.GetDynamicMemberNames();
+            IEnumerable<string> memberNames = a.GetDynamicMemberNames();
 
-            Assert.AreEqual(expectedMemberNames.Count, membernames.Count(), "Unexpected number of members.");
-
-            IEnumerable<Tuple<string, string>> results = expectedMemberNames.Zip(membernames, (x, y) => new Tuple<string, string>(x, y));
-            foreach (Tuple<string, string> result in results)
+            foreach (string expectedName in expectedMemberNames)
             {
-                Assert.AreEqual(result.Item1, result.Item2, "Unexpected member name.");
+                Assert.IsTrue(memberNames.Contains(expectedName), "Could not find member '{0}'.", expectedName);
             }
         }
     }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq.Expressions;
 
@@ -1237,6 +1238,21 @@ namespace Python.Runtime
             }
             result = CheckNone(new PyObject(res));
             return true;
+        }
+
+        /// <summary>
+        /// Returns the enumeration of all dynamic member names.
+        /// </summary>
+        /// <remarks>
+        /// This method exists for debugging purposes only.
+        /// </remarks>
+        /// <returns>A sequence that contains dynamic member names.</returns>
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            foreach (PyObject pyObj in Dir())
+            {
+                yield return pyObj.ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This change implements GetDynamicMemberNames() for PyObject. This allows dynamic object members to be visible in the Visual Studio debugger.

### Does this close any currently open issues?

#443

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
