### PR TITLE
Internal implement Py_CompileString for compat with CPython 3.8.0

### DIFF
--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -503,7 +503,7 @@ namespace Python.Runtime
         /// </remarks>
         public static PyObject ModuleFromString(string name, string code)
         {
-            IntPtr c = Runtime.Py_CompileString(code, "none", (IntPtr)257);
+            IntPtr c = Runtime.Py_CompileString(code, "none", (int)RunFlagType.File);
             Runtime.CheckExceptionOccurred();
             IntPtr m = Runtime.PyImport_ExecCodeModule(name, c);
             Runtime.CheckExceptionOccurred();
@@ -512,7 +512,7 @@ namespace Python.Runtime
 
         public static PyObject Compile(string code, string filename = "", RunFlagType mode = RunFlagType.File)
         {
-            var flag = (IntPtr)mode;
+            var flag = (int)mode;
             IntPtr ptr = Runtime.Py_CompileString(code, filename, flag);
             Runtime.CheckExceptionOccurred();
             return new PyObject(ptr);
@@ -610,7 +610,7 @@ namespace Python.Runtime
         }
     }
 
-    public enum RunFlagType
+    public enum RunFlagType : int
     {
         Single = 256,
         File = 257, /* Py_file_input */

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -763,8 +763,36 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyEval_EvalCode(IntPtr co, IntPtr globals, IntPtr locals);
 
+#if PYTHON2
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr Py_CompileString(string code, string file, IntPtr tok);
+        internal static extern IntPtr Py_CompileString(string code, string file, int start);
+#else
+        /// <summary>
+        /// Return value: New reference.
+        /// This is a simplified interface to Py_CompileStringFlags() below, leaving flags set to NULL.
+        /// </summary>
+        internal static IntPtr Py_CompileString(string str, string file, int start)
+        {
+            return Py_CompileStringFlags(str, file, start, IntPtr.Zero);
+        }
+
+        /// <summary>
+        /// Return value: New reference.
+        /// This is a simplified interface to Py_CompileStringExFlags() below, with optimize set to -1.
+        /// </summary>
+        internal static IntPtr Py_CompileStringFlags(string str, string file, int start, IntPtr flags)
+        {
+            return Py_CompileStringExFlags(str, file, start, flags, -1);
+        }
+
+        /// <summary>
+        /// Return value: New reference.
+        /// Like Py_CompileStringObject(), but filename is a byte string decoded from the filesystem encoding(os.fsdecode()).
+        /// </summary>
+        /// <returns></returns>
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr Py_CompileStringExFlags(string str, string file, int start, IntPtr flags, int optimize);
+#endif
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyImport_ExecCodeModule(string name, IntPtr code);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Since the `Py_CompileString` is a macro in `3.8.0`, a compatibility should be add, assume the release user don't use `Py_LIMITED_API`, we can implement it internal.

Also correct the type of `start` from `IntPtr` to `int`, according the protoype is `PyObject* Py_CompileString(const char *str, const char *filename, int start)`

### Does this close any currently open issues?
https://github.com/pythonnet/pythonnet/pull/988#issuecomment-554718263

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
