### PR TITLE
Allow excluding public .NET types from being exposed to Python via [PyExport(false)]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added function that sets Py_NoSiteFlag to 1.
 -   Added support for Jetson Nano.
 -   Added support for __len__ for .NET classes that implement ICollection
+-   Added `PyExport` attribute to hide .NET types from Python
 -   Added PythonException.Format method to format exceptions the same as traceback.format_exception
 -   Added Runtime.None to be able to pass None as parameter into Python from .NET
 -   Added PyObject.IsNone() to check if a Python object is None in .NET.

--- a/setup.py
+++ b/setup.py
@@ -306,7 +306,6 @@ class BuildExtPythonnet(build_ext.build_ext):
             _config = "{0}Win".format(CONFIG)
             _solution_file = "pythonnet.sln"
             _custom_define_constants = False
-            defines.append("NET40")
         elif DEVTOOLS == "MsDev15":
             _xbuild = '"{0}"'.format(self._find_msbuild_tool_15())
             _config = "{0}Win".format(CONFIG)
@@ -317,7 +316,6 @@ class BuildExtPythonnet(build_ext.build_ext):
             _config = "{0}Mono".format(CONFIG)
             _solution_file = "pythonnet.sln"
             _custom_define_constants = False
-            defines.append("NET40")
         elif DEVTOOLS == "dotnet":
             _xbuild = "dotnet msbuild"
             _config = "{0}Mono".format(CONFIG)

--- a/setup.py
+++ b/setup.py
@@ -306,6 +306,7 @@ class BuildExtPythonnet(build_ext.build_ext):
             _config = "{0}Win".format(CONFIG)
             _solution_file = "pythonnet.sln"
             _custom_define_constants = False
+            defines.append("NET40")
         elif DEVTOOLS == "MsDev15":
             _xbuild = '"{0}"'.format(self._find_msbuild_tool_15())
             _config = "{0}Win".format(CONFIG)
@@ -316,6 +317,7 @@ class BuildExtPythonnet(build_ext.build_ext):
             _config = "{0}Mono".format(CONFIG)
             _solution_file = "pythonnet.sln"
             _custom_define_constants = False
+            defines.append("NET40")
         elif DEVTOOLS == "dotnet":
             _xbuild = "dotnet msbuild"
             _config = "{0}Mono".format(CONFIG)

--- a/src/runtime/PyExportAttribute.cs
+++ b/src/runtime/PyExportAttribute.cs
@@ -1,0 +1,16 @@
+namespace Python.Runtime {
+    using System;
+
+    /// <summary>
+    /// Controls visibility to Python for public .NET type or an entire assembly
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate | AttributeTargets.Enum
+                    | AttributeTargets.Interface | AttributeTargets.Struct | AttributeTargets.Assembly,
+        AllowMultiple = false,
+        Inherited = false)]
+    public class PyExportAttribute : Attribute
+    {
+        internal readonly bool Export;
+        public PyExportAttribute(bool export) { this.Export = export; }
+    }
+}

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -29,46 +29,46 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>-->
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMono'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMonoPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS4</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMono'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMonoPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS4;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWin'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS2</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWinPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS2</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS2</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWin'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS2;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS2;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -29,46 +29,46 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>-->
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMono'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS4</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseMonoPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS4</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS4</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMono'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS4;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugMonoPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS4;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS4;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWin'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS2</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'ReleaseWinPY3'">
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS2</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS2</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWin'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON2;PYTHON27;UCS2;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'DebugWinPY3'">
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants Condition="'$(DefineConstants)' == ''">PYTHON3;PYTHON38;UCS2;TRACE;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(DefineConstants)' == ''">NET40;PYTHON3;PYTHON38;UCS2;TRACE;DEBUG</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
@@ -131,6 +131,7 @@
     <Compile Include="propertyobject.cs" />
     <Compile Include="pyansistring.cs" />
     <Compile Include="pydict.cs" />
+    <Compile Include="PyExportAttribute.cs" />
     <Compile Include="pyfloat.cs" />
     <Compile Include="pyint.cs" />
     <Compile Include="pyiter.cs" />
@@ -151,6 +152,7 @@
     <Compile Include="Util.cs" />
     <Compile Include="platform\Types.cs" />
     <Compile Include="platform\LibraryLoader.cs" />
