### PR TITLE
object.GetRawPythonProxy() extension, that bypasses all conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added function that sets Py_NoSiteFlag to 1.
 -   Added support for Jetson Nano.
 -   Added support for __len__ for .NET classes that implement ICollection
+-   Added `object.GetRawPythonProxy() -> PyObject` extension method, that bypasses any conversions
 
 ### Changed
 
@@ -21,6 +22,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Removes PyLong_GetMax and PyClass_New when targetting Python3
 -   Added support for converting python iterators to C# arrays
 -   Changed usage of obselete function GetDelegateForFunctionPointer(IntPtr, Type) to GetDelegateForFunctionPointer<TDelegate>(IntPtr)
+-   When calling C# from Python, enable passing argument of any type to a parameter of C# type `object` by wrapping it into `PyObject` instance. ([#881][i881])
 -   Added support for kwarg parameters when calling .NET methods from Python
 
 ### Fixed
@@ -58,7 +60,6 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Reattach python exception traceback information (#545)
 -   PythonEngine.Intialize will now call `Py_InitializeEx` with a default value of 0, so signals will not be configured by default on embedding. This is different from the previous behaviour, where `Py_Initialize` was called instead, which sets initSigs to 1. ([#449][i449])
 -   Refactored MethodBinder.Bind in preparation to make it extensible (#829)
--   When calling C# from Python, enable passing argument of any type to a parameter of C# type `object` by wrapping it into `PyObject` instance. ([#881][i881])
 -   Look for installed Windows 10 sdk's during installation instead of relying on specific versions.
 
 ### Fixed

--- a/pythonnet.15.sln
+++ b/pythonnet.15.sln
@@ -17,6 +17,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repo", "Repo", "{441A0123-F4C6-4EE4-9AEE-315FD79BE2D5}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		CHANGELOG.md = CHANGELOG.md
+		README.rst = README.rst
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{D301657F-5EAF-4534-B280-B858D651B2E5}"

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Python.Runtime;
 
@@ -43,6 +45,27 @@ namespace Python.EmbeddingTest
 
             Assert.IsTrue(converted);
             Assert.IsTrue(((double) convertedValue).Equals(testValue));
+        }
+
+        [Test]
+        public void RawListProxy()
+        {
+            var list = new List<string> {"hello", "world"};
+            var listProxy = list.GetRawPythonProxy();
+            var clrObject = (CLRObject)ManagedType.GetManagedObject(listProxy.Handle);
+            Assert.AreSame(list, clrObject.inst);
+        }
+
+        [Test]
+        public void RawPyObjectProxy()
+        {
+            var pyObject = "hello world!".ToPython();
+            var pyObjectProxy = pyObject.GetRawPythonProxy();
+            var clrObject = (CLRObject)ManagedType.GetManagedObject(pyObjectProxy.Handle);
+            Assert.AreSame(pyObject, clrObject.inst);
+
+            var proxiedHandle = pyObjectProxy.GetAttr("Handle").As<IntPtr>();
+            Assert.AreEqual(pyObject.Handle, proxiedHandle);
         }
     }
 }

--- a/src/runtime/NewReference.cs
+++ b/src/runtime/NewReference.cs
@@ -33,6 +33,12 @@ namespace Python.Runtime
             this.pointer = IntPtr.Zero;
         }
 
+        /// <summary>
+        /// Creates <see cref="NewReference"/> from a raw pointer
+        /// </summary>
+        public static NewReference DangerousFromPointer(IntPtr pointer)
+            => new NewReference {pointer = pointer};
+
         [Pure]
         internal static IntPtr DangerousGetAddress(in NewReference reference)
             => IsNull(reference) ? throw new NullReferenceException() : reference.pointer;

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -68,5 +68,17 @@ namespace Python.Runtime
             CLRObject co = GetInstance(ob);
             return co.pyHandle;
         }
+
+        /// <summary>
+        /// Creates <see cref="CLRObject"/> proxy for the given object,
+        /// and returns a <see cref="NewReference"/> to it.
+        /// </summary>
+        internal static NewReference MakeNewReference(object obj)
+        {
+            if (obj is null) throw new ArgumentNullException(nameof(obj));
+
+            // TODO: CLRObject currently does not have Dispose or finalizer which might change in the future
+            return NewReference.DangerousFromPointer(GetInstHandle(obj));
+        }
     }
 }

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -967,5 +967,16 @@ namespace Python.Runtime
         {
             return new PyObject(Converter.ToPython(o, o?.GetType()));
         }
+
+        /// <summary>
+        /// Gets raw Python proxy for this object (bypasses all conversions,
+        /// except <c>null</c> &lt;==&gt; <c>None</c>)
+        /// </summary>
+        public static PyObject GetRawPythonProxy(this object o)
+        {
+            if (o is null) return new PyObject(new BorrowedReference(Runtime.PyNone));
+
+            return CLRObject.MakeNewReference(o).MoveToPyObject();
+        }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`GetRawPythonProxy` creates a `PyObject` pointing to the specified CLR object without performing any conversions, which lets .NET code to pass CLR objects as-is, if it needs Python to have direct access to them.

This is necessary to allow codecs to create arbitrary proxy objects for .NET objects, bypassing default conversions or other registered codecs.

### Does this close any currently open issues?

This is related to #514

### Any other comments?

Without `GetRawPythonProxy` it is impossible for a user to define custom codec for `List<T>`, that returns raw proxy to `List<T>`, as they have no other means to obtain one.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
