### PR TITLE
Improve "No method matches given arguments" message with more details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Changed
 
+-   Added argument types information to "No method matches given arguments" message
+
 ### Fixed
 
 ## [2.4.0][]

--- a/src/embed_tests/TestCallbacks.cs
+++ b/src/embed_tests/TestCallbacks.cs
@@ -1,0 +1,30 @@
+using System;
+
+using NUnit.Framework;
+using Python.Runtime;
+
+namespace Python.EmbeddingTest {
+    public class TestCallbacks {
+        [OneTimeSetUp]
+        public void SetUp() {
+            string path = Environment.GetEnvironmentVariable("PATH");
+        }
+
+        [OneTimeTearDown]
+        public void Dispose() {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void TestNoOverloadException() {
+            int passed = 0;
+            var aFunctionThatCallsIntoPython = new Action<int>(value => passed = value);
+            using (Py.GIL()) {
+                dynamic callWith42 = PythonEngine.Eval("lambda f: f([42])");
+                var error =  Assert.Throws<PythonException>(() => callWith42(aFunctionThatCallsIntoPython.ToPython()));
+                Assert.AreEqual("TypeError", error.PythonTypeName);
+                StringAssert.EndsWith("(<class 'list'>)", error.Message);
+            }
+        }
+    }
+}

--- a/src/embed_tests/TestCallbacks.cs
+++ b/src/embed_tests/TestCallbacks.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 using Python.Runtime;
 
 namespace Python.EmbeddingTest {
+    using Runtime = Python.Runtime.Runtime;
+
     public class TestCallbacks {
         [OneTimeSetUp]
         public void SetUp() {
@@ -23,7 +25,10 @@ namespace Python.EmbeddingTest {
                 dynamic callWith42 = PythonEngine.Eval("lambda f: f([42])");
                 var error =  Assert.Throws<PythonException>(() => callWith42(aFunctionThatCallsIntoPython.ToPython()));
                 Assert.AreEqual("TypeError", error.PythonTypeName);
-                StringAssert.EndsWith("(<class 'list'>)", error.Message);
+                string expectedArgTypes = Runtime.IsPython2
+                    ? "(<type 'list'>)"
+                    : "(<class 'list'>)";
+                StringAssert.EndsWith(expectedArgTypes, error.Message);
             }
         }
     }

--- a/src/embed_tests/TestCallbacks.cs
+++ b/src/embed_tests/TestCallbacks.cs
@@ -7,7 +7,7 @@ namespace Python.EmbeddingTest {
     public class TestCallbacks {
         [OneTimeSetUp]
         public void SetUp() {
-            string path = Environment.GetEnvironmentVariable("PATH");
+            PythonEngine.Initialize();
         }
 
         [OneTimeTearDown]

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Reflection;
+using System.Text;
 
 namespace Python.Runtime
 {
@@ -555,32 +556,36 @@ namespace Python.Runtime
 
             if (binding == null)
             {
-                var value = "No method matches given arguments";
+                var value = new StringBuilder("No method matches given arguments");
                 if (methodinfo != null && methodinfo.Length > 0)
                 {
-                    value += $" for {methodinfo[0].Name}";
+                    value.Append($" for {methodinfo[0].Name}");
                 }
 
                 long argCount = Runtime.PyTuple_Size(args);
-                value += ": (";
+                value.Append(": (");
                 for(long argIndex = 0; argIndex < argCount; argIndex++) {
                     var arg = Runtime.PyTuple_GetItem(args, argIndex);
                     if (arg != IntPtr.Zero) {
                         var type = Runtime.PyObject_Type(arg);
                         if (type != IntPtr.Zero) {
-                            var description = Runtime.PyObject_Unicode(type);
-                            if (description != IntPtr.Zero) {
-                                value += Runtime.GetManagedString(description);
-                                Runtime.XDecref(description);
+                            try {
+                                var description = Runtime.PyObject_Unicode(type);
+                                if (description != IntPtr.Zero) {
+                                    value.Append(Runtime.GetManagedString(description));
+                                    Runtime.XDecref(description);
+                                }
+                            } finally {
+                                Runtime.XDecref(type);
                             }
                         }
                     }
 
                     if (argIndex + 1 < argCount)
-                        value += ", ";
+                        value.Append(", ");
                 }
-                value += ")";
-                Exceptions.SetError(Exceptions.TypeError, value);
+                value.Append(')');
+                Exceptions.SetError(Exceptions.TypeError, value.ToString());
                 return IntPtr.Zero;
             }
 

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -560,6 +560,26 @@ namespace Python.Runtime
                 {
                     value += $" for {methodinfo[0].Name}";
                 }
+
+                long argCount = Runtime.PyTuple_Size(args);
+                value += ": (";
+                for(long argIndex = 0; argIndex < argCount; argIndex++) {
+                    var arg = Runtime.PyTuple_GetItem(args, argIndex);
+                    if (arg != IntPtr.Zero) {
+                        var type = Runtime.PyObject_Type(arg);
+                        if (type != IntPtr.Zero) {
+                            var description = Runtime.PyObject_Unicode(type);
+                            if (description != IntPtr.Zero) {
+                                value += Runtime.GetManagedString(description);
+                                Runtime.XDecref(description);
+                            }
+                        }
+                    }
+
+                    if (argIndex + 1 < argCount)
+                        value += ", ";
+                }
+                value += ")";
                 Exceptions.SetError(Exceptions.TypeError, value);
                 return IntPtr.Zero;
             }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This change adds more information to "No method matches given arguments" message. In particular, it collects types of arguments passed by Python. For example:

> No method matches given arguments for Add: (<class 'list'>, <class 'tuple'>)

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
