### PR TITLE
Update readme with resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,3 +113,8 @@ https://github.com/pythonnet/pythonnet/wiki
    :target: http://stackoverflow.com/questions/tagged/python.net
 .. |conda-forge version| image:: https://img.shields.io/conda/vn/conda-forge/pythonnet.svg
    :target: https://anaconda.org/conda-forge/pythonnet
+
+Resources
+---------
+Mailing list: https://mail.python.org/mailman/listinfo/pythondotnet
+Chat: https://gitter.im/pythonnet/pythonnet


### PR DESCRIPTION
Added resources section with mailing list and chat

### What does this implement/fix? Explain your changes.
Puts discussion resources in the readme. The gitter link is in a badge at the top, but is easy to miss. The mailing list is not referenced at all (as far as I can tell).
