### PR TITLE
Allow borrowing from NewReference

### DIFF
--- a/src/embed_tests/References.cs
+++ b/src/embed_tests/References.cs
@@ -36,5 +36,20 @@ namespace Python.EmbeddingTest
                 reference.Dispose();
             }
         }
+
+        [Test]
+        public void CanBorrowFromNewReference()
+        {
+            var dict = new PyDict();
+            NewReference reference = Runtime.PyDict_Items(dict.Handle);
+            try
+            {
+                PythonException.ThrowIfIsNotZero(Runtime.PyList_Reverse(reference));
+            }
+            finally
+            {
+                reference.Dispose();
+            }
+        }
     }
 }

--- a/src/runtime/NewReference.cs
+++ b/src/runtime/NewReference.cs
@@ -11,6 +11,10 @@ namespace Python.Runtime
     {
         IntPtr pointer;
 
+        [Pure]
+        public static implicit operator BorrowedReference(in NewReference reference)
+            => new BorrowedReference(reference.pointer);
+
         /// <summary>
         /// Returns <see cref="PyObject"/> wrapper around this reference, which now owns
         /// the pointer. Sets the original reference to <c>null</c>, as it no longer owns it.
@@ -36,6 +40,7 @@ namespace Python.Runtime
         /// <summary>
         /// Creates <see cref="NewReference"/> from a raw pointer
         /// </summary>
+        [Pure]
         public static NewReference DangerousFromPointer(IntPtr pointer)
             => new NewReference {pointer = pointer};
 


### PR DESCRIPTION
implemented as an implicit conversion

To be honest, I would prefer an explicit `NewReference.Borrow()` method due to "explicit is better than implicit" motto. The only problem with implicit conversion that I see is `new PyObject(newRef)` will call an extra incref implicitly as opposed to `newRef.MoveToPyObject()`, and will go unnoticed.

Another thing to consider is having a `null`-check in the conversion. E.g. should we throw `NullReferenceException` if `NewReference` is `null`?

### Does this close any currently open issues?

Related to #1087

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example