### PR TITLE
Fixed reference counting for exception objects in Py.With

### DIFF
--- a/src/runtime/Util.cs
+++ b/src/runtime/Util.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Python.Runtime
 {
-    internal class Util
+    internal static class Util
     {
         internal static Int64 ReadCLong(IntPtr tp, int offset)
         {
@@ -29,5 +29,12 @@ namespace Python.Runtime
                 Marshal.WriteInt64(type, offset, flags);
             }
         }
+
+        /// <summary>
+        /// Null-coalesce: if <paramref name="primary"/> parameter is not
+        /// <see cref="IntPtr.Zero"/>, return it. Otherwise return <paramref name="fallback"/>.
+        /// </summary>
+        internal static IntPtr Coalesce(this IntPtr primary, IntPtr fallback)
+            => primary == IntPtr.Zero ? fallback : primary;
     }
 }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -758,11 +758,14 @@ namespace Python.Runtime
             catch (PythonException e)
             {
                 ex = e;
-                type = ex.PyType;
-                val = ex.PyValue;
-                traceBack = ex.PyTB;
+                type = ex.PyType.Coalesce(type);
+                val = ex.PyValue.Coalesce(val);
+                traceBack = ex.PyTB.Coalesce(traceBack);
             }
 
+            Runtime.XIncref(type);
+            Runtime.XIncref(val);
+            Runtime.XIncref(traceBack);
             var exitResult = obj.InvokeMethod("__exit__", new PyObject(type), new PyObject(val), new PyObject(traceBack));
 
             if (ex != null && !exitResult.IsTrue()) throw ex;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`PyObject`s constructed for `__exit__` method referenced existing Python objects without increasing refcount appropriately, which could lead to double-free.

### Does this close any currently open issues?

Not sure, but this issue might have been one of the possible causes for #1050 