### PR TITLE
=Avoid converting ObservableCollection<T> into python list

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.ComponentModel;
 
 namespace Python.Runtime
 {
@@ -134,8 +135,8 @@ namespace Python.Runtime
                 return result;
             }
 
-            if (value is IList && value.GetType().IsGenericType)
-            {
+			if (value is IList && !(value is INotifyPropertyChanged) && value.GetType().IsGenericType)
+			{
                 using (var resultlist = new PyList())
                 {
                     foreach (object o in (IEnumerable)value)


### PR DESCRIPTION
Avoid converting objects implementing INotifyPropertyChanged (eg:ObservableCollection<T>) into python list. This would fix https://github.com/pythonnet/pythonnet/issues/770
