### PR TITLE
__name__ and __signature__ for .NET methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Ability to implement delegates with `ref` and `out` parameters in Python, by returning the modified parameter values in a tuple. ([#1355][i1355])
 -   `PyType` - a wrapper for Python type objects, that also permits creating new heap types from `TypeSpec`
 -    Improved exception handling:
--   exceptions can now be converted with codecs
--   `InnerException` and `__cause__` are propagated properly
+  *   exceptions can now be converted with codecs
+  *   `InnerException` and `__cause__` are propagated properly
+-   `__name__` and `__signature__` to reflected .NET methods
 -   .NET collection types now implement standard Python collection interfaces from `collections.abc`.
 See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   .NET arrays implement Python buffer protocol

--- a/src/embed_tests/Inspect.cs
+++ b/src/embed_tests/Inspect.cs
@@ -30,5 +30,30 @@ namespace Python.EmbeddingTest
             var pyProp = (PropertyObject)ManagedType.GetManagedObject(property.Reference);
             Assert.AreEqual(nameof(Uri.AbsoluteUri), pyProp.info.Value.Name);
         }
+
+        [Test]
+        public void BoundMethodsAreInspectable()
+        {
+            using var scope = Py.CreateScope();
+            try
+            {
+                scope.Import("inspect");
+            }
+            catch (PythonException)
+            {
+                Assert.Inconclusive("Python build does not include inspect module");
+                return;
+            }
+
+            var obj = new Class();
+            scope.Set(nameof(obj), obj);
+            using var spec = scope.Eval($"inspect.getfullargspec({nameof(obj)}.{nameof(Class.Method)})");
+        }
+
+        class Class
+        {
+            public void Method(int a, int b = 10) { }
+            public void Method(int a, object b) { }
+        }
     }
 }

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -420,6 +420,7 @@ namespace Python.Runtime
         public static IntPtr IOError;
         public static IntPtr OSError;
         public static IntPtr ImportError;
+        public static IntPtr ModuleNotFoundError;
         public static IntPtr IndexError;
         public static IntPtr KeyError;
         public static IntPtr KeyboardInterrupt;

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Linq;
+using System.Reflection;
 
 namespace Python.Runtime
 {
@@ -99,6 +99,16 @@ namespace Python.Runtime
             }
             doc = Runtime.PyString_FromString(str);
             return doc;
+        }
+
+        internal NewReference GetName()
+        {
+            var names = new HashSet<string>(binder.GetMethods().Select(m => m.Name));
+            if (names.Count != 1) {
+                Exceptions.SetError(Exceptions.AttributeError, "a method has no name");
+                return default;
+            }
+            return NewReference.DangerousFromPointer(Runtime.PyString_FromString(names.First()));
         }
 
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -178,6 +178,7 @@ namespace Python.Runtime
             AssemblyManager.UpdatePath();
 
             clrInterop = GetModuleLazy("clr.interop");
+            inspect = GetModuleLazy("inspect");
         }
 
         private static void InitPyMembers()
@@ -573,6 +574,8 @@ namespace Python.Runtime
         internal static IntPtr PyNone;
         internal static IntPtr Error;
 
+        private static Lazy<PyObject> inspect;
+        internal static PyObject InspectModule => inspect.Value;
         private static Lazy<PyObject> clrInterop;
         internal static PyObject InteropModule => clrInterop.Value;
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This implements `__name__` and `__signature__` Python members for reflected .NET methods, that enables them to be analyzed with `inspect` module.

### Does this close any currently open issues?

N/A

### Any other comments?

Some Python libraries validate passed callables by using `inspect` module. This makes it possible for .NET methods to pass this kind of validation.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
