### PR TITLE
Fix "from import *" failed after a normal import

### DIFF
--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -184,7 +184,6 @@ namespace Python.Runtime
                 }
             }
 
-            ModuleObject mod;
             string mod_name = Runtime.GetManagedString(py_mod_name);
             // Check these BEFORE the built-in import runs; may as well
             // do the Incref()ed return here, since we've already found
@@ -240,7 +239,7 @@ namespace Python.Runtime
                     // There was no error.
                     if (fromlist && IsLoadAll(fromList))
                     {
-                        mod = ManagedType.GetManagedObject(res) as ModuleObject;
+                        var mod = ManagedType.GetManagedObject(res) as ModuleObject;
                         mod?.LoadNames();
                     }
                     return res;
@@ -298,7 +297,7 @@ namespace Python.Runtime
                 {
                     if (IsLoadAll(fromList))
                     {
-                        mod = ManagedType.GetManagedObject(module) as ModuleObject;
+                        var mod = ManagedType.GetManagedObject(module) as ModuleObject;
                         mod?.LoadNames();
                     }
                     Runtime.XIncref(module);
@@ -356,15 +355,17 @@ namespace Python.Runtime
                 }
             }
 
-            mod = fromlist ? tail : head;
-
-            if (fromlist && IsLoadAll(fromList))
             {
-                mod.LoadNames();
-            }
+                var mod = fromlist ? tail : head;
 
-            Runtime.XIncref(mod.pyHandle);
-            return mod.pyHandle;
+                if (fromlist && IsLoadAll(fromList))
+                {
+                    mod.LoadNames();
+                }
+
+                Runtime.XIncref(mod.pyHandle);
+                return mod.pyHandle;
+            }
         }
 
         private static bool IsLoadAll(IntPtr fromList)

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -190,10 +190,17 @@ namespace Python.Runtime
             foreach (string name in AssemblyManager.GetNames(_namespace))
             {
                 cache.TryGetValue(name, out m);
-                if (m == null)
+                if (m != null)
                 {
-                    ManagedType attr = GetAttribute(name, true);
+                    continue;
                 }
+                IntPtr attr = Runtime.PyDict_GetItemString(dict, name);
+                // If __dict__ has already set a custom property, skip it.
+                if (attr != IntPtr.Zero)
+                {
+                    continue;
+                }
+                GetAttribute(name, true);
             }
         }
 

--- a/src/tests/importtest.py
+++ b/src/tests/importtest.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import sys
+try:
+    del sys.modules["System.IO"]
+except KeyError:
+    pass
+
+assert "FileStream" not in globals()
+import System.IO
+from System.IO import *
+
+assert "FileStream" in globals()

--- a/src/tests/test_import.py
+++ b/src/tests/test_import.py
@@ -14,7 +14,7 @@ def test_relative_missing_import():
 
 
 def test_import_all_on_second_time():
-    """Test import all attributes after a normal.
+    """Test import all attributes after a normal import without '*'.
     Due to import * only allowed at module level, the test body splited
     to a module file."""
     from . import importtest

--- a/src/tests/test_import.py
+++ b/src/tests/test_import.py
@@ -14,6 +14,9 @@ def test_relative_missing_import():
 
 
 def test_import_all_on_second_time():
+    """Test import all attributes after a normal.
+    Due to import * only allowed at module level, the test body splited
+    to a module file."""
     from . import importtest
     del sys.modules[importtest.__name__]
     

--- a/src/tests/test_import.py
+++ b/src/tests/test_import.py
@@ -3,7 +3,7 @@
 """Test the import statement."""
 
 import pytest
-
+import sys
 
 def test_relative_missing_import():
     """Test that a relative missing import doesn't crash.
@@ -11,3 +11,9 @@ def test_relative_missing_import():
     Relative import in the site-packages folder"""
     with pytest.raises(ImportError):
         from . import _missing_import
+
+
+def test_import_all_on_second_time():
+    from . import importtest
+    del sys.modules[importtest.__name__]
+    


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
If module has been imported for once, `from module import *` can only get the attributes which in `__dict__`.
This PR add a check and load for every time when `import *` if it's a CLR module.

### Does this close any currently open issues?

...

### Any other comments?

Perhaps we can ignore changes after `import *`, and just enough for callling `ModuleObject.LoadNames` once.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
