### PR TITLE
Allow user code to register for a callback on shutdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
     Currently there two side-by-side build systems that produces the same output (net40) from the same sources.
     After a some transition time, current (mono/ msbuild 14.0) build system will be removed.
 -   NUnit upgraded to 3.7 (eliminates travis-ci random bug)
+-   Added C# `PythonEngine.AddShutdownHandler` to help client code clean up on shutdown.
 -   Added `clr.GetClrType` ([#432][i432])([#433][p433])
 -   Allowed passing `None` for nullable args ([#460][p460])
 -   Added keyword arguments based on C# syntax for calling CPython methods ([#461][p461])
@@ -598,6 +599,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 [1.0.0]: https://github.com/pythonnet/pythonnet/releases/tag/1.0
 
+[i714]: https://github.com/pythonnet/pythonnet/issues/714
 [i608]: https://github.com/pythonnet/pythonnet/issues/608
 [i443]: https://github.com/pythonnet/pythonnet/issues/443
 [p690]: https://github.com/pythonnet/pythonnet/pull/690

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -168,6 +168,16 @@ namespace Python.Runtime
                 initialized = true;
                 Exceptions.Clear();
 
+                // Make sure we clean up properly on app domain unload.
+                AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
+
+                // Remember to shut down the runtime.
+                AddShutdownHandler(Runtime.Shutdown);
+
+                // The global scope gets used implicitly quite early on, remember
+                // to clear it out when we shut down.
+                AddShutdownHandler(PyScopeManager.Global.Clear);
+
                 if (setSysArgv)
                 {
                     Py.SetArgv(args);
@@ -220,9 +230,6 @@ namespace Python.Runtime
                 {
                     locals.Dispose();
                 }
-
-                // Make sure we clean up properly on app domain unload.
-                AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
             }
         }
 
@@ -302,7 +309,12 @@ namespace Python.Runtime
         {
             if (initialized)
             {
-                PyScopeManager.Global.Clear();
+                // If the shutdown handlers trigger a domain unload,
+                // don't call shutdown again.
+                AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
+
+                ExecuteShutdownHandlers();
+
                 Marshal.FreeHGlobal(_pythonHome);
                 _pythonHome = IntPtr.Zero;
                 Marshal.FreeHGlobal(_programName);
@@ -310,13 +322,73 @@ namespace Python.Runtime
                 Marshal.FreeHGlobal(_pythonPath);
                 _pythonPath = IntPtr.Zero;
 
-                Runtime.Shutdown();
-
-                AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
                 initialized = false;
             }
         }
 
+        /// <summary>
+        /// Called when the engine is shut down.
+        ///
+        /// Shutdown handlers are run in reverse order they were added, so that
+        /// resources available when running a shutdown handler are the same as
+        /// what was available when it was added.
+        /// </summary>
+        public delegate void ShutdownHandler();
+
+        static List<ShutdownHandler> ShutdownHandlers = new List<ShutdownHandler>();
+
+        /// <summary>
+        /// Add a function to be called when the engine is shut down.
+        ///
+        /// Shutdown handlers are executed in the opposite order they were
+        /// added, so that you can be sure that everything that was initialized
+        /// when you added the handler is still initialized when you need to shut
+        /// down.
+        ///
+        /// If the same shutdown handler is added several times, it will be run
+        /// several times.
+        ///
+        /// Don't add shutdown handlers while running a shutdown handler.
+        /// </summary>
+        public static void AddShutdownHandler(ShutdownHandler handler)
+        {
+            ShutdownHandlers.Add(handler);
+        }
+
+        /// <summary>
+        /// Remove a shutdown handler.
+        ///
+        /// If the same shutdown handler is added several times, only the last
+        /// one is removed.
+        ///
+        /// Don't remove shutdown handlers while running a shutdown handler.
+        /// </summary>
+        public static void RemoveShutdownHandler(ShutdownHandler handler)
+        {
+            for (int index = ShutdownHandlers.Count - 1; index >= 0; --index)
+            {
+                if (ShutdownHandlers[index] == handler)
+                {
+                    ShutdownHandlers.RemoveAt(index);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Run all the shutdown handlers.
+        ///
+        /// They're run in opposite order they were added.
+        /// </summary>
+        static void ExecuteShutdownHandlers()
+        {
+            while(ShutdownHandlers.Count > 0)
+            {
+                var handler = ShutdownHandlers[ShutdownHandlers.Count - 1];
+                ShutdownHandlers.RemoveAt(ShutdownHandlers.Count - 1);
+                handler();
+            }
+        }
 
         /// <summary>
         /// AcquireLock Method


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

New feature: allow user code to clean up before python.net shuts down. We use it in a client-server architecture, with python.net on the server and a pyside UI on the client. This callback lets us clean up gracefully.

I decided to also use the feature in order to help PythonEngine itself set up / shut down correctly, because dog food is tasty. And there's a unit test.

### Does this close any currently open issues?

Not on pythonnet.

### Any other comments?

I'm not clear on the division of labour between PythonEngine and Runtime. User code tells the PythonEngine to initialize, not the runtime, so that seemed the place to put the shutdown handler.

But it could just as well be in the runtime, and the runtime also needs the same pattern of building up / tearing down in the opposite order. User code could still think it's PythonEngine handling it (just make PythonEngine.AddShutdownHandler call Runtime.AddShutdownHandler).

Thoughts?

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
===> where? On the wiki?
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
