### PR TITLE
The unicode error was resolved.

### DIFF
--- a/src/embed_tests/dynamic.cs
+++ b/src/embed_tests/dynamic.cs
@@ -138,5 +138,21 @@ namespace Python.EmbeddingTest
             // Compare in .NET
             Assert.IsTrue(sys.testattr1.Equals(sys.testattr2));
         }
+
+        /// <summary>
+        /// Test the encoding of UTF-8 
+        /// </summary>
+        [Test]
+        public void TestEncodingUTF8()
+        {
+            dynamic sys = Py.Import("sys");
+            PythonEngine.RunSimpleString(Encoding.UTF32.GetBytes(
+                "import sys\n" +
+                "printf('안녕하세요')\n" +
+                "sys.val = '안녕하세요'\n"
+            ));
+
+            Assert.AreEqual(sys.val.ToString(), "안녕하세요");
+        }
     }
 }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -145,6 +145,11 @@ namespace Python.Runtime
             return Runtime.PyRun_SimpleString(code);
         }
 
+        public static int RunSimpleString(byte[] code)
+        {
+            return Runtime.PyRun_SimpleString(code);
+        }
+
         public static void Initialize()
         {
             Initialize(setSysArgv: true);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -802,6 +802,9 @@ namespace Python.Runtime
         internal static extern int PyRun_SimpleString(string code);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int PyRun_SimpleString(byte[] code);
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern NewReference PyRun_String(string code, IntPtr st, IntPtr globals, IntPtr locals);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Hello.
When using Korean or Japanese this pythonnet, I was found where the encoding type cannot be selected. When using the existing general string, the following error occurs.
![image](https://user-images.githubusercontent.com/17442903/76605926-a948cc00-6554-11ea-9ef9-6041a4ed071e.png)
So, I have commit the solution, please can you confirm it?

Thank you very much.

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
