### PR TITLE
Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ dist: xenial
 sudo: false
 language: python
 python:
-    - 2.7
-    - 3.5
-    - 3.6
-    - 3.7
     - 3.8
+    - 3.7
+    - 3.6
+    - 3.5
+    - 2.7
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
 
 env:
   matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added PythonException.Format method to format exceptions the same as traceback.format_exception
 -   Added Runtime.None to be able to pass None as parameter into Python from .NET
 -   Added PyObject.IsNone() to check if a Python object is None in .NET.
+-   Support for Python 3.8
 
 ### Changed
 
@@ -29,6 +30,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Added support for kwarg parameters when calling .NET methods from Python
 -   Changed method for finding MSBuild using vswhere
 -   Reworked `Finalizer`. Now objects drop into its queue upon finalization, which is periodically drained when new objects are created.
+-   Marked `Runtime.OperatingSystemName` and `Runtime.MachineName` as `Obsolete`, should never have been `public` in the first place. They also don't necessarily return a result that matches the `platform` module's.
 
 ### Fixed
 
@@ -37,6 +39,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 - Fixes bug where delegates get casts (dotnetcore)
 - Determine size of interpreter longs at runtime
 - Handling exceptions ocurred in ModuleObject's getattribute 
+- Fill `__classcell__` correctly for Python subclasses of .NET types
 
 ## [2.4.0][]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,13 @@ environment:
       BUILD_OPTS: --xplat
     - PYTHON_VERSION: 3.7
       BUILD_OPTS: --xplat
+    - PYTHON_VERSION: 3.8
+      BUILD_OPTS: --xplat
     - PYTHON_VERSION: 2.7
     - PYTHON_VERSION: 3.5
     - PYTHON_VERSION: 3.6
     - PYTHON_VERSION: 3.7
+    - PYTHON_VERSION: 3.8
 
 matrix:
     allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,27 +15,21 @@ environment:
     CODECOV_ENV: PYTHON_VERSION, PLATFORM
 
   matrix:
+    - PYTHON_VERSION: 3.8
+      BUILD_OPTS: --xplat
+    - PYTHON_VERSION: 3.7
+      BUILD_OPTS: --xplat
+    - PYTHON_VERSION: 3.6
+      BUILD_OPTS: --xplat
+    - PYTHON_VERSION: 3.5
+      BUILD_OPTS: --xplat
     - PYTHON_VERSION: 2.7 
       BUILD_OPTS: --xplat
-    - PYTHON_VERSION: 3.5
-      BUILD_OPTS: --xplat
-    - PYTHON_VERSION: 3.6
-      BUILD_OPTS: --xplat
-    - PYTHON_VERSION: 3.7
-      BUILD_OPTS: --xplat
     - PYTHON_VERSION: 3.8
-      BUILD_OPTS: --xplat
+    - PYTHON_VERSION: 3.7
+    - PYTHON_VERSION: 3.6
+    - PYTHON_VERSION: 3.5
     - PYTHON_VERSION: 2.7
-    - PYTHON_VERSION: 3.5
-    - PYTHON_VERSION: 3.6
-    - PYTHON_VERSION: 3.7
-    - PYTHON_VERSION: 3.8
-
-matrix:
-    allow_failures:
-      - PYTHON_VERSION: 3.4
-        BUILD_OPTS: --xplat
-      - PYTHON_VERSION: 3.4
 
 init:
   # Update Environment Variables based on matrix/platform

--- a/src/embed_tests/TestRuntime.cs
+++ b/src/embed_tests/TestRuntime.cs
@@ -30,7 +30,6 @@ namespace Python.EmbeddingTest
 
             Assert.That(Runtime.Runtime.Machine, Is.Not.EqualTo(MachineType.Other));
             Assert.That(Runtime.Runtime.OperatingSystem, Is.Not.EqualTo(OperatingSystemType.Other));
-            Assert.That(!string.IsNullOrEmpty(Runtime.Runtime.OperatingSystemName));
 
             // Don't shut down the runtime: if the python engine was initialized
             // but not shut down by another test, we'd end up in a bad state.

--- a/src/embed_tests/TestRuntime.cs
+++ b/src/embed_tests/TestRuntime.cs
@@ -29,8 +29,6 @@ namespace Python.EmbeddingTest
             Runtime.Runtime.Initialize();
 
             Assert.That(Runtime.Runtime.Machine, Is.Not.EqualTo(MachineType.Other));
