### PR TITLE
GILState.Dispose is safe to be called multiple times

### DIFF
--- a/src/embed_tests/TestGILState.cs
+++ b/src/embed_tests/TestGILState.cs
@@ -1,0 +1,21 @@
+namespace Python.EmbeddingTest
+{
+    using NUnit.Framework;
+    using Python.Runtime;
+
+    public class TestGILState
+    {
+        /// <summary>
+        /// Ensure, that calling <see cref="Py.GILState.Dispose"/> multiple times is safe
+        /// </summary>
+        [Test]
+        public void CanDisposeMultipleTimes()
+        {
+            using (var gilState = Py.GIL())
+            {
+                for(int i = 0; i < 50; i++)
+                    gilState.Dispose();
+            }
+        }
+    }
+}

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -643,7 +643,8 @@ namespace Python.Runtime
         
         public class GILState : IDisposable
         {
-            private IntPtr state;
+            private readonly IntPtr state;
+            private bool isDisposed;
 
             internal GILState()
             {
@@ -652,8 +653,11 @@ namespace Python.Runtime
 
             public void Dispose()
             {
+                if (this.isDisposed) return;
+
                 PythonEngine.ReleaseLock(state);
                 GC.SuppressFinalize(this);
+                this.isDisposed = true;
             }
 
             ~GILState()


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

According to [`IDisposable` documentation](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?redirectedfrom=MSDN&view=netframework-4.8#remarks), `Dispose` method must be safe to call multiple times.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
