### PR TITLE
Link stdc++

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -404,6 +404,7 @@ class BuildExtPythonnet(build_ext.build_ext):
         # build the clr python module
         clr_ext = Extension(
             "clr",
+            language="c++",
             sources=["src/monoclr/pynetinit.c", "src/monoclr/clrmod.c"],
             extra_compile_args=cflags.split(" "),
             extra_link_args=libs.split(" "),

--- a/src/monoclr/pynetclr.h
+++ b/src/monoclr/pynetclr.h
@@ -12,6 +12,10 @@
 #define MONO_DOMAIN "Python.Runtime"
 #define PR_ASSEMBLY "Python.Runtime.dll"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct
 {
     MonoDomain *domain;
@@ -28,5 +32,9 @@ PyNet_Args *PyNet_Init(int);
 void PyNet_Finalize(PyNet_Args *);
 void main_thread_handler(PyNet_Args *user_data);
 char *PyNet_ExceptionToString(MonoObject *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // PYNET_CLR_H

--- a/src/monoclr/pynetinit.c
+++ b/src/monoclr/pynetinit.c
@@ -19,6 +19,11 @@ PyNet_Args *PyNet_Init(int ext)
     pn_args->shutdown = NULL;
     pn_args->module = NULL;
 
+#ifdef __linux__
+    // Force preload libmono-2.0 as global
+    dlopen("libmono-2.0.so", RTLD_LAZY | RTLD_GLOBAL);
+#endif
+
     if (ext == 0)
     {
         pn_args->init_name = "Python.Runtime:Initialize()";
@@ -122,7 +127,7 @@ void main_thread_handler(PyNet_Args *user_data)
             strcpy(new_ld_library_path, py_libdir);
             strcat(new_ld_library_path, ":");
             strcat(new_ld_library_path, ld_library_path);
-            setenv("LD_LIBRARY_PATH", py_libdir, 1);
+            setenv("LD_LIBRARY_PATH", new_ld_library_path, 1);
         }
     }
 

--- a/src/monoclr/pynetinit.c
+++ b/src/monoclr/pynetinit.c
@@ -20,7 +20,11 @@ PyNet_Args *PyNet_Init(int ext)
     pn_args->module = NULL;
 
 #ifdef __linux__
-    // Force preload libmono-2.0 as global
+    // Force preload libmono-2.0 as global. Without this, on some systems 
+    // symbols from libmono are not found by libmononative (which implements
+    // some of the System.* namespaces). Since the only happened on Linux so
+    // far, we hardcode the library name, load the symbols into the global
+    // namespace and leak the handle.
     dlopen("libmono-2.0.so", RTLD_LAZY | RTLD_GLOBAL);
 #endif
 

--- a/tools/geninterop/geninterop.py
+++ b/tools/geninterop/geninterop.py
@@ -174,6 +174,8 @@ def preprocess_python_headers():
     include_py = sysconfig.get_config_var("INCLUDEPY")
     include_dirs.append(include_py)
 
+    include_args = [c for p in include_dirs for c in ["-I", p]]
+
     defines = [
         "-D", "__attribute__(x)=",
         "-D", "__inline__=inline",
@@ -198,7 +200,7 @@ def preprocess_python_headers():
             defines.extend(("-D", "PYTHON_WITH_WIDE_UNICODE"))
 
     python_h = os.path.join(include_py, "Python.h")
-    cmd = ["clang", "-pthread", "-I"] + include_dirs + defines + ["-E", python_h]
+    cmd = ["clang", "-pthread"] + include_args + defines + ["-E", python_h]
 
     # normalize as the parser doesn't like windows line endings.
     lines = []


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Links `monoclr` as a C++ library and thus includes `libstdc++` and whatever else `g++` adds. Additionally, it force-loads `libmono-2.0` on Linux with `RTLD_GLOBAL` to make sure the symbols are in place when `libmono-native.so` is being loaded. 

### Does this close any currently open issues?

I hope this fixes #939. The second part fixes #1034 on my machine.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change: N/A
-   [x] If an enhancement PR, please create docs and at best an example: N/A
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
