### PR TITLE
Remove delegate casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Moved wheel import in setup.py inside of a try/except to prevent pip collection failures
 -   Removes PyLong_GetMax and PyClass_New when targetting Python3
 -   Added support for converting python iterators to C# arrays
+-   Changed usage of obselete function GetDelegateForFunctionPointer(IntPtr, Type) to GetDelegateForFunctionPointer<TDelegate>(IntPtr)
 
 ### Fixed
 
 - Fixed runtime that fails loading when using pythonnet in an environment
   together with Nuitka
+- Fixes bug where delegates get casts (dotnetcore)
 
 ## [2.4.0][]
 

--- a/src/runtime/nativecall.cs
+++ b/src/runtime/nativecall.cs
@@ -32,19 +32,21 @@ namespace Python.Runtime
 
         public static void Void_Call_1(IntPtr fp, IntPtr a1)
         {
-            ((Void_1_Delegate)Marshal.GetDelegateForFunctionPointer(fp, typeof(Void_1_Delegate)))(a1);
+            var d = Marshal.GetDelegateForFunctionPointer<Interop.DestructorFunc>(fp);
+            d(a1);
         }
 
         public static IntPtr Call_3(IntPtr fp, IntPtr a1, IntPtr a2, IntPtr a3)
         {
-            var d = (Interop.TernaryFunc)Marshal.GetDelegateForFunctionPointer(fp, typeof(Interop.TernaryFunc));
+            var d = Marshal.GetDelegateForFunctionPointer<Interop.TernaryFunc>(fp);
             return d(a1, a2, a3);
         }
 
 
         public static int Int_Call_3(IntPtr fp, IntPtr a1, IntPtr a2, IntPtr a3)
         {
-            return ((Int_3_Delegate)Marshal.GetDelegateForFunctionPointer(fp, typeof(Int_3_Delegate)))(a1, a2, a3);
+            var d = Marshal.GetDelegateForFunctionPointer<Interop.ObjObjArgFunc>(fp);
+            return d(a1, a2, a3);
         }
 #else
         private static AssemblyBuilder aBuilder;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fixes an issue where pythonnet attempts to cast one managed delegate to another. This is explicitly forbidden in the documentation: [see here](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.getdelegateforfunctionpointer?view=netstandard-2.0#System_Runtime_InteropServices_Marshal_GetDelegateForFunctionPointer__1_System_IntPtr_). In particular:

> You cannot use this method to create a delegate from a function pointer to another managed delegate

I have also removed the usage of the obselete function GetDelegateForFunctionPointer(IntPtr, Type) and replaced it with GetDelegateForFunctionPointer<TDelegate><IntPtr).

### Does this close any currently open issues?

No

### Any other comments?

It seems like this issue got partially fixed in PR #550 and was mentioned in issue #96. See also this related [issue](https://github.com/dotnet/coreclr/issues/14362) in dotnet core.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
