### PR TITLE
Ensure Python handles are inaccessible after PythonException is disposed

### DIFF
--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -21,7 +21,7 @@ namespace Python.Runtime
         public PythonException()
         {
             IntPtr gs = PythonEngine.AcquireLock();
-            Runtime.PyErr_Fetch(ref _pyType, ref _pyValue, ref _pyTB);
+            Runtime.PyErr_Fetch(out _pyType, out _pyValue, out _pyTB);
             if (_pyType != IntPtr.Zero && _pyValue != IntPtr.Zero)
             {
                 string type;
@@ -161,12 +161,23 @@ namespace Python.Runtime
                 if (Runtime.Py_IsInitialized() > 0 && !Runtime.IsFinalizing)
                 {
                     IntPtr gs = PythonEngine.AcquireLock();
-                    Runtime.XDecref(_pyType);
-                    Runtime.XDecref(_pyValue);
+                    if (_pyType != IntPtr.Zero)
+                    {
+                        Runtime.XDecref(_pyType);
+                        _pyType= IntPtr.Zero;
+                    }
+
+                    if (_pyValue != IntPtr.Zero)
+                    {
+                        Runtime.XDecref(_pyValue);
+                        _pyValue = IntPtr.Zero;
+                    }
+
                     // XXX Do we ever get TraceBack? //
                     if (_pyTB != IntPtr.Zero)
                     {
                         Runtime.XDecref(_pyTB);
+                        _pyTB = IntPtr.Zero;
                     }
                     PythonEngine.ReleaseLock(gs);
                 }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1933,7 +1933,7 @@ namespace Python.Runtime
         internal static extern IntPtr PyErr_Occurred();
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void PyErr_Fetch(ref IntPtr ob, ref IntPtr val, ref IntPtr tb);
+        internal static extern void PyErr_Fetch(out IntPtr ob, out IntPtr val, out IntPtr tb);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyErr_Restore(IntPtr ob, IntPtr val, IntPtr tb);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This clears references to Python objects from `PythonException` when it is disposed to prevent accidental use in the future.

### Does this close any currently open issues?

No

### Any other comments?

This might help to fix [this crash](https://travis-ci.org/pythonnet/pythonnet/jobs/653883143?utm_medium=notification&utm_source=github_status), which happens immediately after exception handling tests.
