### PR TITLE
Update NonCopyableAnalyzer

### DIFF
--- a/src/embed_tests/Python.EmbeddingTest.15.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.15.csproj
@@ -77,6 +77,7 @@
 
   
   <ItemGroup>
+    <PackageReference Include="NonCopyableAnalyzer" Version="0.6.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
@@ -130,7 +130,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NonCopyableAnalyzer" Version="0.5.1">
+    <PackageReference Include="NonCopyableAnalyzer" Version="0.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This brings the fix for ufcpp/NonCopyableAnalyzer#14

Without it, borrowing (an implicit conversion) a `BorrowedReference` from `NewReference` would not compile