### PR TITLE
Removes imports deprecated in Python3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 -   Added argument types information to "No method matches given arguments" message
 -   Moved wheel import in setup.py inside of a try/except to prevent pip collection failures
+-   Removes PyLong_GetMax and PyClass_New when targetting Python3
 
 ### Fixed
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -769,8 +769,10 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyCFunction_Call(IntPtr func, IntPtr args, IntPtr kw);
 
+#if PYTHON2
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyClass_New(IntPtr bases, IntPtr dict, IntPtr name);
+#endif
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyInstance_New(IntPtr cls, IntPtr args, IntPtr kw);
@@ -1012,10 +1014,6 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
             EntryPoint = "PyLong_FromString")]
         internal static extern IntPtr PyInt_FromString(string value, IntPtr end, int radix);
-
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
-            EntryPoint = "PyLong_GetMax")]
-        internal static extern int PyInt_GetMax();
 #elif PYTHON2
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr PyInt_FromLong(IntPtr value);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
A small number of existing imports are deprecated in Python3. 
This removes them or compiles them out.

### Does this close any currently open issues?
Fixes #924 
...

### Any other comments?

N/A

### Checklist

Check all those that are applicable and complete.

-   [N/A] Make sure to include one or more tests for your change
-   [N/A] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
