### PR TITLE
Simplified Finalizer: drain finalization queue when new objects are created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   When calling C# from Python, enable passing argument of any type to a parameter of C# type `object` by wrapping it into `PyObject` instance. ([#881][i881])
 -   Added support for kwarg parameters when calling .NET methods from Python
 -   Changed method for finding MSBuild using vswhere
+-   Reworked `Finalizer`. Now objects drop into its queue upon finalization, which is periodically drained when new objects are created.
 
 ### Fixed
 

--- a/src/embed_tests/TestFinalizer.cs
+++ b/src/embed_tests/TestFinalizer.cs
@@ -77,7 +77,7 @@ namespace Python.EmbeddingTest
             }
             try
             {
-                Finalizer.Instance.Collect(forceDispose: false);
+                Finalizer.Instance.Collect();
             }
             finally
             {

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -35,13 +35,13 @@ namespace Python.Runtime
         }
 
 
-        internal static CLRObject GetInstance(object ob, IntPtr pyType)
+        static CLRObject GetInstance(object ob, IntPtr pyType)
         {
             return new CLRObject(ob, pyType);
         }
 
 
-        internal static CLRObject GetInstance(object ob)
+        static CLRObject GetInstance(object ob)
         {
             ClassBase cc = ClassManager.GetClass(ob.GetType());
             return GetInstance(ob, cc.tpHandle);

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -187,7 +187,29 @@ namespace Python.Runtime
 
             if (!Runtime.IsFinalizing)
             {
-                Runtime.XDecref(this.obj);
+                long refcount = Runtime.Refcount(this.obj);
+                Debug.Assert(refcount > 0, "Object refcount is 0 or less");
+
+                if (refcount == 1)
+                {
+                    Runtime.PyErr_Fetch(out var errType, out var errVal, out var traceback);
+
+                    try
+                    {
+                        Runtime.XDecref(this.obj);
+                        Runtime.CheckExceptionOccurred();
+                    }
+                    finally
+                    {
+                        // Python requires finalizers to preserve exception:
+                        // https://docs.python.org/3/extending/newtypes.html#finalization-and-de-allocation
+                        Runtime.PyErr_Restore(errType, errVal, traceback);
+                    }
+                }
+                else
+                {
+                    Runtime.XDecref(this.obj);
+                }
             }
             this.obj = IntPtr.Zero;
         }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -30,8 +30,6 @@ namespace Python.Runtime
 #endif  
 
         protected internal IntPtr obj = IntPtr.Zero;
-        private bool disposed = false;
-        private bool _finalized = false;
 
         internal BorrowedReference Reference => new BorrowedReference(obj);
 
@@ -49,6 +47,7 @@ namespace Python.Runtime
             if (ptr == IntPtr.Zero) throw new ArgumentNullException(nameof(ptr));
 
             obj = ptr;
+            Finalizer.Instance.ThrottledCollect();
 #if TRACE_ALLOC
             Traceback = new StackTrace(1);
 #endif
@@ -64,6 +63,7 @@ namespace Python.Runtime
             if (reference.IsNull) throw new ArgumentNullException(nameof(reference));
 
             obj = Runtime.SelfIncRef(reference.DangerousGetAddress());
+            Finalizer.Instance.ThrottledCollect();
 #if TRACE_ALLOC
             Traceback = new StackTrace(1);
 #endif
@@ -74,6 +74,7 @@ namespace Python.Runtime
         [Obsolete("Please, always use PyObject(*Reference)")]
         protected PyObject()
         {
+            Finalizer.Instance.ThrottledCollect();
 #if TRACE_ALLOC
             Traceback = new StackTrace(1);
 #endif
@@ -87,12 +88,6 @@ namespace Python.Runtime
             {
                 return;
             }
-            if (_finalized || disposed)
-            {
-                return;
-            }
-            // Prevent a infinity loop by calling GC.WaitForPendingFinalizers
-            _finalized = true;
             Finalizer.Instance.AddFinalizedObject(this);
         }
 
@@ -182,17 +177,19 @@ namespace Python.Runtime
         /// </remarks>
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (this.obj == IntPtr.Zero)
             {
-                if (Runtime.Py_IsInitialized() > 0 && !Runtime.IsFinalizing)
-                {
-                    IntPtr gs = PythonEngine.AcquireLock();
-                    Runtime.XDecref(obj);
-                    obj = IntPtr.Zero;
-                    PythonEngine.ReleaseLock(gs);
-                }
-                disposed = true;
+                return;
             }
+
+            if (Runtime.Py_IsInitialized() == 0)
+                throw new InvalidOperationException("Python runtime must be initialized");
+
+            if (!Runtime.IsFinalizing)
+            {
+                Runtime.XDecref(this.obj);
+            }
+            this.obj = IntPtr.Zero;
         }
 
         public void Dispose()

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -80,6 +80,7 @@ namespace Python.Runtime
             }
             set
             {
+                // this value is null in the beginning
                 Marshal.FreeHGlobal(_pythonHome);
                 _pythonHome = UcsMarshaler.Py3UnicodePy2StringtoPtr(value);
                 Runtime.Py_SetPythonHome(_pythonHome);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
@@ -8,7 +9,6 @@ using Python.Runtime.Platform;
 
 namespace Python.Runtime
 {
-
     /// <summary>
     /// Encapsulates the low-level Python C API. Note that it is
     /// the responsibility of the caller to have acquired the GIL
@@ -106,7 +106,7 @@ namespace Python.Runtime
         internal static object IsFinalizingLock = new object();
         internal static bool IsFinalizing;
 
-        internal static bool Is32Bit = IntPtr.Size == 4;
+        internal static bool Is32Bit => IntPtr.Size == 4;
 
         // .NET core: System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         internal static bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
@@ -649,6 +649,7 @@ namespace Python.Runtime
 #endif
         }
 
+        [Pure]
         internal static unsafe long Refcount(IntPtr op)
         {
             var p = (void*)op;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This is an attempt to make finalizer much simpler.

Instead of using .NET async tasks, `Py_AddPendingCall` or other synchronization mechanisms we simply move objects to be finalized into a `ConcurrentQueue`, which is periodically drained when a new `PyObject` is constructed.

### Does this close any currently open issues?

At the very least this should be resolved, as the new finalization code never tries to acquire GIL on its own: #1093

### Performance

`Finalizer` is not in the baseline (e.g. Python.Runtime 2.3.0), but the following test drops from 98ms/op to 93ms/op on my machine:
```csharp
const int testObjectCount = 100000;
using (Py.GIL())
{
    for (int i = 0; i < testObjectCount; i++)
        new PyList();
}
GC.Collect();
GC.WaitForPendingFinalizers();
Finalizer.Instance.Collect();
```

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)

### Suggested reviewers

@amos402 @Martin-Molinero @benoithudson 