### PR TITLE
RawProxyEncoder

### DIFF
--- a/src/embed_tests/CodecGroups.cs
+++ b/src/embed_tests/CodecGroups.cs
@@ -11,10 +11,10 @@ namespace Python.EmbeddingTest
         [Test]
         public void GetEncodersByType()
         {
-            var encoder1 = new ObjectToRawProxyEncoder<Uri>();
-            var encoder2 = new ObjectToRawProxyEncoder<Uri>();
+            var encoder1 = new ObjectToEncoderInstanceEncoder<Uri>();
+            var encoder2 = new ObjectToEncoderInstanceEncoder<Uri>();
             var group = new EncoderGroup {
-                new ObjectToRawProxyEncoder<Tuple<int>>(),
+                new ObjectToEncoderInstanceEncoder<Tuple<int>>(),
                 encoder1,
                 encoder2,
             };
@@ -27,8 +27,8 @@ namespace Python.EmbeddingTest
         public void CanEncode()
         {
             var group = new EncoderGroup {
-                new ObjectToRawProxyEncoder<Tuple<int>>(),
-                new ObjectToRawProxyEncoder<Uri>(),
+                new ObjectToEncoderInstanceEncoder<Tuple<int>>(),
+                new ObjectToEncoderInstanceEncoder<Uri>(),
             };
 
             Assert.IsTrue(group.CanEncode(typeof(Tuple<int>)));
@@ -39,9 +39,9 @@ namespace Python.EmbeddingTest
         [Test]
         public void Encodes()
         {
-            var encoder0 = new ObjectToRawProxyEncoder<Tuple<int>>();
-            var encoder1 = new ObjectToRawProxyEncoder<Uri>();
-            var encoder2 = new ObjectToRawProxyEncoder<Uri>();
+            var encoder0 = new ObjectToEncoderInstanceEncoder<Tuple<int>>();
+            var encoder1 = new ObjectToEncoderInstanceEncoder<Uri>();
+            var encoder2 = new ObjectToEncoderInstanceEncoder<Uri>();
             var group = new EncoderGroup {
                 encoder0,
                 encoder1,

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -86,9 +86,9 @@ namespace Python.EmbeddingTest {
 
     /// <summary>
     /// "Decodes" only objects of exact type <typeparamref name="T"/>.
-    /// Result is just a raw Python object proxy.
+    /// Result is just the raw proxy to the encoder instance itself.
     /// </summary>
-    class ObjectToRawProxyEncoder<T> : IPyObjectEncoder
+    class ObjectToEncoderInstanceEncoder<T> : IPyObjectEncoder
     {
         public bool CanEncode(Type type) => type == typeof(T);
         public PyObject TryEncode(object value) => this.GetRawPythonProxy();

--- a/src/runtime/Codecs/RawProxyEncoder.cs
+++ b/src/runtime/Codecs/RawProxyEncoder.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Python.Runtime.Codecs
+{
+    /// <summary>
+    /// A .NET object encoder, that returns raw proxies (e.g. no conversion to Python types).
+    /// <para>You must inherit from this class and override <see cref="CanEncode"/>.</para>
+    /// </summary>
+    [Obsolete(Util.UnstableApiMessage)]
+    public abstract class RawProxyEncoder: IPyObjectEncoder
+    {
+        public PyObject TryEncode(object value)
+        {
+            if (value is null) throw new ArgumentNullException(nameof(value));
+
+            return value.GetRawPythonProxy();
+        }
+        public abstract bool CanEncode(Type type);
+    }
+}

--- a/src/runtime/Codecs/RawProxyEncoder.cs
+++ b/src/runtime/Codecs/RawProxyEncoder.cs
@@ -7,7 +7,7 @@ namespace Python.Runtime.Codecs
     /// <para>You must inherit from this class and override <see cref="CanEncode"/>.</para>
     /// </summary>
     [Obsolete(Util.UnstableApiMessage)]
-    public abstract class RawProxyEncoder: IPyObjectEncoder
+    public class RawProxyEncoder: IPyObjectEncoder
     {
         public PyObject TryEncode(object value)
         {
@@ -15,6 +15,7 @@ namespace Python.Runtime.Codecs
 
             return value.GetRawPythonProxy();
         }
-        public abstract bool CanEncode(Type type);
+
+        public virtual bool CanEncode(Type type) => false;
     }
 }

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -78,6 +78,7 @@
   <ItemGroup>
     <Compile Include="Codecs\EncoderGroup.cs" />
     <Compile Include="Codecs\DecoderGroup.cs" />
+    <Compile Include="Codecs\RawProxyEncoder.cs" />
     <Compile Include="Codecs\TupleCodecs.cs" />
     <Compile Include="converterextensions.cs" />
     <Compile Include="finalizer.cs" />

--- a/src/testing/conversiontest.cs
+++ b/src/testing/conversiontest.cs
@@ -1,7 +1,9 @@
 namespace Python.Test
 {
+    using System.Collections.Generic;
+
     /// <summary>
-    /// Supports units tests for field access.
+    /// Supports unit tests for field access.
     /// </summary>
     public class ConversionTest
     {
@@ -32,6 +34,7 @@ namespace Python.Test
 
         public byte[] ByteArrayField;
         public sbyte[] SByteArrayField;
+        public readonly List<int> ListField = new List<int>();
 
         public T? Echo<T>(T? arg) where T: struct {
             return arg;

--- a/src/tests/test_conversion.py
+++ b/src/tests/test_conversion.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 import System
 import pytest
 from Python.Test import ConversionTest, UnicodeString
+from Python.Runtime import PyObjectConversions
+from Python.Runtime.Codecs import RawProxyEncoder
 
 from ._compat import indexbytes, long, unichr, text_type, PY2, PY3
 
@@ -700,3 +702,18 @@ def test_sbyte_array_conversion():
     array = ob.SByteArrayField
     for i, _ in enumerate(value):
         assert array[i] == indexbytes(value, i)
+
+def test_codecs():
+    """Test codec registration from Python"""
+    class ListAsRawEncoder(RawProxyEncoder):
+        def CanEncode(self, clr_type):
+            return clr_type.Name == "List`1" and clr_type.Namespace == "System.Collections.Generic"
+
+    list_raw_encoder = ListAsRawEncoder()
+    PyObjectConversions.RegisterEncoder(list_raw_encoder)
+
+    ob = ConversionTest()
+
+    l = ob.ListField
+    l.Add(42)
+    assert ob.ListField.Count == 1

--- a/src/tests/test_conversion.py
+++ b/src/tests/test_conversion.py
@@ -706,6 +706,7 @@ def test_sbyte_array_conversion():
 def test_codecs():
     """Test codec registration from Python"""
     class ListAsRawEncoder(RawProxyEncoder):
+        __namespace__ = "Python.Test"
         def CanEncode(self, clr_type):
             return clr_type.Name == "List`1" and clr_type.Namespace == "System.Collections.Generic"
 


### PR DESCRIPTION
Now Python host can force raw encoding for autoconverted .NET types.

### What does this implement/fix? Explain your changes.

This class allows Python to override some automatic conversions done by Python.NET, which was otherwise impossible.

To do that, Python code can define a class derived from `RawProxyEncoder`, and override `CanEncode` to return `True` for the desired types. Create an instance of this class, and register it with `Python.Runtime.PyObjectConversions.RegisterEncoder(instance)` (see new test for example)

### Does this close any currently open issues?

Enables workaround for #514

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
