### PR TITLE
Python runtime must be initialized before trying to acquire GIL

### DIFF
--- a/src/embed_tests/TestGILState.cs
+++ b/src/embed_tests/TestGILState.cs
@@ -17,5 +17,17 @@ namespace Python.EmbeddingTest
                     gilState.Dispose();
             }
         }
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
     }
 }


### PR DESCRIPTION
Subj. `TestGILState` was missing `PythonEngine.Initialize` setup action.