-            Assert.That(!string.IsNullOrEmpty(Runtime.Runtime.MachineName));
-
             Assert.That(Runtime.Runtime.OperatingSystem, Is.Not.EqualTo(OperatingSystemType.Other));
             Assert.That(!string.IsNullOrEmpty(Runtime.Runtime.OperatingSystemName));
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1966,6 +1966,15 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyErr_Print();
 
+        //====================================================================
+        // Cell API
+        //====================================================================
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NewReference PyCell_Get(IntPtr cell);
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int PyCell_Set(IntPtr cell, IntPtr value);
 
         //====================================================================
         // Miscellaneous

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -154,11 +154,6 @@ namespace Python.Runtime
         /// </summary>
         public static MachineType Machine { get; private set; }/* set in Initialize using python's platform.machine */
 
-        /// <summary>
-        /// Gets the machine architecture as reported by python's platform.machine().
-        /// </summary>
-        public static string MachineName { get; private set; }
-
         internal static bool IsPython2 = pyversionnumber < 30;
         internal static bool IsPython3 = pyversionnumber >= 30;
 
@@ -370,7 +365,7 @@ namespace Python.Runtime
 
             fn = PyObject_GetAttrString(platformModule, "machine");
             op = PyObject_Call(fn, emptyTuple, IntPtr.Zero);
-            MachineName = GetManagedString(op);
+            string machineName = GetManagedString(op);
             XDecref(op);
             XDecref(fn);
 
@@ -387,7 +382,7 @@ namespace Python.Runtime
             OperatingSystem = OSType;
 
             MachineType MType;
-            if (!MachineTypeMapping.TryGetValue(MachineName.ToLower(), out MType))
+            if (!MachineTypeMapping.TryGetValue(machineName.ToLower(), out MType))
             {
                 MType = MachineType.Other;
             }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -356,6 +356,7 @@ namespace Python.Runtime
         /// </summary>
         private static void InitializePlatformData()
         {
+#if !NETSTANDARD
             IntPtr op;
             IntPtr fn;
             IntPtr platformModule = PyImport_ImportModule("platform");
@@ -391,6 +392,34 @@ namespace Python.Runtime
                 MType = MachineType.Other;
             }
             Machine = MType;
+#else
+            OperatingSystem = OperatingSystemType.Other;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                OperatingSystem = OperatingSystemType.Linux;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                OperatingSystem = OperatingSystemType.Darwin;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                OperatingSystem = OperatingSystemType.Windows;
+            
+            switch (RuntimeInformation.ProcessArchitecture)
+            {
+                case Architecture.X86:
+                    Machine = MachineType.i386;
+                    break;
+                case Architecture.X64:
+                    Machine = MachineType.x86_64;
+                    break;
+                case Architecture.Arm:
+                    Machine = MachineType.armv7l;
+                    break;
+                case Architecture.Arm64:
+                    Machine = MachineType.aarch64;
+                    break;
+                default:
+                    Machine = MachineType.Other;
+                    break;
+            }
+#endif
         }
 
         internal static void Shutdown()

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Emit;
 using System;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
@@ -117,6 +118,12 @@ namespace Python.Runtime
             { "Darwin", OperatingSystemType.Darwin },
             { "Linux", OperatingSystemType.Linux },
         };
+
+        [Obsolete]
+        public static string OperatingSystemName => OperatingSystem.ToString();
+
+        [Obsolete]
+        public static string MachineName => Machine.ToString();
 
         /// <summary>
         /// Gets the operating system as reported by python's platform.system().
@@ -1990,10 +1997,10 @@ namespace Python.Runtime
         //====================================================================
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern NewReference PyCell_Get(IntPtr cell);
+        internal static extern NewReference PyCell_Get(BorrowedReference cell);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyCell_Set(IntPtr cell, IntPtr value);
+        internal static extern int PyCell_Set(BorrowedReference cell, IntPtr value);
 
         //====================================================================
         // Miscellaneous

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -124,12 +124,6 @@ namespace Python.Runtime
         public static OperatingSystemType OperatingSystem { get; private set; }
 
         /// <summary>
-        /// Gets the operating system as reported by python's platform.system().
-        /// </summary>
-        public static string OperatingSystemName { get; private set; }
-
-
-        /// <summary>
         /// Map lower-case version of the python machine name to the processor
         /// type. There are aliases, e.g. x86_64 and amd64 are two names for
         /// the same thing. Make sure to lower-case the search string, because