+    <Compile Include="polyfill\ReflectionPolifills.cs" />
     <Compile Include="slots\mp_length.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PythonInteropFile)' != '' ">

--- a/src/runtime/polyfill/ReflectionPolifills.cs
+++ b/src/runtime/polyfill/ReflectionPolifills.cs
@@ -19,7 +19,6 @@ namespace Python.Runtime
             return typeBuilder.GetTypeInfo().GetType();
         }
 #endif
-#if NET40
         public static T GetCustomAttribute<T>(this Type type) where T: Attribute
         {
             return type.GetCustomAttributes(typeof(T), inherit: false)
@@ -33,6 +32,5 @@ namespace Python.Runtime
                 .Cast<T>()
                 .SingleOrDefault();
         }
-#endif
     }
 }

--- a/src/runtime/polyfill/ReflectionPolifills.cs
+++ b/src/runtime/polyfill/ReflectionPolifills.cs
@@ -1,12 +1,14 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 
 namespace Python.Runtime
 {
-#if NETSTANDARD
+    [Obsolete("This API is for internal use only")]
     public static class ReflectionPolifills
     {
+#if NETSTANDARD
         public static AssemblyBuilder DefineDynamicAssembly(this AppDomain appDomain, AssemblyName assemblyName, AssemblyBuilderAccess assemblyBuilderAccess)
         {
             return AssemblyBuilder.DefineDynamicAssembly(assemblyName, assemblyBuilderAccess);
@@ -16,6 +18,21 @@ namespace Python.Runtime
         {
             return typeBuilder.GetTypeInfo().GetType();
         }
-    }
 #endif
+#if NET40
+        public static T GetCustomAttribute<T>(this Type type) where T: Attribute
+        {
+            return type.GetCustomAttributes(typeof(T), inherit: false)
+                .Cast<T>()
+                .SingleOrDefault();
+        }
+
+        public static T GetCustomAttribute<T>(this Assembly assembly) where T: Attribute
+        {
+            return assembly.GetCustomAttributes(typeof(T), inherit: false)
+                .Cast<T>()
+                .SingleOrDefault();
+        }
+#endif
+    }
 }

--- a/src/testing/Python.Test.csproj
+++ b/src/testing/Python.Test.csproj
@@ -92,6 +92,7 @@
     <Compile Include="doctest.cs" />
     <Compile Include="subclasstest.cs" />
     <Compile Include="ReprTest.cs" />
+    <Compile Include="nonexportable.cs" />
     <Compile Include="mp_lengthtest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/testing/nonexportable.cs
+++ b/src/testing/nonexportable.cs
@@ -1,0 +1,8 @@
+namespace Python.Test
+{
+    using Python.Runtime;
+
+    // this class should not be visible to Python
+    [PyExport(false)]
+    public class NonExportable { }
+}

--- a/src/tests/test_class.py
+++ b/src/tests/test_class.py
@@ -14,7 +14,6 @@ def test_basic_reference_type():
     """Test usage of CLR defined reference types."""
     assert System.String.Empty == ""
 
-
 def test_basic_value_type():
     """Test usage of CLR defined value types."""
     assert System.Int32.MaxValue == 2147483647
@@ -28,7 +27,6 @@ def test_class_standard_attrs():
     assert ClassTest.__module__ == 'Python.Test'
     assert isinstance(ClassTest.__dict__, DictProxyType)
     assert len(ClassTest.__doc__) > 0
-
 
 def test_class_docstrings():
     """Test standard class docstring generation"""
@@ -57,6 +55,14 @@ def test_non_public_class():
 
     with pytest.raises(AttributeError):
         _ = Test.InternalClass
+
+def test_non_exported():
+    """Test [PyExport(false)]"""
+    with pytest.raises(ImportError):
+        from Python.Test import NonExportable
+
+    with pytest.raises(AttributeError):
+        _ = Test.NonExportable
 
 
 def test_basic_subclass():


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Introduced [`PyExportAttribute`](https://github.com/pythonnet/pythonnet/wiki/PyExport), that can be applied to individual types or the entire assembly, and controls visibility of these types/assemblies to Python. This is useful in case .NET type has a name conflict with Python type.

The attribute in checked in `ScanAssembly`.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
