### PR TITLE
fix compile error when PYTHON_WITHOUT_ENABLE_SHARED is not set

### DIFF
--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1976,11 +1976,9 @@ namespace Python.Runtime
         {
             var loader = LibraryLoader.Get(OperatingSystem);
 
-            IntPtr dllLocal;
-            if (_PythonDll != "__Internal")
-            {
-                dllLocal = loader.Load(_PythonDll);
-            }
+            IntPtr dllLocal = _PythonDll != "__Internal"
+                ? loader.Load(_PythonDll)
+                : IntPtr.Zero;
 
             try
             {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This solves 

> error CS0165: Use of unassigned local variable 'dllLocal'

when building with `PYTHON_WITHOUT_ENABLE_SHARED`

### Does this close any currently open issues?

Yes, #977

### Any other comments?

This restores build on many platforms, however, I am not sure about behavior on platforms, where python executable is not linked to libpython. The change is otherwise harmless.
