### PR TITLE
Add function to set Py_NoSiteFlag global variable to 1

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,7 @@
 
 ## Contributors
 
+-   Alex Helms ([@alexhelms](https://github.com/alexhelms))
 -   Alexandre Catarino([@AlexCatarino](https://github.com/AlexCatarino))
 -   Arvid JB ([@ArvidJB](https://github.com/ArvidJB))
 -   Benoît Hudson ([@benoithudson](https://github.com/benoithudson))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Added
 
 -   Added automatic NuGet package generation in appveyor and local builds
+-   Added function that sets Py_NoSiteFlag to 1.
 
 ### Changed
 

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -130,6 +130,16 @@ namespace Python.Runtime
             get { return Marshal.PtrToStringAnsi(Runtime.Py_GetCompiler()); }
         }
 
+        /// <summary>
+        /// Set the NoSiteFlag to disable loading the site module.
+        /// Must be called before Initialize.
+        /// https://docs.python.org/3/c-api/init.html#c.Py_NoSiteFlag
+        /// </summary>
+        public static void SetNoSiteFlag()
+        {
+            Runtime.SetNoSiteFlag();
+        }
+
         public static int RunSimpleString(string code)
         {
             return Runtime.PyRun_SimpleString(code);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1900,11 +1900,7 @@ namespace Python.Runtime
             try
             {
                 Py_NoSiteFlag = loader.GetFunction(dllLocal, "Py_NoSiteFlag");
-
-                if (Is32Bit)
-                    Marshal.WriteInt32(Py_NoSiteFlag, 1);
-                else
-                    Marshal.WriteInt64(Py_NoSiteFlag, 1);
+                Marshal.WriteInt32(Py_NoSiteFlag, 1);
             }
             finally
             {

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -414,6 +414,8 @@ namespace Python.Runtime
         internal static IntPtr PyNoneType;
         internal static IntPtr PyTypeType;
 
+        internal static IntPtr Py_NoSiteFlag;
+
 #if PYTHON3
         internal static IntPtr PyBytesType;
 #endif
@@ -1884,5 +1886,33 @@ namespace Python.Runtime
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Py_MakePendingCalls();
+
+        internal static void SetNoSiteFlag()
+        {
+            var loader = LibraryLoader.Get(OperatingSystem);
+
+            IntPtr dllLocal;
+            if (_PythonDll != "__Internal")
+            {
+                dllLocal = loader.Load(_PythonDll);
+            }
+
+            try
+            {
+                Py_NoSiteFlag = loader.GetFunction(dllLocal, "Py_NoSiteFlag");
+
+                if (Is32Bit)
+                    Marshal.WriteInt32(Py_NoSiteFlag, 1);
+                else
+                    Marshal.WriteInt64(Py_NoSiteFlag, 1);
+            }
+            finally
+            {
+                if (dllLocal != IntPtr.Zero)
+                {
+                    loader.Free(dllLocal);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
I'm using pythonnet to embed python 3.6 in a C# WPF application. I'm effectively booting up a venv with pythonnet and I noticed the user site folder kept getting included in `sys.path`.

There is a command line argument to disable this, (-S, more info here: https://docs.python.org/3/using/cmdline.html#id3) but as pythonnet loads python directly, this won't work.

There is a way to access this flag with the C API, info here: https://docs.python.org/3/c-api/init.html#c.Py_NoSiteFlag

This is a global variable that is exported, defined here: https://github.com/python/cpython/blob/3.6/Include/pydebug.h

My particular use case is for python 3.6, but it appears this flag is present in 2.7 and all currently supported 3.x versions.

Here is an example on how I am using this addition:

```
PythonEngine.PythonHome = pythonHome;
PythonEngine.PythonPath = pythonPath;
PythonEngine.SetNoSiteFlag();
PythonEngine.Initialize();
```

It seems to do the business and I no longer get the user site package path in `sys.path`.

Note: I'm not quite sure how to test this addition as really is dependent on the user's environment. Perhaps a test to verify the global var is set to 1? Please let me know your thoughts.
