### PR TITLE
Removes new object.GetRawPythonProxy extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added function that sets Py_NoSiteFlag to 1.
 -   Added support for Jetson Nano.
 -   Added support for __len__ for .NET classes that implement ICollection
--   Added `object.GetRawPythonProxy() -> PyObject` extension method, that bypasses any conversions
 -   Added PythonException.Format method to format exceptions the same as traceback.format_exception
 
 ### Changed

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -91,7 +91,7 @@ namespace Python.EmbeddingTest {
     class ObjectToEncoderInstanceEncoder<T> : IPyObjectEncoder
     {
         public bool CanEncode(Type type) => type == typeof(T);
-        public PyObject TryEncode(object value) => this.GetRawPythonProxy();
+        public PyObject TryEncode(object value) => PyObject.FromManagedObject(this);
     }
 
     /// <summary>

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -51,7 +51,7 @@ namespace Python.EmbeddingTest
         public void RawListProxy()
         {
             var list = new List<string> {"hello", "world"};
-            var listProxy = list.GetRawPythonProxy();
+            var listProxy = PyObject.FromManagedObject(list);
             var clrObject = (CLRObject)ManagedType.GetManagedObject(listProxy.Handle);
             Assert.AreSame(list, clrObject.inst);
         }
@@ -60,7 +60,7 @@ namespace Python.EmbeddingTest
         public void RawPyObjectProxy()
         {
             var pyObject = "hello world!".ToPython();
-            var pyObjectProxy = pyObject.GetRawPythonProxy();
+            var pyObjectProxy = PyObject.FromManagedObject(pyObject);
             var clrObject = (CLRObject)ManagedType.GetManagedObject(pyObjectProxy.Handle);
             Assert.AreSame(pyObject, clrObject.inst);
 

--- a/src/runtime/Codecs/RawProxyEncoder.cs
+++ b/src/runtime/Codecs/RawProxyEncoder.cs
@@ -13,7 +13,7 @@ namespace Python.Runtime.Codecs
         {
             if (value is null) throw new ArgumentNullException(nameof(value));
 
-            return value.GetRawPythonProxy();
+            return PyObject.FromManagedObject(value);
         }
 
         public virtual bool CanEncode(Type type) => false;

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -68,17 +68,5 @@ namespace Python.Runtime
             CLRObject co = GetInstance(ob);
             return co.pyHandle;
         }
-
-        /// <summary>
-        /// Creates <see cref="CLRObject"/> proxy for the given object,
-        /// and returns a <see cref="NewReference"/> to it.
-        /// </summary>
-        internal static NewReference MakeNewReference(object obj)
-        {
-            if (obj is null) throw new ArgumentNullException(nameof(obj));
-
-            // TODO: CLRObject currently does not have Dispose or finalizer which might change in the future
-            return NewReference.DangerousFromPointer(GetInstHandle(obj));
-        }
     }
 }

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -967,16 +967,5 @@ namespace Python.Runtime
         {
             return new PyObject(Converter.ToPython(o, o?.GetType()));
         }
-
-        /// <summary>
-        /// Gets raw Python proxy for this object (bypasses all conversions,
-        /// except <c>null</c> &lt;==&gt; <c>None</c>)
-        /// </summary>
-        public static PyObject GetRawPythonProxy(this object o)
-        {
-            if (o is null) return new PyObject(new BorrowedReference(Runtime.PyNone));
-
-            return CLRObject.MakeNewReference(o).MoveToPyObject();
-        }
     }
 }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -111,7 +111,8 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// FromManagedObject Method
+        /// Gets raw Python proxy for this object (bypasses all conversions,
+        /// except <c>null</c> &lt;==&gt; <c>None</c>)
         /// </summary>
         /// <remarks>
         /// Given an arbitrary managed object, return a Python instance that


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Reverts most of https://github.com/pythonnet/pythonnet/pull/1078

Turned out there already was `PyObject.FromManagedObject`. It was not covered by tests however, so I changed former `GetRawPythonProxy` tests to test `FromManagedObject`

### Does this close any currently open issues?

No

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
