### PR TITLE
Explorarion of the new *Reference types: reimplemented some of the PyList members using BorrowedReference

### DIFF
--- a/src/embed_tests/pyimport.cs
+++ b/src/embed_tests/pyimport.cs
@@ -39,7 +39,7 @@ namespace Python.EmbeddingTest
 
             IntPtr str = Runtime.Runtime.PyString_FromString(testPath);
             IntPtr path = Runtime.Runtime.PySys_GetObject("path");
-            Runtime.Runtime.PyList_Append(path, str);
+            Runtime.Runtime.PyList_Append(new BorrowedReference(path), str);
         }
 
         [TearDown]

--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -14,7 +14,10 @@ namespace Python.Runtime
         public IntPtr DangerousGetAddress()
             => this.IsNull ? throw new NullReferenceException() : this.pointer;
 
-        BorrowedReference(IntPtr pointer)
+        /// <summary>
+        /// Creates new instance of <see cref="BorrowedReference"/> from raw pointer. Unsafe.
+        /// </summary>
+        public BorrowedReference(IntPtr pointer)
         {
             this.pointer = pointer;
         }

--- a/src/runtime/pylist.cs
+++ b/src/runtime/pylist.cs
@@ -120,7 +120,7 @@ namespace Python.Runtime
         /// </remarks>
         public void Append(PyObject item)
         {
-            int r = Runtime.PyList_Append(obj, item.obj);
+            int r = Runtime.PyList_Append(this.Reference, item.obj);
             if (r < 0)
             {
                 throw new PythonException();
@@ -135,7 +135,7 @@ namespace Python.Runtime
         /// </remarks>
         public void Insert(int index, PyObject item)
         {
-            int r = Runtime.PyList_Insert(obj, index, item.obj);
+            int r = Runtime.PyList_Insert(this.Reference, index, item.obj);
             if (r < 0)
             {
                 throw new PythonException();
@@ -151,7 +151,7 @@ namespace Python.Runtime
         /// </remarks>
         public void Reverse()
         {
-            int r = Runtime.PyList_Reverse(obj);
+            int r = Runtime.PyList_Reverse(this.Reference);
             if (r < 0)
             {
                 throw new PythonException();
@@ -167,7 +167,7 @@ namespace Python.Runtime
         /// </remarks>
         public void Sort()
         {
-            int r = Runtime.PyList_Sort(obj);
+            int r = Runtime.PyList_Sort(this.Reference);
             if (r < 0)
             {
                 throw new PythonException();

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -33,6 +33,8 @@ namespace Python.Runtime
         private bool disposed = false;
         private bool _finalized = false;
 
+        internal BorrowedReference Reference => new BorrowedReference(obj);
+
         /// <summary>
         /// PyObject Constructor
         /// </summary>
@@ -52,9 +54,24 @@ namespace Python.Runtime
 #endif
         }
 
+        /// <summary>
+        /// Creates new <see cref="PyObject"/> pointing to the same object as
+        /// the <paramref name="reference"/>. Increments refcount, allowing <see cref="PyObject"/>
+        /// to have ownership over its own reference.
+        /// </summary>
+        internal PyObject(BorrowedReference reference)
+        {
+            if (reference.IsNull) throw new ArgumentNullException(nameof(reference));
+
+            obj = Runtime.SelfIncRef(reference.DangerousGetAddress());
+#if TRACE_ALLOC
+            Traceback = new StackTrace(1);
+#endif
+        }
+
         // Protected default constructor to allow subclasses to manage
         // initialization in different ways as appropriate.
-        [Obsolete("Please, always use PyObject(IntPtr)")]
+        [Obsolete("Please, always use PyObject(*Reference)")]
         protected PyObject()
         {
 #if TRACE_ALLOC

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -341,7 +341,7 @@ namespace Python.Runtime
             string rtdir = RuntimeEnvironment.GetRuntimeDirectory();
             IntPtr path = PySys_GetObject("path");
             IntPtr item = PyString_FromString(rtdir);
-            PyList_Append(path, item);
+            PyList_Append(new BorrowedReference(path), item);
             XDecref(item);
             AssemblyManager.UpdatePath();
         }
@@ -1658,22 +1658,22 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         private static extern int PyList_SetItem(IntPtr pointer, IntPtr index, IntPtr value);
 
-        internal static int PyList_Insert(IntPtr pointer, long index, IntPtr value)
+        internal static int PyList_Insert(BorrowedReference pointer, long index, IntPtr value)
         {
             return PyList_Insert(pointer, new IntPtr(index), value);
         }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int PyList_Insert(IntPtr pointer, IntPtr index, IntPtr value);
+        private static extern int PyList_Insert(BorrowedReference pointer, IntPtr index, IntPtr value);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyList_Append(IntPtr pointer, IntPtr value);
+        internal static extern int PyList_Append(BorrowedReference pointer, IntPtr value);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyList_Reverse(IntPtr pointer);
+        internal static extern int PyList_Reverse(BorrowedReference pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyList_Sort(IntPtr pointer);
+        internal static extern int PyList_Sort(BorrowedReference pointer);
 
         internal static IntPtr PyList_GetSlice(IntPtr pointer, long start, long end)
         {


### PR DESCRIPTION
Just playing with the new *Reference types to see what patterns might arise.

This adds:
- `PyObject.Reference` internal property, that exposes the same pointer as `obj`, but in a way, that it is clear, that the reference is borrowed
- `PyObject(BorrowedReference)` constructor, that extracts the address from the reference and `IncRef`s it before storing in the instance
- a few of the `PyList_*` methods now explicitly take `BorrowedReference` instead of raw pointers