### PR TITLE
Update mp_length to support all ICollection implementers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -12,6 +12,7 @@
 
 ## Contributors
 
+-   Alex Earl ([@slide](https://github.com/slide))
 -   Alex Helms ([@alexhelms](https://github.com/alexhelms))
 -   Alexandre Catarino([@AlexCatarino](https://github.com/AlexCatarino))
 -   Arvid JB ([@ArvidJB](https://github.com/ArvidJB))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added automatic NuGet package generation in appveyor and local builds
 -   Added function that sets Py_NoSiteFlag to 1.
 -   Added support for Jetson Nano.
+-   Added support for __len__ for .NET classes that implement ICollection
 
 ### Changed
 

--- a/src/runtime/arrayobject.cs
+++ b/src/runtime/arrayobject.cs
@@ -244,16 +244,5 @@ namespace Python.Runtime
 
             return 0;
         }
-
-
-        /// <summary>
-        /// Implements __len__ for array types.
-        /// </summary>
-        public static int mp_length(IntPtr ob)
-        {
-            var self = (CLRObject)GetManagedObject(ob);
-            var items = self.inst as Array;
-            return items.Length;
-        }
     }
 }

--- a/src/runtime/arrayobject.cs
+++ b/src/runtime/arrayobject.cs
@@ -244,5 +244,15 @@ namespace Python.Runtime
 
             return 0;
         }
+
+        /// <summary>
+        /// Implements __len__ for array types.
+        /// </summary>
+        public static int mp_length(IntPtr ob)
+        {
+            var self = (CLRObject)GetManagedObject(ob);
+            var items = self.inst as Array;
+            return items.Length;
+        }
     }
 }

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -284,6 +284,26 @@ namespace Python.Runtime
             }
         }
 
+        /// <summary>
+        /// Implements __len__ for classes that implement ICollection
+        /// (this includes any IList implementer or Array subclass)
+        /// </summary>
+        public static int mp_length(IntPtr ob)
+        {
+            var co = GetManagedObject(ob) as CLRObject;
+            if (co == null)
+            {
+                Exceptions.RaiseTypeError("invalid object");
+            }
+
+            if (co.inst is ICollection c)
+            {
+                return c.Count;
+            }
+
+            Exceptions.SetError(Exceptions.TypeError, $"object of type '{co.inst.GetType().Name}' has no len()");
+            return -1;
+        }
 
         /// <summary>
         /// Standard dealloc implementation for instances of reflected types.

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -285,27 +285,6 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// Implements __len__ for classes that implement ICollection
-        /// (this includes any IList implementer or Array subclass)
-        /// </summary>
-        public static int mp_length(IntPtr ob)
-        {
-            var co = GetManagedObject(ob) as CLRObject;
-            if (co == null)
-            {
-                Exceptions.RaiseTypeError("invalid object");
-            }
-
-            if (co.inst is ICollection c)
-            {
-                return c.Count;
-            }
-
-            Exceptions.SetError(Exceptions.TypeError, $"object of type '{co.inst.GetType().Name}' has no len()");
-            return -1;
-        }
-
-        /// <summary>
         /// Standard dealloc implementation for instances of reflected types.
         /// </summary>
         public static void tp_dealloc(IntPtr ob)

--- a/src/runtime/slots/mp_length.cs
+++ b/src/runtime/slots/mp_length.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Reflection;
+
+namespace Python.Runtime.Slots
+{
+    static class mp_length_slot
+    {
+        /// <summary>
+        /// Implements __len__ for classes that implement ICollection
+        /// (this includes any IList implementer or Array subclass)
+        /// </summary>
+        public static int mp_length(IntPtr ob)
+        {
+            var co = ManagedType.GetManagedObject(ob) as CLRObject;
+            if (co == null)
+            {
+                Exceptions.RaiseTypeError("invalid object");
+            }
+
+            Type t = co.inst.GetType();
+            PropertyInfo p = t.GetProperty("Count");
+            if (p != null)
+            {
+                return (int)p.GetValue(co.inst, null);
+            }
+
+            Exceptions.SetError(Exceptions.TypeError, $"object of type '{co.inst.GetType().Name}' has no len()");
+            return -1;
+        }
+    }
+}

--- a/src/tests/test_conversion.py
+++ b/src/tests/test_conversion.py
@@ -701,3 +701,21 @@ def test_sbyte_array_conversion():
     array = ob.SByteArrayField
     for i, _ in enumerate(value):
         assert array[i] == indexbytes(value, i)
+
+def test_list___len__():
+    """Test __len__ for ICollection implementers"""
+    import System
+    import System.Collections.Generic
+    l = System.Collections.Generic.List[int]()
+    assert len(l) == 0
+    l.Add(5)
+    l.Add(6)
+    assert len(l) == 2
+
+    d = System.Collections.Generic.Dictionary[int, int]()
+    assert len(d) == 0
+    d.Add(4, 5)
+    assert len(d) == 1
+
+    a = System.Array[int]([0,1,2,3])
+    assert len(a) == 4


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Currently, if you try and use `len` on anything other than Array subclasses, it fails. This adds the ability to use `len` on any .NET class that implements ICollection (List, Dictionary, etc).

### Does this close any currently open issues?

No, there is no current issue that I know of.

### Any other comments?

Not sure if this is enhancement PR that requires a doc, but I am happy to add doc info if others think it is necessary.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
