### PR TITLE
allow .NET classes to override __getattr__ and __setattr__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Added
 
 -   Added automatic NuGet package generation in appveyor and local builds
+-   Added IGetAttr and ISetAttr, so that .NET classes could override __getattr__ and __setattr__
 
 ### Changed
 

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -89,6 +89,7 @@
     <Compile Include="TestDomainReload.cs" />
     <Compile Include="TestExample.cs" />
     <Compile Include="TestFinalizer.cs" />
+    <Compile Include="TestInstanceWrapping.cs" />
     <Compile Include="TestPyAnsiString.cs" />
     <Compile Include="TestPyFloat.cs" />
     <Compile Include="TestPyInt.cs" />

--- a/src/embed_tests/TestInstanceWrapping.cs
+++ b/src/embed_tests/TestInstanceWrapping.cs
@@ -1,0 +1,60 @@
+using NUnit.Framework;
+using Python.Runtime;
+using Python.Runtime.Slots;
+
+namespace Python.EmbeddingTest {
+    public class TestInstanceWrapping {
+        [OneTimeSetUp]
+        public void SetUp() {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose() {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void GetAttrCanBeOverriden() {
+            var overloaded = new Overloaded();
+            using (Py.GIL()) {
+                var o = overloaded.ToPython();
+                dynamic getNonexistingAttr = PythonEngine.Eval("lambda o: o.non_existing_attr");
+                string nonexistentAttrValue = getNonexistingAttr(o);
+                Assert.AreEqual(GetAttrFallbackValue, nonexistentAttrValue);
+            }
+        }
+
+        [Test]
+        public void SetAttrCanBeOverriden() {
+            var overloaded = new Overloaded();
+            using (Py.GIL())
+            using (var scope = Py.CreateScope()) {
+                var o = overloaded.ToPython();
+                scope.Set(nameof(o), o);
+                scope.Exec($"{nameof(o)}.non_existing_attr = 42");
+                Assert.AreEqual(42, overloaded.Value);
+            }
+        }
+
+        const string GetAttrFallbackValue = "undefined";
+
+        class Base {}
+        class Derived: Base { }
+
+        class Overloaded: Derived, IGetAttr, ISetAttr
+        {
+            public int Value { get; private set; }
+
+            public bool TryGetAttr(string name, out PyObject value) {
+                value = GetAttrFallbackValue.ToPython();
+                return true;
+            }
+
+            public bool TrySetAttr(string name, PyObject value) {
+                this.Value = value.As<int>();
+                return true;
+            }
+        }
+    }
+}

--- a/src/embed_tests/TestInstanceWrapping.cs
+++ b/src/embed_tests/TestInstanceWrapping.cs
@@ -4,16 +4,6 @@ using Python.Runtime.Slots;
 
 namespace Python.EmbeddingTest {
     public class TestInstanceWrapping {
-        [OneTimeSetUp]
-        public void SetUp() {
-            PythonEngine.Initialize();
-        }
-
-        [OneTimeTearDown]
-        public void Dispose() {
-            PythonEngine.Shutdown();
-        }
-
         [Test]
         public void GetAttrCanBeOverriden() {
             var overloaded = new Overloaded();

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -137,6 +137,7 @@
     <Compile Include="pythonexception.cs" />
     <Compile Include="pytuple.cs" />
     <Compile Include="runtime.cs" />
+    <Compile Include="slots.cs" />
     <Compile Include="typemanager.cs" />
     <Compile Include="typemethod.cs" />
     <Compile Include="Util.cs" />

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -103,7 +103,7 @@ namespace Python.Runtime
         internal static object IsFinalizingLock = new object();
         internal static bool IsFinalizing;
 
-        internal static bool Is32Bit = IntPtr.Size == 4;
+        internal static readonly bool Is32Bit = IntPtr.Size == 4;
 
         // .NET core: System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         internal static bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -562,6 +562,14 @@ namespace Python.Runtime
 #endif
         }
 
+        /// <summary>
+        /// Increase Python's ref counter for the given object, and return the object back.
+        /// </summary>
+        internal static IntPtr SelfIncRef(IntPtr op) {
+            XIncref(op);
+            return op;
+        }
+
         internal static unsafe void XDecref(IntPtr op)
         {
 #if PYTHON_WITH_PYDEBUG || NETSTANDARD

--- a/src/runtime/slots.cs
+++ b/src/runtime/slots.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace Python.Runtime.Slots
+{
+    /// <summary>
+    /// Implement this interface to override Python's __getattr__ for your class
+    /// </summary>
+    public interface IGetAttr {
+        bool TryGetAttr(string name, out PyObject value);
+    }
+
+    /// <summary>
+    /// Implement this interface to override Python's __setattr__ for your class
+    /// </summary>
+    public interface ISetAttr {
+        bool TrySetAttr(string name, PyObject value);
+    }
+
+    static class SlotOverrides {
+        public static IntPtr tp_getattro(IntPtr ob, IntPtr key) {
+            IntPtr genericResult = Runtime.PyObject_GenericGetAttr(ob, key);
+            if (genericResult != IntPtr.Zero || !Runtime.PyString_Check(key)) {
+                return genericResult;
+            }
+
+            Exceptions.Clear();
+
+            var self = (IGetAttr)((CLRObject)ManagedType.GetManagedObject(ob)).inst;
+            string attr = Runtime.GetManagedString(key);
+            return self.TryGetAttr(attr, out var value)
+                ? Runtime.SelfIncRef(value.Handle)
+                : Runtime.PyObject_GenericGetAttr(ob, key);
+        }
+
+        public static int tp_setattro(IntPtr ob, IntPtr key, IntPtr val) {
+            if (!Runtime.PyString_Check(key)) {
+                return Runtime.PyObject_GenericSetAttr(ob, key, val);
+            }
+
+            var self = (ISetAttr)((CLRObject)ManagedType.GetManagedObject(ob)).inst;
+            string attr = Runtime.GetManagedString(key);
+            return self.TrySetAttr(attr, new PyObject(Runtime.SelfIncRef(val)))
+                ? 0
+                : Runtime.PyObject_GenericSetAttr(ob, key, val);
+        }
+    }
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This enables .NET classes to override `__getattr__` and `__setattr__` by implementing `IGetAttr` and `ISetAttr` interfaces correspondingly.

### How does it work

When constructing a Python type, that will represent C# type, if the C# type implements one of the interfaces, fill corresponding slots in the Python type with custom handlers for `tp_getattro` or `tp_setattro` with implementations from `slots.cs`.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)

### P.S.
This is a single-commit change. Probably could be cherry-picked merged without a merge commit.
