### PR TITLE
List installed Win10 SDK's when looking for windows sdk tool

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -55,6 +55,7 @@
 -   ([@civilx64](https://github.com/civilx64))
 -   ([@GSPP](https://github.com/GSPP))
 -   ([@omnicognate](https://github.com/omnicognate))
+-   ([@OneBlue](https://github.com/OneBlue))
 -   ([@rico-chet](https://github.com/rico-chet))
 -   ([@rmadsen-ks](https://github.com/rmadsen-ks))
 -   ([@stonebig](https://github.com/stonebig))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ## [unreleased][]
 
+-   Look for installed Windows 10 sdk's during installation instead of relying on specific versions.
+
 ### Added
 
 -   Added support for embedding python into dotnet core 2.0 (NetStandard 2.0)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When I try to run `setup.py install`, the installation failed with the following error:
```
RuntimeError: mt.exe could not be found
```

Because setup.py is searching for specific versions of the Windows 10 sdk.

This patch changes that behaviour to use the installed Windows 10 sdk instead of relying on specific versions.

### Does this close any currently open issues?
No.

### Any other comments?
I kept the existing hard-coded sdk version to ensure that this is a non-breaking change.

The objective of this patch is make installation easier.


### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
