### PR TITLE
clr.FindAssembly() method,throw exception when file not found.

### DIFF
--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -451,7 +451,12 @@ namespace Python.Runtime
         public static string FindAssembly(string name)
         {
             AssemblyManager.UpdatePath();
-            return AssemblyManager.FindAssembly(name);
+            string assemblyName = AssemblyManager.FindAssembly(name);
+            if (assemblyName == null)
+            {
+                throw new FileNotFoundException($"Unable to find assembly '{name}' dll or exe.");
+            }
+            return assemblyName;
         }
 
         [ModuleFunction]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

clr.FindAssembly() method,throw exception when file not found.

### Does this close any currently open issues?

maybe

### Any other comments?

no

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
