### PR TITLE
Drop List and IEnumerable conversions

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -155,7 +155,7 @@ namespace Python.Runtime
             // type is. we'd rather have the object bound to the actual
             // implementing class.
 
-            type = type ?? value.GetType();
+            type = type == null || type == typeof(object) ? value.GetType() : type;
 
             TypeCode tc = Type.GetTypeCode(type);
 

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -155,7 +155,7 @@ namespace Python.Runtime
             // type is. we'd rather have the object bound to the actual
             // implementing class.
 
-            type = value.GetType();
+            type = type ?? value.GetType();
 
             TypeCode tc = Type.GetTypeCode(type);
 

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -155,7 +155,7 @@ namespace Python.Runtime
             // type is. we'd rather have the object bound to the actual
             // implementing class.
 
-            type = type == null || type == typeof(object) ? value.GetType() : type;
+            type = type ?? value.GetType();
 
             TypeCode tc = Type.GetTypeCode(type);
 

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -135,22 +135,6 @@ namespace Python.Runtime
                 return result;
             }
 
-			if (value is IList && !(value is INotifyPropertyChanged) && value.GetType().IsGenericType)
-			{
-                using (var resultlist = new PyList())
-                {
-                    foreach (object o in (IEnumerable)value)
-                    {
-                        using (var p = new PyObject(ToPython(o, o?.GetType())))
-                        {
-                            resultlist.Append(p);
-                        }
-                    }
-                    Runtime.XIncref(resultlist.Handle);
-                    return resultlist.Handle;
-                }
-            }
-
             // it the type is a python subclass of a managed type then return the
             // underlying python object rather than construct a new wrapper object.
             var pyderived = value as IPythonDerivedType;
@@ -231,21 +215,6 @@ namespace Python.Runtime
                     return Runtime.PyLong_FromUnsignedLongLong((ulong)value);
 
                 default:
-                    if (value is IEnumerable)
-                    {
-                        using (var resultlist = new PyList())
-                        {
-                            foreach (object o in (IEnumerable)value)
-                            {
-                                using (var p = new PyObject(ToPython(o, o?.GetType())))
-                                {
-                                    resultlist.Append(p);
-                                }
-                            }
-                            Runtime.XIncref(resultlist.Handle);
-                            return resultlist.Handle;
-                        }
-                    }
                     result = CLRObject.GetInstHandle(value, type);
                     return result;
             }
@@ -862,7 +831,7 @@ namespace Python.Runtime
 
             var listType = typeof(List<>);
             var constructedListType = listType.MakeGenericType(elementType);
-            IList list = IsSeqObj ? (IList) Activator.CreateInstance(constructedListType, new Object[] {(int) len}) : 
+            IList list = IsSeqObj ? (IList) Activator.CreateInstance(constructedListType, new Object[] {(int) len}) :
                                         (IList) Activator.CreateInstance(constructedListType);
             IntPtr item;
 
@@ -883,7 +852,7 @@ namespace Python.Runtime
 
             items = Array.CreateInstance(elementType, list.Count);
             list.CopyTo(items, 0);
-            
+
             result = items;
             return true;
         }

--- a/src/runtime/iterator.cs
+++ b/src/runtime/iterator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System;
 using System.Collections;
 
@@ -10,10 +11,18 @@ namespace Python.Runtime
     internal class Iterator : ExtensionType
     {
         private IEnumerator iter;
+        private Type type;
 
         public Iterator(IEnumerator e)
         {
             iter = e;
+
+            var genericType = e.GetType().GetInterfaces().FirstOrDefault(
+                x => x.IsGenericType &&
+                x.GetGenericTypeDefinition() == typeof(System.Collections.Generic.IEnumerator<>)
+            );
+
+            type = genericType?.GetGenericArguments().FirstOrDefault();
         }
 
 
@@ -41,7 +50,7 @@ namespace Python.Runtime
                 return IntPtr.Zero;
             }
             object item = self.iter.Current;
-            return Converter.ToPythonImplicit(item);
+            return Converter.ToPython(item, self.type);
         }
 
         public static IntPtr tp_iter(IntPtr ob)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Drop implicit conversion of `List<>` and `IEnumerable`.

### Does this close any currently open issues?

Heaps, I'll list them later

### Any other comments?

Breaks the interface, so we'll have to announce this loudly and raise the minor version number.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