@@ -359,7 +353,7 @@ namespace Python.Runtime
 
             fn = PyObject_GetAttrString(platformModule, "system");
             op = PyObject_Call(fn, emptyTuple, IntPtr.Zero);
-            OperatingSystemName = GetManagedString(op);
+            string operatingSystemName = GetManagedString(op);
             XDecref(op);
             XDecref(fn);
 
@@ -375,7 +369,7 @@ namespace Python.Runtime
             // Now convert the strings into enum values so we can do switch
             // statements rather than constant parsing.
             OperatingSystemType OSType;
-            if (!OperatingSystemTypeMapping.TryGetValue(OperatingSystemName, out OSType))
+            if (!OperatingSystemTypeMapping.TryGetValue(operatingSystemName, out OSType))
             {
                 OSType = OperatingSystemType.Other;
             }
@@ -388,14 +382,15 @@ namespace Python.Runtime
             }
             Machine = MType;
 #else
-            OperatingSystem = OperatingSystemType.Other;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 OperatingSystem = OperatingSystemType.Linux;
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 OperatingSystem = OperatingSystemType.Darwin;
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 OperatingSystem = OperatingSystemType.Windows;
-            
+            else
+                OperatingSystem = OperatingSystemType.Other;
+
             switch (RuntimeInformation.ProcessArchitecture)
             {
                 case Architecture.X86:

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -280,6 +280,14 @@ namespace Python.Runtime
                 IntPtr cls_dict = Marshal.ReadIntPtr(py_type, TypeOffset.tp_dict);
                 Runtime.PyDict_Update(cls_dict, py_dict);
 
+                // Update the __classcell__ if it exists
+                IntPtr cell = Runtime.PyDict_GetItemString(cls_dict, "__classcell__");
+                if (cell != IntPtr.Zero)
+                {
+                    Runtime.PyCell_Set(cell, py_type);
+                    Runtime.PyDict_DelItemString(cls_dict, "__classcell__");
+                }
+
                 return py_type;
             }
             catch (Exception e)

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -625,7 +625,7 @@ namespace Python.Runtime
                         case OperatingSystemType.Linux:
                             return 0x20;
                         default:
-                            throw new NotImplementedException($"mmap is not supported on {Runtime.OperatingSystemName}");
+                            throw new NotImplementedException($"mmap is not supported on this operating system");
                     }
                 }
             }
@@ -659,7 +659,7 @@ namespace Python.Runtime
                 case OperatingSystemType.Windows:
                     return new WindowsMemoryMapper();
                 default:
-                    throw new NotImplementedException($"No support for {Runtime.OperatingSystemName}");
+                    throw new NotImplementedException($"No support for this operating system");
             }
         }
 

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -281,8 +281,8 @@ namespace Python.Runtime
                 Runtime.PyDict_Update(cls_dict, py_dict);
 
                 // Update the __classcell__ if it exists
-                IntPtr cell = Runtime.PyDict_GetItemString(cls_dict, "__classcell__");
-                if (cell != IntPtr.Zero)
+                var cell = new BorrowedReference(Runtime.PyDict_GetItemString(cls_dict, "__classcell__"));
+                if (!cell.IsNull)
                 {
                     Runtime.PyCell_Set(cell, py_type);
                     Runtime.PyDict_DelItemString(cls_dict, "__classcell__");
@@ -625,7 +625,9 @@ namespace Python.Runtime
                         case OperatingSystemType.Linux:
                             return 0x20;
                         default:
-                            throw new NotImplementedException($"mmap is not supported on this operating system");
+                            throw new NotImplementedException(
+                                $"mmap is not supported on {Runtime.OperatingSystem}"
+                            );
                     }
                 }
             }
@@ -659,7 +661,9 @@ namespace Python.Runtime
                 case OperatingSystemType.Windows:
                     return new WindowsMemoryMapper();
                 default:
-                    throw new NotImplementedException($"No support for this operating system");
+                    throw new NotImplementedException(
+                        $"No support for {Runtime.OperatingSystem}"
+                    );
             }
         }
 


### PR DESCRIPTION
Adds Python 3.8 to the CI and fixes the remaining issue by assigning `__classcell__` the created class if it exists. This is required as for the case of subclassing a C# class in Python, we (currently) don't initialise the type via `type_new` (`== PyType_Type.tp_new`) but instead generate it manually. The added code is done at the end of `type_new` and is required from Python 3.8 onwards (see command below).