### PR TITLE
Remove unnecessary glib-dev dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -398,11 +398,9 @@ class BuildExtPythonnet(build_ext.build_ext):
                 return
             raise
         mono_cflags = _check_output("pkg-config --cflags mono-2", shell=True)
-        glib_libs = _check_output("pkg-config --libs glib-2.0", shell=True)
-        glib_cflags = _check_output("pkg-config --cflags glib-2.0", shell=True)
-        cflags = mono_cflags.strip() + " " + glib_cflags.strip()
-        libs = mono_libs.strip() + " " + glib_libs.strip()
-
+        cflags = mono_cflags.strip()
+        libs = mono_libs.strip()
+        
         # build the clr python module
         clr_ext = Extension(
             "clr",

--- a/src/monoclr/pynetclr.h
+++ b/src/monoclr/pynetclr.h
@@ -7,7 +7,6 @@
 #include <mono/metadata/mono-config.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/assembly.h>
-#include <glib.h>
 
 #define MONO_VERSION "v4.0.30319.1"
 #define MONO_DOMAIN "Python.Runtime"
@@ -27,7 +26,7 @@ typedef struct
 
 PyNet_Args *PyNet_Init(int);
 void PyNet_Finalize(PyNet_Args *);
-void main_thread_handler(gpointer user_data);
+void main_thread_handler(PyNet_Args *user_data);
 char *PyNet_ExceptionToString(MonoObject *);
 
 #endif // PYNET_CLR_H

--- a/src/monoclr/pynetinit.c
+++ b/src/monoclr/pynetinit.c
@@ -91,9 +91,9 @@ MonoMethod *getMethodFromClass(MonoClass *cls, char *name)
     return method;
 }
 
-void main_thread_handler(gpointer user_data)
+void main_thread_handler(PyNet_Args *user_data)
 {
-    PyNet_Args *pn_args = (PyNet_Args *)user_data;
+    PyNet_Args *pn_args = user_data;
     MonoMethod *init;
     MonoImage *pr_image;
     MonoClass *pythonengine;
@@ -241,7 +241,7 @@ void main_thread_handler(gpointer user_data)
 // Get string from a Mono exception
 char *PyNet_ExceptionToString(MonoObject *e)
 {
-    MonoMethodDesc *mdesc = mono_method_desc_new(":ToString()", FALSE);
+    MonoMethodDesc *mdesc = mono_method_desc_new(":ToString()", 0 /*FALSE*/);
     MonoMethod *mmethod = mono_method_desc_search_in_class(mdesc, mono_get_object_class());
     mono_method_desc_free(mdesc);
 


### PR DESCRIPTION
It was only used for `gobject` type, which is simply a pointer.
