### PR TITLE
Detect py arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 - Fixed runtime that fails loading when using pythonnet in an environment
   together with Nuitka
 - Fixes bug where delegates get casts (dotnetcore)
+- Determine size of interpreter longs at runtime
 
 ## [2.4.0][]
 

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -728,7 +728,20 @@ namespace Python.Runtime
                         }
                         goto type_error;
                     }
-                    uint ui = (uint)Runtime.PyLong_AsUnsignedLong(op);
+                    
+                    uint ui;
+                    try 
+                    {
+                        ui = Convert.ToUInt32(Runtime.PyLong_AsUnsignedLong(op));
+                    } catch (OverflowException)
+                    {
+                        // Probably wasn't an overflow in python but was in C# (e.g. if cpython
+                        // longs are 64 bit then 0xFFFFFFFF + 1 will not overflow in 
+                        // PyLong_AsUnsignedLong)
+                        Runtime.XDecref(op);
+                        goto overflow;
+                    }
+                    
 
                     if (Exceptions.ErrorOccurred())
                     {

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -155,11 +155,6 @@ namespace Python.Runtime
         /// </summary>
         public static string MachineName { get; private set; }
 
-        /// <summary>
-        /// Gets the architecture the python interpreter is using as reported by python's struct.calcsize("P")
-        /// </summary>
-        public static MachineType PythonArchitecture { get; private set; }
-
         internal static bool IsPython2 = pyversionnumber < 30;
         internal static bool IsPython3 = pyversionnumber >= 30;
 
@@ -197,9 +192,6 @@ namespace Python.Runtime
 
             IntPtr op;
             IntPtr dict;
-
-            InitializePythonArch();
-
             if (IsPython3)
             {
                 op = PyImport_ImportModule("builtins");
@@ -377,43 +369,6 @@ namespace Python.Runtime
                 MType = MachineType.Other;
             }
             Machine = MType;
-        }
-
-        /// <summary>
-        /// Initializes the architecture used within the python interpreter
-        ///
-        /// For various reasons the python interpreter often has a different
-        /// architecture to that of the machine. For example on a 64 bit Windows
-        /// platform the CPython interpreter is compiled with 32 bit longs.
-        /// This method will allow pythonnet to determine at runtime how big
-        /// python's longs are.
-        /// </summary>
-        private static void InitializePythonArch()
-        {
-            IntPtr structModule = PyImport_ImportModule("struct");
-            IntPtr calcsizeMethod = PyObject_GetAttrString(structModule, "calcsize");
-            IntPtr methodArgs = PyTuple_New(1);
-            IntPtr pString = PyString_FromString("P");
-
-            if(PyTuple_SetItem(methodArgs, 0, pString) != 0) 
-            {
-                PythonArchitecture = MachineType.Other;
-                return;
-            }
-
-            var result = PyLong_AsLong(PyObject_Call(calcsizeMethod, methodArgs, IntPtr.Zero));
-
-            switch(result){
-                case 4:
-                    PythonArchitecture = MachineType.i386;
-                    break;
-                case 8:
-                    PythonArchitecture = MachineType.x86_64;
-                    break;
-                default:
-                    PythonArchitecture = MachineType.Other;
-                    break;
-            }
         }
 
         internal static void Shutdown()
@@ -1091,12 +1046,9 @@ namespace Python.Runtime
 
         internal static IntPtr PyLong_FromUnsignedLong(object value)
         {
-            if(PythonArchitecture == MachineType.i386)
+            if(Is32Bit || IsWindows)
                 return PyLong_FromUnsignedLong32(Convert.ToUInt32(value));
-            else if(PythonArchitecture == MachineType.x86_64)
-                return PyLong_FromUnsignedLong64(Convert.ToUInt64(value));
             else
-                // Couldn't determine interpreter arch, try 64 bit
                 return PyLong_FromUnsignedLong64(Convert.ToUInt64(value));
         }
 
@@ -1125,15 +1077,11 @@ namespace Python.Runtime
 
         internal static object PyLong_AsUnsignedLong(IntPtr value)
         {
-            if (PythonArchitecture == MachineType.i386)
+            if (Is32Bit || IsWindows)
                 return PyLong_AsUnsignedLong32(value);
-            else if (PythonArchitecture == MachineType.x86_64)
-                return PyLong_AsUnsignedLong64(value);
-            else  
+            else
                 return PyLong_AsUnsignedLong64(value);
         }
-
-
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern long PyLong_AsLongLong(IntPtr value);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1115,8 +1115,25 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyLong_AsLong(IntPtr value);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint PyLong_AsUnsignedLong(IntPtr value);
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
+            EntryPoint = "PyLong_AsUnsignedLong")]
+        internal static extern uint PyLong_AsUnsignedLong32(IntPtr value);
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
+            EntryPoint = "PyLong_AsUnsignedLong")]
+        internal static extern ulong PyLong_AsUnsignedLong64(IntPtr value);
+
+        internal static object PyLong_AsUnsignedLong(IntPtr value)
+        {
+            if (PythonArchitecture == MachineType.i386)
+                return PyLong_AsUnsignedLong32(value);
+            else if (PythonArchitecture == MachineType.x86_64)
+                return PyLong_AsUnsignedLong64(value);
+            else  
+                return PyLong_AsUnsignedLong64(value);
+        }
+
+
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern long PyLong_AsLongLong(IntPtr value);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1081,8 +1081,24 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyLong_FromLong(long value);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyLong_FromUnsignedLong(uint value);
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
+            EntryPoint = "PyLong_FromUnsignedLong")]
+        internal static extern IntPtr PyLong_FromUnsignedLong32(uint value);
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
+            EntryPoint = "PyLong_FromUnsignedLong")]
+        internal static extern IntPtr PyLong_FromUnsignedLong64(ulong value);
+
+        internal static IntPtr PyLong_FromUnsignedLong(object value)
+        {
+            if(PythonArchitecture == MachineType.i386)
+                return PyLong_FromUnsignedLong32(Convert.ToUInt32(value));
+            else if(PythonArchitecture == MachineType.x86_64)
+                return PyLong_FromUnsignedLong64(Convert.ToUInt64(value));
+            else
+                // Couldn't determine interpreter arch, try 64 bit
+                return PyLong_FromUnsignedLong64(Convert.ToUInt64(value));
+        }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyLong_FromDouble(double value);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

As described in Issue #950, the size of python's longs can vary depending on platform. This changes allows pythonnet to determine at runtime the architecture of the python interpreter and select the correct size of long/int for the affected methods.

### Does this close any currently open issues?

#950 

### Any other comments?

No

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
