### PR TITLE
#1047 ModuleObject __getattribute__ doesn't treat exceptions ocurred during internal GetAttribute

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@
 -   Alex Earl ([@slide](https://github.com/slide))
 -   Alex Helms ([@alexhelms](https://github.com/alexhelms))
 -   Alexandre Catarino([@AlexCatarino](https://github.com/AlexCatarino))
+-   Andrey Sant'Anna ([@andreydani](https://github.com/andreydani))
 -   Arvid JB ([@ArvidJB](https://github.com/ArvidJB))
 -   Benoît Hudson ([@benoithudson](https://github.com/benoithudson))
 -   Bradley Friedman ([@leith-bartrich](https://github.com/leith-bartrich))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
   together with Nuitka
 - Fixes bug where delegates get casts (dotnetcore)
 - Determine size of interpreter longs at runtime
+- Handling exceptions ocurred in ModuleObject's getattribute 
 
 ## [2.4.0][]
 

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -280,7 +280,18 @@ namespace Python.Runtime
                 return self.dict;
             }
 
-            ManagedType attr = self.GetAttribute(name, true);
+            ManagedType attr = null;
+
+            try
+            {
+                attr = self.GetAttribute(name, true);
+            }
+            catch (Exception e)
+            {
+                Exceptions.SetError(e);
+                return IntPtr.Zero;
+            }
+            
 
             if (attr == null)
             {


### PR DESCRIPTION
…during internal GetAttribute

### What does this implement/fix? Explain your changes.

It converts any exception retured from GetAttribute into a Python exception

### Does this close any currently open issues?

Yes, Issue #1047 

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
