### PR TITLE
Proposal: Safe pointers

### DIFF
--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -1,0 +1,26 @@
+namespace Python.Runtime
+{
+    using System;
+    [NonCopyable]
+    ref struct BorrowedReference
+    {
+        public IntPtr Pointer;
+        public bool IsNull => this.Pointer == IntPtr.Zero;
+
+        public PyObject ToPyObject()
+        {
+            if (this.IsNull) throw new NullReferenceException();
+
+            Runtime.XIncref(this.Pointer);
+            return new PyObject(this.Pointer);
+        }
+    }
+
+    static class BorrowedReferenceExtensions {
+        [Obsolete("Use overloads, that take BorrowedReference or NewReference")]
+        public static IntPtr DangerousGetAddress(this in BorrowedReference reference)
+            => reference.IsNull() ? throw new NullReferenceException() : reference.Pointer;
+        public static bool IsNull(this in BorrowedReference reference)
+            => reference.Pointer == IntPtr.Zero;
+    }
+}

--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -3,24 +3,24 @@ namespace Python.Runtime
     using System;
     readonly ref struct BorrowedReference
     {
-        public readonly IntPtr Pointer;
-        public bool IsNull => this.Pointer == IntPtr.Zero;
+        readonly IntPtr pointer;
+        public bool IsNull => this.pointer == IntPtr.Zero;
 
         public PyObject ToPyObject()
         {
             if (this.IsNull) throw new NullReferenceException();
 
-            Runtime.XIncref(this.Pointer);
-            return new PyObject(this.Pointer);
+            Runtime.XIncref(this.pointer);
+            return new PyObject(this.pointer);
         }
 
         [Obsolete("Use overloads, that take BorrowedReference or NewReference")]
         public IntPtr DangerousGetAddress()
-            => this.IsNull ? throw new NullReferenceException() : this.Pointer;
+            => this.IsNull ? throw new NullReferenceException() : this.pointer;
 
         BorrowedReference(IntPtr pointer)
         {
-            this.Pointer = pointer;
+            this.pointer = pointer;
         }
     }
 }

--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -1,9 +1,9 @@
 namespace Python.Runtime
 {
     using System;
-    ref struct BorrowedReference
+    readonly ref struct BorrowedReference
     {
-        public IntPtr Pointer;
+        public readonly IntPtr Pointer;
         public bool IsNull => this.Pointer == IntPtr.Zero;
 
         public PyObject ToPyObject()
@@ -13,13 +13,14 @@ namespace Python.Runtime
             Runtime.XIncref(this.Pointer);
             return new PyObject(this.Pointer);
         }
-    }
 
-    static class BorrowedReferenceExtensions {
         [Obsolete("Use overloads, that take BorrowedReference or NewReference")]
-        public static IntPtr DangerousGetAddress(this in BorrowedReference reference)
-            => reference.IsNull() ? throw new NullReferenceException() : reference.Pointer;
-        public static bool IsNull(this in BorrowedReference reference)
-            => reference.Pointer == IntPtr.Zero;
+        public IntPtr DangerousGetAddress()
+            => this.IsNull ? throw new NullReferenceException() : this.Pointer;
+
+        BorrowedReference(IntPtr pointer)
+        {
+            this.Pointer = pointer;
+        }
     }
 }

