### PR TITLE
Provide more info about failuers to load CLR assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Changed
 -   Drop support for Python 2
+-   `clr.AddReference` may now throw errors besides `FileNotFoundException`, that provide more
+details about the cause of the failure
+-   `clr.AddReference` no longer adds ".dll" implicitly
 
 ### Fixed
 

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -254,9 +254,9 @@ namespace Python.Runtime
         /// Sets the current Python exception given a Python object.
         /// This is a wrapper for the Python PyErr_SetObject call.
         /// </remarks>
-        public static void SetError(IntPtr ob, IntPtr value)
+        public static void SetError(IntPtr type, IntPtr exceptionObject)
         {
-            Runtime.PyErr_SetObject(ob, value);
+            Runtime.PyErr_SetObject(new BorrowedReference(type), new BorrowedReference(exceptionObject));
         }
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace Python.Runtime
 
             IntPtr op = CLRObject.GetInstHandle(e);
             IntPtr etype = Runtime.PyObject_GetAttrString(op, "__class__");
-            Runtime.PyErr_SetObject(etype, op);
+            Runtime.PyErr_SetObject(new BorrowedReference(etype), new BorrowedReference(op));
             Runtime.XDecref(etype);
             Runtime.XDecref(op);
         }

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -291,8 +291,8 @@ namespace Python.Runtime
                 IntPtr valueList = Runtime.PyDict_Values(kw);
                 for (int i = 0; i < pynkwargs; ++i)
                 {
-                    var keyStr = Runtime.GetManagedString(Runtime.PyList_GetItem(keylist, i));
-                    kwargDict[keyStr] = Runtime.PyList_GetItem(valueList, i).DangerousGetAddress();
+                    var keyStr = Runtime.GetManagedString(Runtime.PyList_GetItem(new BorrowedReference(keylist), i));
+                    kwargDict[keyStr] = Runtime.PyList_GetItem(new BorrowedReference(valueList), i).DangerousGetAddress();
                 }
                 Runtime.XDecref(keylist);
                 Runtime.XDecref(valueList);

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -119,7 +119,7 @@ namespace Python.Runtime
             // cost. Ask the AssemblyManager to do implicit loading for each
             // of the steps in the qualified name, then try it again.
             bool ignore = name.StartsWith("__");
-            if (AssemblyManager.LoadImplicit(qname, !ignore))
+            if (AssemblyManager.LoadImplicit(qname, assemblyLoadErrorHandler: ImportWarning, !ignore))
             {
                 if (AssemblyManager.IsValidNamespace(qname))
                 {
@@ -159,6 +159,11 @@ namespace Python.Runtime
             }
 
             return null;
+        }
+
+        static void ImportWarning(Exception exception)
+        {
+            Exceptions.warn(exception.ToString(), Exceptions.ImportWarning);
         }
 
 
@@ -365,7 +370,7 @@ namespace Python.Runtime
             if (interactive_preload)
             {
                 interactive_preload = false;
-                if (Runtime.PySys_GetObject("ps1") != IntPtr.Zero)
+                if (!Runtime.PySys_GetObject("ps1").IsNull)
                 {
                     preload = true;
                 }

--- a/src/runtime/pylist.cs
+++ b/src/runtime/pylist.cs
@@ -22,6 +22,11 @@ namespace Python.Runtime
         {
         }
 
+        /// <summary>
+        /// Creates new <see cref="PyList"/> pointing to the same object, as the given reference.
+        /// </summary>
+        internal PyList(BorrowedReference reference) : base(reference) { }
+
 
         /// <summary>
         /// PyList Constructor

--- a/src/runtime/pysequence.cs
+++ b/src/runtime/pysequence.cs
@@ -16,6 +16,8 @@ namespace Python.Runtime
         {
         }
 
+        internal PySequence(BorrowedReference reference) : base(reference) { }
+
         protected PySequence()
         {
         }

--- a/src/runtime/pytuple.cs
+++ b/src/runtime/pytuple.cs
@@ -22,6 +22,15 @@ namespace Python.Runtime
         {
         }
 
+        /// <summary>
+        /// PyTuple Constructor
+        /// </summary>
+        /// <remarks>
+        /// Creates a new PyTuple from an existing object reference.
+        /// The object reference is not checked for type-correctness.
+        /// </remarks>
+        internal PyTuple(BorrowedReference reference) : base(reference) { }
+
 
         /// <summary>
         /// PyTuple Constructor


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

1. When trying to implicitly load assemblies, and that fails **not** because an assembly is missing, but because loading failed for some reason, emit Python warning.
2. When trying to import a module in our import hook, if the module name is an assembly name, and CLR fails to load it, and Python also fails to find a module with the same name, add the exceptions we got from both during the attempt into `__cause__` attribute of the final `ImportError`.

BREAKING: `clr.AddReference` will now throw exceptions besides `FileNotFoundException`.

Additional: a few uses of `BorrowedReference`

### Does this close any currently open issues?

This addresses https://github.com/pythonnet/pythonnet/issues/261
It is an alternative to https://github.com/pythonnet/pythonnet/pull/298

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
