### PR TITLE
If tests are taking too long, create a memory dump and abort

### DIFF
--- a/src/embed_tests/GlobalTestsSetup.cs
+++ b/src/embed_tests/GlobalTestsSetup.cs
@@ -51,7 +51,9 @@ namespace Python.EmbeddingTest
             const string dumpPath = "memory.dmp";
 
             // ensure DbgHelp is loaded
-            MiniDumpWriteDump(IntPtr.Zero, 0, IntPtr.Zero, MiniDumpType.Normal, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            MiniDumpWriteDump(IntPtr.Zero, 0, IntPtr.Zero,
+                MiniDumpType.WithFullMemory | MiniDumpType.IgnoreInaccessibleMemory,
+                IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 
             using (var fileHandle = CreateFile(dumpPath, FileAccess.Write, FileShare.Write,
                 securityAttrs: IntPtr.Zero, dwCreationDisposition: FileMode.Create, dwFlagsAndAttributes: 0,
@@ -99,9 +101,33 @@ namespace Python.EmbeddingTest
             int processID, IntPtr hFile, MiniDumpType dumpType,
             IntPtr causeException, IntPtr userStream, IntPtr callback);
 
+        [Flags]
         enum MiniDumpType
         {
-            Normal,
+            Normal = 0x00000000,
+            WithDataSegments = 0x00000001,
+            WithFullMemory = 0x00000002,
+            WithHandleData = 0x00000004,
+            FilterMemory = 0x00000008,
+            ScanMemory = 0x00000010,
+            WithUnloadedModules = 0x00000020,
+            WithIndirectlyReferencedMemory = 0x00000040,
+            FilterModulePaths = 0x00000080,
+            WithProcessThreadData = 0x00000100,
+            WithPrivateReadWriteMemory = 0x00000200,
+            WithoutOptionalData = 0x00000400,
+            WithFullMemoryInfo = 0x00000800,
+            WithThreadInfo = 0x00001000,
+            WithCodeSegments = 0x00002000,
+            WithoutAuxiliaryState = 0x00004000,
+            WithFullAuxiliaryState = 0x00008000,
+            WithPrivateWriteCopyMemory = 0x00010000,
+            IgnoreInaccessibleMemory = 0x00020000,
+            WithTokenInformation = 0x00040000,
+            WithModuleHeaders = 0x00080000,
+            FilterTriage = 0x00100000,
+            WithAvxXStateContext = 0x00200000,
+            ValidTypeFlags = 0x003fffff,
         }
     }
 }

--- a/src/embed_tests/GlobalTestsSetup.cs
+++ b/src/embed_tests/GlobalTestsSetup.cs
@@ -20,15 +20,19 @@ namespace Python.EmbeddingTest
         [OneTimeSetUp]
         public void GlobalSetup()
         {
-            new Thread(() =>
+            if (!Debugger.IsAttached)
             {
-                Thread.Sleep(TimeSpan.FromSeconds(30));
-                UploadDump();
-                Console.Error.WriteLine("Test has been running for too long. Created memory dump");
-                Environment.Exit(1);
-            }) {
-                IsBackground = true,
-            }.Start();
+                new Thread(() =>
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(30));
+                    UploadDump();
+                    Console.Error.WriteLine("Test has been running for too long. Created memory dump");
+                    Environment.Exit(1);
+                })
+                {
+                    IsBackground = true,
+                }.Start();
+            }
         }
 
         [OneTimeTearDown]

--- a/src/embed_tests/GlobalTestsSetup.cs
+++ b/src/embed_tests/GlobalTestsSetup.cs
@@ -1,14 +1,35 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+using Microsoft.Win32.SafeHandles;
 using NUnit.Framework;
 using Python.Runtime;
 
 namespace Python.EmbeddingTest
 {
-
     // As the SetUpFixture, the OneTimeTearDown of this class is executed after
     // all tests have run.
     [SetUpFixture]
     public class GlobalTestsSetup
     {
+        [OneTimeSetUp]
+        public void GlobalSetup()
+        {
+            new Thread(() =>
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(30));
+                UploadDump();
+                Console.Error.WriteLine("Test has been running for too long. Created memory dump");
+                Environment.Exit(1);
+            }) {
+                IsBackground = true,
+            }.Start();
+        }
+
         [OneTimeTearDown]
         public void FinalCleanup()
         {
@@ -16,6 +37,49 @@ namespace Python.EmbeddingTest
             {
                 PythonEngine.Shutdown();
             }
+        }
+
+        static void UploadDump()
+        {
+            var self = Process.GetCurrentProcess();
+
+            const string dumpPath = "memory.dmp";
+
+            // ensure DbgHelp is loaded
+            MiniDumpWriteDump(IntPtr.Zero, 0, IntPtr.Zero, MiniDumpType.Normal, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+
+            using (var fileHandle = CreateFile(dumpPath, FileAccess.Write, FileShare.Write,
+                securityAttrs: IntPtr.Zero, dwCreationDisposition: FileMode.Create, dwFlagsAndAttributes: 0,
+                hTemplateFile: IntPtr.Zero))
+            {
+                if (fileHandle.IsInvalid)
+                    throw new Win32Exception();
+
+                if (!MiniDumpWriteDump(self.Handle, self.Id, fileHandle.DangerousGetHandle(), MiniDumpType.Normal,
+                    causeException: IntPtr.Zero, userStream: IntPtr.Zero, callback: IntPtr.Zero))
+                    throw new Win32Exception();
+            }
+
+            Process.Start("appveyor", arguments: $"PushArtifact -Path \"{dumpPath}\"").WaitForExit();
+        }
+
+        [DllImport("kernel32", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern SafeFileHandle CreateFile(
+            string lpFileName,
+            FileAccess dwDesiredAccess,
+            FileShare dwShareMode,
+            IntPtr securityAttrs,
+            FileMode dwCreationDisposition,
+            int dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+        [DllImport("DbgHelp", SetLastError = true)]
+        static extern bool MiniDumpWriteDump(IntPtr hProcess,
+            int processID, IntPtr hFile, MiniDumpType dumpType,
+            IntPtr causeException, IntPtr userStream, IntPtr callback);
+
+        enum MiniDumpType
+        {
+            Normal,
         }
     }
 }

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -211,9 +211,9 @@ namespace Python.EmbeddingTest
             {
                 Console.WriteLine($"[Program.Main] The Proxy object is valid ({theProxy}). Unexpected domain unload behavior");
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-                Console.WriteLine("[Program.Main] The Proxy object is not valid anymore, domain unload complete.");
+                Console.WriteLine("[Program.Main] The Proxy object is not valid anymore, domain unload complete: " + exception);
             }
         }
 

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -211,9 +211,9 @@ namespace Python.EmbeddingTest
             {
                 Console.WriteLine($"[Program.Main] The Proxy object is valid ({theProxy}). Unexpected domain unload behavior");
             }
-            catch (Exception exception)
+            catch (AppDomainUnloadedException)
             {
-                Console.WriteLine("[Program.Main] The Proxy object is not valid anymore, domain unload complete: " + exception);
+                Console.WriteLine("[Program.Main] The Proxy object is not valid anymore, domain unload complete.");
             }
         }
 


### PR DESCRIPTION
This change is to investigate [AppVeyor tests failing with timeout](https://github.com/pythonnet/pythonnet/issues/1050) #1050