--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -1,20 +1,16 @@
 namespace Python.Runtime
 {
     using System;
+    /// <summary>
+    /// Represents a reference to a Python object, that is being lent, and
+    /// can only be safely used until execution returns to the caller.
+    /// </summary>
     readonly ref struct BorrowedReference
     {
         readonly IntPtr pointer;
         public bool IsNull => this.pointer == IntPtr.Zero;
 
-        public PyObject ToPyObject()
-        {
-            if (this.IsNull) throw new NullReferenceException();
-
-            Runtime.XIncref(this.pointer);
-            return new PyObject(this.pointer);
-        }
-
-        [Obsolete("Use overloads, that take BorrowedReference or NewReference")]
+        /// <summary>Gets a raw pointer to the Python object</summary>
         public IntPtr DangerousGetAddress()
             => this.IsNull ? throw new NullReferenceException() : this.pointer;
 

--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -1,7 +1,6 @@
 namespace Python.Runtime
 {
     using System;
-    [NonCopyable]
     ref struct BorrowedReference
     {
         public IntPtr Pointer;

--- a/src/runtime/NewReference.cs
+++ b/src/runtime/NewReference.cs
@@ -1,6 +1,9 @@
 namespace Python.Runtime
 {
     using System;
+    /// <summary>
+    /// Represents a reference to a Python object, that is tracked by Python's reference counting.
+    /// </summary>
     [NonCopyable]
     ref struct NewReference
     {
@@ -11,6 +14,10 @@ namespace Python.Runtime
         public IntPtr DangerousGetAddress()
             => this.IsNull ? throw new NullReferenceException() : this.pointer;
 
+        /// <summary>
+        /// Returns <see cref="PyObject"/> wrapper around this reference, which now owns
+        /// the pointer. Sets the original reference to <c>null</c>, as it no longer owns it.
+        /// </summary>
         public PyObject MoveToPyObject()
         {
             if (this.IsNull) throw new NullReferenceException();
@@ -19,7 +26,9 @@ namespace Python.Runtime
             this.pointer = IntPtr.Zero;
             return result;
         }
-
+        /// <summary>
+        /// Removes this reference to a Python object, and sets it to <c>null</c>.
+        /// </summary>
         public void Dispose()
         {
             if (!this.IsNull)

--- a/src/runtime/NewReference.cs
+++ b/src/runtime/NewReference.cs
@@ -1,0 +1,26 @@
+namespace Python.Runtime
+{
+    using System;
+    [NonCopyable]
+    ref struct NewReference
+    {
+        public IntPtr Pointer { get; set; }
+        public bool IsNull => this.Pointer == IntPtr.Zero;
+
+        public PyObject ToPyObject()
+        {
+            if (this.IsNull) throw new NullReferenceException();
+
+            var result = new PyObject(this.Pointer);
+            this.Pointer = IntPtr.Zero;
+            return result;
+        }
+
+        public void Dispose()
+        {
+            if (!this.IsNull)
+                Runtime.XDecref(this.Pointer);
+            this.Pointer = IntPtr.Zero;
+        }
+    }
+}

--- a/src/runtime/NewReference.cs
+++ b/src/runtime/NewReference.cs
@@ -4,23 +4,27 @@ namespace Python.Runtime
     [NonCopyable]
     ref struct NewReference
     {
-        public IntPtr Pointer { get; set; }
-        public bool IsNull => this.Pointer == IntPtr.Zero;
+        IntPtr pointer;
+        public bool IsNull => this.pointer == IntPtr.Zero;
 
-        public PyObject ToPyObject()
+        /// <summary>Gets a raw pointer to the Python object</summary>
+        public IntPtr DangerousGetAddress()
+            => this.IsNull ? throw new NullReferenceException() : this.pointer;
+
+        public PyObject MoveToPyObject()
         {
             if (this.IsNull) throw new NullReferenceException();
 
-            var result = new PyObject(this.Pointer);
-            this.Pointer = IntPtr.Zero;
+            var result = new PyObject(this.pointer);
+            this.pointer = IntPtr.Zero;
             return result;
         }
 
         public void Dispose()
         {
             if (!this.IsNull)
-                Runtime.XDecref(this.Pointer);
-            this.Pointer = IntPtr.Zero;
+                Runtime.XDecref(this.pointer);
+            this.pointer = IntPtr.Zero;
         }
     }
 }

--- a/src/runtime/NonCopyableAttribute.cs
+++ b/src/runtime/NonCopyableAttribute.cs
@@ -1,0 +1,6 @@
+namespace Python.Runtime
+{
+    using  System;
+    [AttributeUsage(AttributeTargets.Struct)]
+    class NonCopyableAttribute : Attribute { }
+}

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -30,7 +30,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <PythonBuildDir Condition="'$(PythonBuildDir)' == ''">$(SolutionDir)\bin\</PythonBuildDir>
     <PublishDir Condition="'$(TargetFramework)'!='net40'">$(PythonBuildDir)\$(TargetFramework)\</PublishDir>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyOriginatorKeyFile>..\pythonnet.snk</AssemblyOriginatorKeyFile>
     <CustomDefineConstants Condition="'$(CustomDefineConstants)' == ''">$(PYTHONNET_DEFINE_CONSTANTS)</CustomDefineConstants>
@@ -127,6 +127,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.5" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NonCopyableAnalyzer" Version="0.5.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -30,7 +30,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <PythonBuildDir Condition="'$(PythonBuildDir)' == ''">$(SolutionDir)\bin\</PythonBuildDir>
     <PublishDir Condition="'$(TargetFramework)'!='net40'">$(PythonBuildDir)\$(TargetFramework)\</PublishDir>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyOriginatorKeyFile>..\pythonnet.snk</AssemblyOriginatorKeyFile>
     <CustomDefineConstants Condition="'$(CustomDefineConstants)' == ''">$(PYTHONNET_DEFINE_CONSTANTS)</CustomDefineConstants>

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -15,7 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <PythonBuildDir Condition=" '$(PythonBuildDir)' == '' ">$(SolutionDir)\bin\</PythonBuildDir>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pythonnet.snk</AssemblyOriginatorKeyFile>
@@ -83,6 +83,7 @@
     </Compile>
     <Compile Include="arrayobject.cs" />
     <Compile Include="assemblymanager.cs" />
+    <Compile Include="BorrowedReference.cs" />
     <Compile Include="classderived.cs" />
     <Compile Include="classbase.cs" />
     <Compile Include="classmanager.cs" />
@@ -119,6 +120,8 @@
     <Compile Include="moduleobject.cs" />
     <Compile Include="modulepropertyobject.cs" />
     <Compile Include="nativecall.cs" />
+    <Compile Include="NewReference.cs" />
+    <Compile Include="NonCopyableAttribute.cs" />
     <Compile Include="overload.cs" />
     <Compile Include="propertyobject.cs" />
     <Compile Include="pyansistring.cs" />

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -15,7 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <PythonBuildDir Condition=" '$(PythonBuildDir)' == '' ">$(SolutionDir)\bin\</PythonBuildDir>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pythonnet.snk</AssemblyOriginatorKeyFile>

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -145,7 +145,7 @@ namespace Python.Runtime
                 probed.Clear();
                 for (var i = 0; i < count; i++)
                 {
-                    IntPtr item = Runtime.PyList_GetItem(list, i);
+                    BorrowedReference item = Runtime.PyList_GetItem(list, i);
                     string path = Runtime.GetManagedString(item);
                     if (path != null)
                     {

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -292,7 +292,7 @@ namespace Python.Runtime
                 for (int i = 0; i < pynkwargs; ++i)
                 {
                     var keyStr = Runtime.GetManagedString(Runtime.PyList_GetItem(keylist, i));
-                    kwargDict[keyStr] = Runtime.PyList_GetItem(valueList, i);
+                    kwargDict[keyStr] = Runtime.PyList_GetItem(valueList, i).DangerousGetAddress();
                 }
                 Runtime.XDecref(keylist);
                 Runtime.XDecref(valueList);

--- a/src/runtime/pydict.cs
+++ b/src/runtime/pydict.cs
@@ -139,12 +139,13 @@ namespace Python.Runtime
         /// </remarks>
         public PyObject Items()
         {
-            IntPtr items = Runtime.PyDict_Items(obj);
-            if (items == IntPtr.Zero)
+            using var items = Runtime.PyDict_Items(this.obj);
+            if (items.IsNull)
             {
                 throw new PythonException();
             }
-            return new PyObject(items);
+
+            return items.ToPyObject();
         }
 
 

--- a/src/runtime/pydict.cs
+++ b/src/runtime/pydict.cs
@@ -147,7 +147,7 @@ namespace Python.Runtime
                     throw new PythonException();
                 }
 
-                return items.ToPyObject();
+                return items.MoveToPyObject();
             }
             finally
             {

--- a/src/runtime/pydict.cs
+++ b/src/runtime/pydict.cs
@@ -139,13 +139,20 @@ namespace Python.Runtime
         /// </remarks>
         public PyObject Items()
         {
-            using var items = Runtime.PyDict_Items(this.obj);
-            if (items.IsNull)
+            var items = Runtime.PyDict_Items(this.obj);
+            try
             {
-                throw new PythonException();
-            }
+                if (items.IsNull)
+                {
+                    throw new PythonException();
+                }
 
-            return items.ToPyObject();
+                return items.ToPyObject();
+            }
+            finally
+            {
+                items.Dispose();
+            }
         }
 
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1591,7 +1591,7 @@ namespace Python.Runtime
         internal static extern IntPtr PyDict_Values(IntPtr pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyDict_Items(IntPtr pointer);
+        internal static extern NewReference PyDict_Items(IntPtr pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyDict_Copy(IntPtr pointer);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1509,6 +1509,8 @@ namespace Python.Runtime
             return PyUnicode_FromUnicode(s, s.Length);
         }
 
+        internal static string GetManagedString(in BorrowedReference borrowedReference)
+            => GetManagedString(borrowedReference.DangerousGetAddress());
         /// <summary>
         /// Function to access the internal PyUnicode/PyString object and
         /// convert it to a managed string with the correct encoding.
@@ -1631,13 +1633,13 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyList_AsTuple(IntPtr pointer);
 
-        internal static IntPtr PyList_GetItem(IntPtr pointer, long index)
+        internal static BorrowedReference PyList_GetItem(IntPtr pointer, long index)
         {
             return PyList_GetItem(pointer, new IntPtr(index));
         }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr PyList_GetItem(IntPtr pointer, IntPtr index);
+        private static extern BorrowedReference PyList_GetItem(IntPtr pointer, IntPtr index);
 
         internal static int PyList_SetItem(IntPtr pointer, long index, IntPtr value)
         {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

With C# 7.3 `ref structs` and C# 8.0 `using` working on any method named `Dispose` it is possible to track new vs borrowed references at compile time.

This proposal introduces `BorrowedReference` and `NewReference` types, that are `ref`-only structs, meaning you can't put them into `PyObject` directly, so they can implement different `ToPyObject` methods, one doing `IncRef`, and the other one not (alternatively, we can have `PyObject` constructor overloads). Along with Roslyn-based [NonCopyableAnalyzer](https://github.com/ufcpp/NonCopyableAnalyzer) and [FxCop](https://github.com/dotnet/roslyn-analyzers) after https://github.com/dotnet/roslyn-analyzers/issues/3305 is fixed, this can ensure, that we do reference counting correctly at compile time.

We can gradually change return and parameter types in PInvoke methods in `Runtime` to one of `BorrowedReference` or `NewReference` to take advantage of this.

### Downsides
~~Build system must support C# 8.0, which is currently not supported in all build configurations.~~
Without C# 8.0 one would have to dispose `NewReference` instances with `try ... finally ...` block.