### PR TITLE
Add Lock synchronization to PyScopeTest.TestThread

### DIFF
--- a/src/embed_tests/TestPyScope.cs
+++ b/src/embed_tests/TestPyScope.cs
@@ -338,16 +338,16 @@ namespace Python.EmbeddingTest
                     //add function to the scope 
                     //can be call many times, more efficient than ast 
                     ps.Exec(
-                        "import clr\n" +
-                        "from System.Threading import Thread\n" +
+                        "import threading\n" +
+                        "lock = threading.Lock()\n" +
                         "def update():\n" +
-                        "    global res, th_cnt\n" +
+                        "  global res, th_cnt\n" +
+                        "  with lock:\n" +
                         "    res += bb + 1\n" +
-                        "    Thread.MemoryBarrier()\n" +
                         "    th_cnt += 1\n"
                     );
                 }
-                int th_cnt = 3;
+                int th_cnt = 100;
                 for (int i = 0; i < th_cnt; i++)
                 {
                     System.Threading.Thread th = new System.Threading.Thread(() =>
@@ -368,9 +368,8 @@ namespace Python.EmbeddingTest
                     {
                         cnt = ps.Get<int>("th_cnt");
                     }
-                    Thread.Sleep(10);
+                    Thread.Yield();
                 }
-                Thread.MemoryBarrier();
                 using (Py.GIL())
                 {
                     var result = ps.Get<int>("res");


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This adds `Lock` class-based synchronization to `update` Python function
in `PyScopeTest.TestThread` as suggested by @amos402 .

### Does this close any currently open issues?

#1067
