### PR TITLE
Correctly dispose the result of PyRun_String

### DIFF
--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -88,6 +88,7 @@
     <Compile Include="pyimport.cs" />
     <Compile Include="pyinitialize.cs" />
     <Compile Include="pyrunstring.cs" />
+    <Compile Include="References.cs" />
     <Compile Include="TestConverter.cs" />
     <Compile Include="TestCustomMarshal.cs" />
     <Compile Include="TestDomainReload.cs" />

--- a/src/embed_tests/References.cs
+++ b/src/embed_tests/References.cs
@@ -1,0 +1,40 @@
+namespace Python.EmbeddingTest
+{
+    using NUnit.Framework;
+    using Python.Runtime;
+
+    public class References
+    {
+        private Py.GILState _gs;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _gs = Py.GIL();
+        }
+
+        [TearDown]
+        public void Dispose()
+        {
+            _gs.Dispose();
+        }
+
+        [Test]
+        public void MoveToPyObject_SetsNull()
+        {
+            var dict = new PyDict();
+            NewReference reference = Runtime.PyDict_Items(dict.Handle);
+            try
+            {
+                Assert.IsFalse(reference.IsNull());
+
+                using (reference.MoveToPyObject())
+                    Assert.IsTrue(reference.IsNull());
+            }
+            finally
+            {
+                reference.Dispose();
+            }
+        }
+    }
+}

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -141,6 +141,7 @@
     <Compile Include="pythonengine.cs" />
     <Compile Include="pythonexception.cs" />
     <Compile Include="pytuple.cs" />
+    <Compile Include="ReferenceExtensions.cs" />
     <Compile Include="runtime.cs" />
     <Compile Include="typemanager.cs" />
     <Compile Include="typemethod.cs" />

--- a/src/runtime/ReferenceExtensions.cs
+++ b/src/runtime/ReferenceExtensions.cs
@@ -1,0 +1,20 @@
+namespace Python.Runtime
+{
+    using System.Diagnostics.Contracts;
+
+    static class ReferenceExtensions
+    {
+        /// <summary>
+        /// Checks if the reference points to Python object <c>None</c>.
+        /// </summary>
+        [Pure]
+        public static bool IsNone(this in NewReference reference)
+            => reference.DangerousGetAddress() == Runtime.PyNone;
+        /// <summary>
+        /// Checks if the reference points to Python object <c>None</c>.
+        /// </summary>
+        [Pure]
+        public static bool IsNone(this BorrowedReference reference)
+            => reference.DangerousGetAddress() == Runtime.PyNone;
+    }
+}

--- a/src/runtime/pydict.cs
+++ b/src/runtime/pydict.cs
@@ -142,7 +142,7 @@ namespace Python.Runtime
             var items = Runtime.PyDict_Items(this.obj);
             try
             {
-                if (items.IsNull)
+                if (items.IsNull())
                 {
                     throw new PythonException();
                 }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -543,12 +543,13 @@ namespace Python.Runtime
         /// </remarks>
         public static void Exec(string code, IntPtr? globals = null, IntPtr? locals = null)
         {
-            PyObject result = RunString(code, globals, locals, RunFlagType.File);
-            if (result.obj != Runtime.PyNone)
+            using (PyObject result = RunString(code, globals, locals, RunFlagType.File))
             {
-                throw new PythonException();
+                if (result.obj != Runtime.PyNone)
+                {
+                    throw new PythonException();
+                }
             }
-            result.Dispose();
         }
 
 
@@ -594,13 +595,20 @@ namespace Python.Runtime
 
             try
             {
-                IntPtr result = Runtime.PyRun_String(
+                NewReference result = Runtime.PyRun_String(
                     code, (IntPtr)flag, globals.Value, locals.Value
                 );
 
-                Runtime.CheckExceptionOccurred();
+                try
+                {
+                    Runtime.CheckExceptionOccurred();
 
-                return new PyObject(result);
+                    return result.MoveToPyObject();
+                }
+                finally
+                {
+                    result.Dispose();
+                }
             }
             finally
             {

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -802,7 +802,7 @@ namespace Python.Runtime
         internal static extern int PyRun_SimpleString(string code);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyRun_String(string code, IntPtr st, IntPtr globals, IntPtr locals);
+        internal static extern NewReference PyRun_String(string code, IntPtr st, IntPtr globals, IntPtr locals);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyEval_EvalCode(IntPtr co, IntPtr globals, IntPtr locals);


### PR DESCRIPTION
this also changes a few members of `NewReference` type to make them work in `PyRun_String` scenario

### What does this implement/fix? Explain your changes.

This PR is motivated by an observation of a crash after `PyRunString.TestExec2`. It calls `PythonEngine.Exec`, which in case of exception fails to decref `PyRun_String` result.

I replace `PyRun_String` return type with `NewReference` and handle it accordingly.

### `NewReference` instance members replaced with extension methods

In the process of making this change it was discovered, that members of `NewReference` should be moved to an extension class, because in regular instance members `this` is passed by mutable reference (e.g. analogous to `ref NewReference` in C# or `NewReference&` in C++),
which requires any method calling this member to have a mutable reference to `NewReference`:
```csharp
bool TakeReference(NewReference reference)
  // can use `IsNull` here, because `reference` is a mutable parameter-variable
  // but this causes a problem below
  => reference.IsNull; 
NewReference reference = ...;
TakeReference(reference); // <= ERROR: `reference` has to be copied to be passed by value
                          // but we can't simply copy instances of `NewReference`
```

```csharp
bool TakeReference(in NewReference reference)
  => reference.IsNull; // <= ERROR: instance member IsNull requires mutable `reference`
                       // but `in` makes it read-only. We could fix it by using `ref` instead,
                       // but that would force us to use `ref` in the caller, its caller, etc
```

Instead we do this:
```csharp
bool TakeReference(in NewReference reference) => reference.IsNull();
static bool IsNull(this in NewReference reference)
    // NOTE: `this in` above impossible in regular instance members
  => reference.pointer == IntPtr.Zero;
```

This would be obsolete one day once https://github.com/dotnet/csharplang/issues/1710 is released.

### Does this close any currently open issues?

This might (unlikely) fix this test crash: https://ci.appveyor.com/project/pythonnet/pythonnet/builds/31115525/job/kkciw8xk5jaux5t7

### Checklist

-   [x] Make sure to include one or more tests for your change