### PR TITLE
Fix for random Travis test crashes with Python 2.7 on Mono

### DIFF
--- a/src/embed_tests/TestRuntime.cs
+++ b/src/embed_tests/TestRuntime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Python.Runtime;
 using Python.Runtime.Platform;
@@ -110,9 +111,15 @@ namespace Python.EmbeddingTest
             // Create an instance of threading.Lock, which is one of the very few types that does not have the
             // TypeFlags.HaveIter set in Python 2. This tests a different code path in PyObject_IsIterable and PyIter_Check.
             var threading = Runtime.Runtime.PyImport_ImportModule("threading");
+            Exceptions.ErrorCheck(threading);
             var threadingDict = Runtime.Runtime.PyModule_GetDict(threading);
+            Exceptions.ErrorCheck(threadingDict);
             var lockType = Runtime.Runtime.PyDict_GetItemString(threadingDict, "Lock");
+            if (lockType == IntPtr.Zero)
+                throw new KeyNotFoundException("class 'Lock' was not found in 'threading'");
+
             var lockInstance = Runtime.Runtime.PyObject_CallObject(lockType, Runtime.Runtime.PyTuple_New(0));
+            Exceptions.ErrorCheck(lockInstance);
 
             Assert.IsFalse(Runtime.Runtime.PyObject_IsIterable(lockInstance));
             Assert.IsFalse(Runtime.Runtime.PyIter_Check(lockInstance));


### PR DESCRIPTION
This is an ongoing work on [random test crashes on Python 2.7 on Mono](https://github.com/pythonnet/pythonnet/issues/1060)

### What does this implement/fix? Explain your changes.

I've added error checks to the test, whose start precedes crashing (`PyCheck_Iter_PyObject_IsIterable_ThreadingLock_Test`). This might replace segfault with a more meaningful error message.

### Does this close any currently open issues?

Not yet, but it should help narrow down #1060 