### PR TITLE
Add C# Dictionary to Python Dict conversion

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -64,6 +64,7 @@
 -   ([@OneBlue](https://github.com/OneBlue))
 -   ([@rico-chet](https://github.com/rico-chet))
 -   ([@rmadsen-ks](https://github.com/rmadsen-ks))
+-   ([@SnGmng](https://github.com/SnGmng))
 -   ([@stonebig](https://github.com/stonebig))
 -   ([@testrunner123](https://github.com/testrunner123))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Added
 
 -   Added automatic NuGet package generation in appveyor and local builds
+-   Added Dictionary to PyDict conversion to the function ToPython()
 
 ### Changed
 

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -150,6 +150,24 @@ namespace Python.Runtime
                     return resultlist.Handle;
                 }
             }
+            else if (value is IDictionary && !(value is INotifyPropertyChanged) && value.GetType().IsGenericType)
+            {
+                using (var resultdict = new PyDict())
+                {
+                    foreach (DictionaryEntry o in (IDictionary)value)
+                    {
+                        using (var k = new PyObject(ToPython(o.Key, o.Key?.GetType())))
+                        {
+                            using (var v = new PyObject(ToPython(o.Value, o.Value?.GetType())))
+                            {
+                                resultdict.SetItem(k, v);
+                            }
+                        }
+                    }
+                    Runtime.XIncref(resultdict.Handle);
+                    return resultdict.Handle;
+                }
+            }
 
             // it the type is a python subclass of a managed type then return the
             // underlying python object rather than construct a new wrapper object.


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

You can now convert a C# IDictionary to a Python Dict by calling ToPython()

    Dictionary<string, string> dict = new Dictionary<string, string>();
    dict.Add("hello", "world");

    dynamic d = dict.ToPython();
    string value = d.get("hello", "");

### Does this close any currently open issues?

No, but it is progress for #623

### Any other comments?

Do i really have to include a test for this? I mean, the [TestConverter.cs](../blob/master/src/embed_tests/TestConverter.cs) file doesnt have any tests for other similar types like `IList` at all.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
