### PR TITLE
Fix so that Runtime.PyModuleType is retrieved via Python.dll (#904)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@
 -   David Lassonde ([@lassond](https://github.com/lassond))
 -   David Lechner ([@dlech](https://github.com/dlech))
 -   Dmitriy Se ([@dmitriyse](https://github.com/dmitriyse))
+-   Florian Treurniet ([@ftreurni](https://github.com/ftreurni))
 -   He-chien Tsai ([@t3476](https://github.com/t3476))
 -   Inna Wiesel ([@inna-w](https://github.com/inna-w))
 -   Ivan Cronyn ([@cronan](https://github.com/cronan))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Fixed
 
+- Fixed runtime that fails loading when using pythonnet in an environment
+  together with Nuitka
+
 ## [2.4.0][]
 
 ### Added
@@ -60,7 +63,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Fixed conversion of 'float' and 'double' values ([#486][i486])
 -   Fixed 'clrmethod' for python 2 ([#492][i492])
 -   Fixed double calling of constructor when deriving from .NET class ([#495][i495])
--   Fixed `clr.GetClrType` when iterating over `System` members ([#607][p607]) 
+-   Fixed `clr.GetClrType` when iterating over `System` members ([#607][p607])
 -   Fixed `LockRecursionException` when loading assemblies ([#627][i627])
 -   Fixed errors breaking .NET Remoting on method invoke ([#276][i276])
 -   Fixed PyObject.GetHashCode ([#676][i676])

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -205,7 +205,6 @@ namespace Python.Runtime
             PyNotImplemented = PyObject_GetAttrString(op, "NotImplemented");
             PyBaseObjectType = PyObject_GetAttrString(op, "object");
 
-            PyModuleType = PyObject_Type(op);
             PyNone = PyObject_GetAttrString(op, "None");
             PyTrue = PyObject_GetAttrString(op, "True");
             PyFalse = PyObject_GetAttrString(op, "False");
@@ -302,6 +301,7 @@ namespace Python.Runtime
                 dllLocal = loader.Load(_PythonDll);
             }
             _PyObject_NextNotImplemented = loader.GetFunction(dllLocal, "_PyObject_NextNotImplemented");
+            PyModuleType = loader.GetFunction(dllLocal, "PyModule_Type");
 
             if (dllLocal != IntPtr.Zero)
             {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Currently the PyModuleType is deduced from the ``__builtin__`` module. However, this fails when some third party package messes with this module (Nuitka). In this PR the PyModuleType is deduced directly from the Python shared library instead, which should be a safer approach to achieve the same.

### Does this close any currently open issues?

#904 

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
