### PR TITLE
Split from PR 958: restoring the __import__ after shutdown.

### DIFF
--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -26,25 +26,64 @@ namespace Python.Runtime
 #endif
 
         /// <summary>
+        /// Get a <i>New reference</i> to the builtins module.
+        /// </summary>
+        static IntPtr GetNewRefToBuiltins()
+        {
+            if (Runtime.IsPython3)
+            {
+                return Runtime.PyImport_ImportModule("builtins");
+            }
+            else
+            {
+                // dict is a borrowed ref, no need to decref
+                IntPtr dict = Runtime.PyImport_GetModuleDict();
+
+                // GetItemString is a borrowed ref; incref to get a new ref
+                IntPtr builtins = Runtime.PyDict_GetItemString(dict, "__builtin__");
+                Runtime.XIncref(builtins);
+                return builtins;
+            }
+        }
+
+        /// <summary>
+        /// Initialize just the __import__ hook itself.
+        /// </summary>
+        static void InitImport()
+        {
+            // We replace the built-in Python __import__ with our own: first
+            // look in CLR modules, then if we don't find any call the default
+            // Python __import__.
+            IntPtr builtins = GetNewRefToBuiltins();
+            py_import = Runtime.PyObject_GetAttrString(builtins, "__import__");
+            hook = new MethodWrapper(typeof(ImportHook), "__import__", "TernaryFunc");
+            Runtime.PyObject_SetAttrString(builtins, "__import__", hook.ptr);
+            Runtime.XDecref(hook.ptr);
+            Runtime.XDecref(builtins);
+        }
+
+        /// <summary>
+        /// Restore the __import__ hook.
+        /// </summary>
+        static void RestoreImport()
+        {
+            IntPtr builtins = GetNewRefToBuiltins();
+
+            Runtime.PyObject_SetAttrString(builtins, "__import__", py_import);
+            Runtime.XDecref(py_import);
+            py_import = IntPtr.Zero;
+
+            Runtime.XDecref(builtins);
+        }
+
+        /// <summary>
         /// Initialization performed on startup of the Python runtime.
         /// </summary>
         internal static void Initialize()
         {
-            // Initialize the Python <--> CLR module hook. We replace the
-            // built-in Python __import__ with our own. This isn't ideal,
-            // but it provides the most "Pythonic" way of dealing with CLR
-            // modules (Python doesn't provide a way to emulate packages).
-            IntPtr dict = Runtime.PyImport_GetModuleDict();
+            InitImport();
 
-            IntPtr mod = Runtime.IsPython3
-                ? Runtime.PyImport_ImportModule("builtins")
-                : Runtime.PyDict_GetItemString(dict, "__builtin__");
-
-            py_import = Runtime.PyObject_GetAttrString(mod, "__import__");
-            hook = new MethodWrapper(typeof(ImportHook), "__import__", "TernaryFunc");
-            Runtime.PyObject_SetAttrString(mod, "__import__", hook.ptr);
-            Runtime.XDecref(hook.ptr);
-
+            // Initialize the clr module and tell Python about it.
             root = new CLRModule();
 
 #if PYTHON3
@@ -62,6 +101,7 @@ namespace Python.Runtime
             Runtime.XIncref(root.pyHandle); // we are using the module two times
             py_clr_module = root.pyHandle; // Alias handle for PY2/PY3
 #endif
+            IntPtr dict = Runtime.PyImport_GetModuleDict();
             Runtime.PyDict_SetItemString(dict, "CLR", py_clr_module);
             Runtime.PyDict_SetItemString(dict, "clr", py_clr_module);
         }
@@ -74,9 +114,10 @@ namespace Python.Runtime
         {
             if (Runtime.Py_IsInitialized() != 0)
             {
+                RestoreImport();
+
                 Runtime.XDecref(py_clr_module);
                 Runtime.XDecref(root.pyHandle);
-                Runtime.XDecref(py_import);
             }
         }
 


### PR DESCRIPTION
When C# shuts down we should restore Python to its original state.

### What does this implement/fix? Explain your changes.

This is adapted from the large patch that amos put in PR #958. It restores the import hook.

### Does this close any currently open issues?

Not yet.

### Any other comments?

I would have used the ShutdownHandler but that's only in the PythonEngine, whereas `__import__` is in the Runtime. Maybe we should move the ShutdownHandler mechanism to the runtime?

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change

Can't really test this at the moment. After Py_Finalize (in Shutdown), we can't check the state of the `__import__` function until we call Py_Initialize. But Py_Initialize will create a new `__import__`, so we can't see whether our code ran. This change only becomes relevant when we stop calling Py_Finalize in Shutdown.

-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)