### PR TITLE
Allow formatting an exception with traceback.format_exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added automatic NuGet package generation in appveyor and local builds
 -   Added function that sets Py_NoSiteFlag to 1.
 -   Added support for Jetson Nano.
+-   Added Format method to PythonException class that uses traceback.format_exception
 
 ### Changed
 

--- a/src/embed_tests/TestPythonException.cs
+++ b/src/embed_tests/TestPythonException.cs
@@ -54,5 +54,41 @@ namespace Python.EmbeddingTest
                 Assert.That(ex.PythonTypeName, Is.EqualTo("ModuleNotFoundError").Or.EqualTo("ImportError"));
             }
         }
+
+        [Test]
+        public void TestPythonExceptionFormat()
+        {
+            try
+            {
+                PythonEngine.Exec("raise ValueError('Error!')");
+                Assert.Fail("Exception should have been raised");
+            }
+            catch (PythonException ex)
+            {
+                Assert.That(ex.Format(), Does.Contain("Traceback").And.Contains("(most recent call last):").And.Contains("ValueError: Error!"));
+            }
+        }
+
+        [Test]
+        public void TestPythonExceptionFormatNoError()
+        {
+            var e = new PythonException();
+            Assert.AreEqual("Missing exception/traceback information", e.Format());
+        }
+
+        [Test]
+        public void TestPythonExceptionFormatNoTraceback()
+        {
+            try
+            {
+                var module = PythonEngine.ImportModule("really____unknown___module");
+                Assert.Fail("Unknown module should not be loaded");
+            }
+            catch (PythonException ex)
+            {
+                // ImportError/ModuleNotFoundError do not have a traceback when not running in a script 
+                Assert.AreEqual("Missing exception/traceback information", ex.Format());
+            }
+        }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This implements the ability to format an exception using traceback.format_exception. This is very useful for when you are embedding Python into an application and want to show the Python exception similar to how it would be printed in the Python console.

### Does this close any currently open issues?

None that I know of.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
