### PR TITLE
Reduce perf iterations further to keep up with BenchmarkDotNet autotuning

### DIFF
--- a/src/perf_tests/BaselineComparisonConfig.cs
+++ b/src/perf_tests/BaselineComparisonConfig.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Horology;
 
 namespace Python.PerformanceTests
 {
@@ -18,7 +19,11 @@ namespace Python.PerformanceTests
 
             string deploymentRoot = BenchmarkTests.DeploymentRoot;
 
-            var baseJob = Job.Default;
+            var baseJob = Job.Default
+                .WithLaunchCount(1)
+                .WithWarmupCount(3)
+                .WithMaxIterationCount(100)
+                .WithIterationTime(TimeInterval.FromMilliseconds(100));
             this.Add(baseJob
                 .WithId("baseline")
                 .WithEnvironmentVariable(EnvironmentVariableName,


### PR DESCRIPTION
BenchmarkDotNet tuned the number of runs up to keep the total perf tests run time high. This reduces the number of runs per test further, which allows BenchmarkDotNet to do more runs of a smaller test to collect more information for better statistical results.
