### PR TITLE
Qc patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Changed
 
 -   Added argument types information to "No method matches given arguments" message
+-   Improved performance of calls from Python to C#
 
 ### Fixed
 
@@ -59,7 +60,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Fixed conversion of 'float' and 'double' values ([#486][i486])
 -   Fixed 'clrmethod' for python 2 ([#492][i492])
 -   Fixed double calling of constructor when deriving from .NET class ([#495][i495])
--   Fixed `clr.GetClrType` when iterating over `System` members ([#607][p607]) 
+-   Fixed `clr.GetClrType` when iterating over `System` members ([#607][p607])
 -   Fixed `LockRecursionException` when loading assemblies ([#627][i627])
 -   Fixed errors breaking .NET Remoting on method invoke ([#276][i276])
 -   Fixed PyObject.GetHashCode ([#676][i676])

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -253,7 +253,7 @@ namespace Python.Runtime
         public static void tp_dealloc(IntPtr ob)
         {
             ManagedType self = GetManagedObject(ob);
-            IntPtr dict = Marshal.ReadIntPtr(ob, ObjectOffset.DictOffset(ob));
+            IntPtr dict = Marshal.ReadIntPtr(ob, ObjectOffset.TypeDictOffset(self.tpHandle));
             if (dict != IntPtr.Zero)
             {
                 Runtime.XDecref(dict);

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -877,7 +877,7 @@ namespace Python.Runtime
                         // the C# object is being destroyed which must mean there are no more
                         // references to the Python object as well so now we can dealloc the
                         // python object.
-                        IntPtr dict = Marshal.ReadIntPtr(self.pyHandle, ObjectOffset.DictOffset(self.pyHandle));
+                        IntPtr dict = Marshal.ReadIntPtr(self.pyHandle, ObjectOffset.TypeDictOffset(self.tpHandle));
                         if (dict != IntPtr.Zero)
                         {
                             Runtime.XDecref(dict);

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -29,9 +29,13 @@ namespace Python.Runtime
             gcHandle = gc;
             inst = ob;
 
-            // Fix the BaseException args (and __cause__ in case of Python 3)
-            // slot if wrapping a CLR exception
-            Exceptions.SetArgsAndCause(py);
+            // for performance before calling SetArgsAndCause() lets check if we are an exception
+            if (inst is Exception)
+            {
+                // Fix the BaseException args (and __cause__ in case of Python 3)
+                // slot if wrapping a CLR exception
+                Exceptions.SetArgsAndCause(py);
+            }
         }
 
 

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -14,11 +14,11 @@ namespace Python.Runtime
             long flags = Util.ReadCLong(tp, TypeOffset.tp_flags);
             if ((flags & TypeFlags.Subclass) != 0)
             {
-                IntPtr dict = Marshal.ReadIntPtr(py, ObjectOffset.DictOffset(tp));
+                IntPtr dict = Marshal.ReadIntPtr(py, ObjectOffset.TypeDictOffset(tp));
                 if (dict == IntPtr.Zero)
                 {
                     dict = Runtime.PyDict_New();
-                    Marshal.WriteIntPtr(py, ObjectOffset.DictOffset(tp), dict);
+                    Marshal.WriteIntPtr(py, ObjectOffset.TypeDictOffset(tp), dict);
                 }
             }
 

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections;
-using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Text;
@@ -88,8 +88,7 @@ namespace Python.Runtime
 
         public static int magic(IntPtr ob)
         {
-            if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
-                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
+            if (IsException(ob))
             {
                 return ExceptionOffset.ob_data;
             }
@@ -98,8 +97,7 @@ namespace Python.Runtime
 
         public static int DictOffset(IntPtr ob)
         {
-            if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
-                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
+            if (IsException(ob))
             {
                 return ExceptionOffset.ob_dict;
             }
@@ -108,8 +106,7 @@ namespace Python.Runtime
 
         public static int Size(IntPtr ob)
         {
-            if ((Runtime.PyObject_TypeCheck(ob, Exceptions.BaseException) ||
-                 (Runtime.PyType_Check(ob) && Runtime.PyType_IsSubtype(ob, Exceptions.BaseException))))
+            if (IsException(ob))
             {
                 return ExceptionOffset.Size();
             }
@@ -128,6 +125,21 @@ namespace Python.Runtime
         public static int ob_type;
         private static int ob_dict;
         private static int ob_data;
+        private static readonly Dictionary<IntPtr, bool> ExceptionTypeCache = new Dictionary<IntPtr, bool>();
+
+        private static bool IsException(IntPtr pyObject)
+        {
+            bool res;
+            var type = Runtime.PyObject_TYPE(pyObject);
+            if (!ExceptionTypeCache.TryGetValue(type, out res))
+            {
+                res = Runtime.PyObjectType_TypeCheck(type, Exceptions.BaseException)
+                    || Runtime.PyObjectType_TypeCheck(type, Runtime.PyTypeType)
+                    && Runtime.PyType_IsSubtype(pyObject, Exceptions.BaseException);
+                ExceptionTypeCache.Add(type, res);
+            }
+            return res;
+        }
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -125,20 +125,13 @@ namespace Python.Runtime
         public static int ob_type;
         private static int ob_dict;
         private static int ob_data;
-        private static readonly Dictionary<IntPtr, bool> ExceptionTypeCache = new Dictionary<IntPtr, bool>();
 
         private static bool IsException(IntPtr pyObject)
         {
-            bool res;
             var type = Runtime.PyObject_TYPE(pyObject);
-            if (!ExceptionTypeCache.TryGetValue(type, out res))
-            {
-                res = Runtime.PyObjectType_TypeCheck(type, Exceptions.BaseException)
-                    || Runtime.PyObjectType_TypeCheck(type, Runtime.PyTypeType)
-                    && Runtime.PyType_IsSubtype(pyObject, Exceptions.BaseException);
-                ExceptionTypeCache.Add(type, res);
-            }
-            return res;
+            return Runtime.PyObjectType_TypeCheck(type, Exceptions.BaseException)
+                || Runtime.PyObjectType_TypeCheck(type, Runtime.PyTypeType)
+                && Runtime.PyType_IsSubtype(pyObject, Exceptions.BaseException);
         }
     }
 

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -33,7 +33,7 @@ namespace Python.Runtime
                 {
                     IntPtr op = tp == ob
                         ? Marshal.ReadIntPtr(tp, TypeOffset.magic())
-                        : Marshal.ReadIntPtr(ob, ObjectOffset.magic(ob));
+                        : Marshal.ReadIntPtr(ob, ObjectOffset.magic(tp));
                     if (op == IntPtr.Zero)
                     {
                         return null;

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -187,6 +187,13 @@ namespace Python.Runtime
                 val += ArgPrecedence(pi[i].ParameterType);
             }
 
+            var info = mi as MethodInfo;
+            if (info != null)
+            {
+                val += ArgPrecedence(info.ReturnType);
+                val += mi.DeclaringType == mi.ReflectedType ? 0 : 3000;
+            }
+
             return val;
         }
 
@@ -199,6 +206,11 @@ namespace Python.Runtime
             if (t == objectType)
             {
                 return 3000;
+            }
+
+            if (t.IsAssignableFrom(typeof(PyObject)))
+            {
+                return -1;
             }
 
             TypeCode tc = Type.GetTypeCode(t);

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -53,7 +53,7 @@ namespace Python.Runtime
             Runtime.XDecref(pyfilename);
             Runtime.XDecref(pydocstring);
 
-            Marshal.WriteIntPtr(pyHandle, ObjectOffset.DictOffset(pyHandle), dict);
+            Marshal.WriteIntPtr(pyHandle, ObjectOffset.TypeDictOffset(tpHandle), dict);
 
             InitializeModuleMembers();
         }

--- a/src/runtime/propertyobject.cs
+++ b/src/runtime/propertyobject.cs
@@ -232,8 +232,13 @@ namespace Python.Runtime
             // so 'obj' is declared as typeof(object)
             var instance = Expression.Convert(obj, methodInfo.DeclaringType);
 
+            var parameters = methodInfo.GetParameters();
+            if (parameters.Length != 1)
+            {
+                return null;
+            }
             var value = Expression.Parameter(typeof(object));
-            var argument = Expression.Convert(value, methodInfo.GetParameters()[0].ParameterType);
+            var argument = Expression.Convert(value, parameters[0].ParameterType);
 
             var expressionCall = Expression.Call(instance, methodInfo, argument);
 

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -26,7 +26,7 @@ namespace Python.Runtime
         /// Trace stack for PyObject's construction
         /// </summary>
         public StackTrace Traceback { get; private set; }
-#endif  
+#endif
 
         protected internal IntPtr obj = IntPtr.Zero;
         private bool disposed = false;
@@ -184,6 +184,24 @@ namespace Python.Runtime
         public IntPtr[] GetTrackedHandles()
         {
             return new IntPtr[] { obj };
+        }
+
+        /// <summary>
+        /// Unsafe Dispose Method.
+        /// To be used when already owning the GIL lock. <see cref="Dispose()"/>
+        /// </summary>
+        public void UnsafeDispose()
+        {
+            if (!disposed)
+            {
+                if (!Runtime.IsFinalizing)
+                {
+                    Runtime.XDecref(obj);
+                    obj = IntPtr.Zero;
+                }
+                disposed = true;
+            }
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1741,6 +1741,11 @@ namespace Python.Runtime
             return (t == tp) || PyType_IsSubtype(t, tp);
         }
 
+        internal static bool PyObjectType_TypeCheck(IntPtr type, IntPtr tp)
+        {
+            return (type == tp) || PyType_IsSubtype(type, tp);
+        }
+
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyType_GenericNew(IntPtr type, IntPtr args, IntPtr kw);
 

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -85,7 +85,7 @@ namespace Python.Runtime
             // Set tp_basicsize to the size of our managed instance objects.
             Marshal.WriteIntPtr(type, TypeOffset.tp_basicsize, (IntPtr)ob_size);
 
-            var offset = (IntPtr)ObjectOffset.DictOffset(type);
+            var offset = (IntPtr)ObjectOffset.TypeDictOffset(type);
             Marshal.WriteIntPtr(type, TypeOffset.tp_dictoffset, offset);
 
             InitializeSlots(type, impl);
@@ -123,7 +123,6 @@ namespace Python.Runtime
 
             IntPtr base_ = IntPtr.Zero;
             int ob_size = ObjectOffset.Size(Runtime.PyTypeType);
-            int tp_dictoffset = ObjectOffset.DictOffset(Runtime.PyTypeType);
 
             // XXX Hack, use a different base class for System.Exception
             // Python 2.5+ allows new style class exceptions but they *must*
@@ -131,8 +130,9 @@ namespace Python.Runtime
             if (typeof(Exception).IsAssignableFrom(clrType))
             {
                 ob_size = ObjectOffset.Size(Exceptions.Exception);
-                tp_dictoffset = ObjectOffset.DictOffset(Exceptions.Exception);
             }
+
+            int tp_dictoffset = ob_size + ManagedDataOffsets.ob_dict;
 
             if (clrType == typeof(Exception))
             {


### PR DESCRIPTION
This is a rollup of 6 patches from the Quantconnect fork that can be easily applied on master. With this merged, the only things separating the fork from upstream will be

1. The type conversion logic
2. A few changes to the finalizer code
3. The different versioning scheme

@AlexCatarino @Martin-Molinero @AlexCatarino, could you verify that I didn't botch your changes?