### PR TITLE
Revert zone check for assembly loading

### DIFF
--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -413,14 +413,6 @@ namespace Python.Runtime
             {
                 assembly = AssemblyManager.LoadAssemblyFullPath(name);
             }
-            if (System.IO.File.Exists(name))
-            {
-                var zone = System.Security.Policy.Zone.CreateFromUrl(name);
-                if (zone.SecurityZone != System.Security.SecurityZone.MyComputer)
-                {
-                     throw new Exception($"File is blocked (NTFS Security)");
-                }
-            }
             if (assembly == null)
             {
                 throw new FileNotFoundException($"Unable to find assembly '{name}'.");


### PR DESCRIPTION
Reverts pythonnet/pythonnet#655, "contains #841" and fixes #732 .

If anyone (in particular @icetiger1974 who contributed this patch) wants to have another go on it, please ensure that only the actually thrown exception message is modified instead of introducing a whole new error condition.