### PR TITLE
fix #732 - add NoZone to allowed zones

### DIFF
--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -416,7 +416,7 @@ namespace Python.Runtime
             if (System.IO.File.Exists(name))
             {
                 var zone = System.Security.Policy.Zone.CreateFromUrl(name);
-                if (zone.SecurityZone != System.Security.SecurityZone.MyComputer)
+                if ((zone.SecurityZone != System.Security.SecurityZone.MyComputer) && (zone.SecurityZone != System.Security.SecurityZone.NoZone))
                 {
                      throw new Exception($"File is blocked (NTFS Security)");
                 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
In addition to 'MyComputer', add 'NoZone' to the list of allowed zones.
System.Security.SecurityZone.NoZone is added to the allowed zones in order to prevent "File is blocked (NTFS Security)" error on certain Windows and mac installations. 
Fixes issue #732.
...

### Does this close any currently open issues?
fixes issue 732
...

### Any other comments?
only tested locally on a windows 7 installation
...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
