### PR TITLE
Inheritance not working with non-abstract base methods

### DIFF
--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -601,6 +601,19 @@ namespace Python.Runtime
     {
         int IComparer.Compare(object m1, object m2)
         {
+            var me1 = (MethodBase)m1;
+            var me2 = (MethodBase)m2;
+            if (me1.DeclaringType != me2.DeclaringType)
+            {
+                // m2's type derives from m1's type, favor m2
+                if (me1.DeclaringType.IsAssignableFrom(me2.DeclaringType))
+                    return 1;
+
+                // m1's type derives from m2's type, favor m1
+                if (me2.DeclaringType.IsAssignableFrom(me1.DeclaringType))
+                    return -1;
+            }
+
             int p1 = MethodBinder.GetPrecedence((MethodBase)m1);
             int p2 = MethodBinder.GetPrecedence((MethodBase)m2);
             if (p1 < p2)


### PR DESCRIPTION
Fixes #755. Also check https://stackoverflow.com/questions/52868552/why-does-python-net-use-the-base-method-instead-of-the-method-from-a-derived-cla