### PR TITLE
Improve "No constructor matches given arguments" message with more details

### DIFF
--- a/src/runtime/constructorbinder.cs
+++ b/src/runtime/constructorbinder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Text;
 
 namespace Python.Runtime
 {
@@ -93,7 +94,15 @@ namespace Python.Runtime
 
                 if (binding == null)
                 {
-                    Exceptions.SetError(Exceptions.TypeError, "no constructor matches given arguments");
+                    var errorMessage = new StringBuilder("No constructor matches given arguments");
+                    if (info != null && info.IsConstructor && info.DeclaringType != null)
+                    {
+                        errorMessage.Append(" for ").Append(info.DeclaringType.Name);
+                    }
+
+                    errorMessage.Append(": ");
+                    AppendArgumentTypes(to: errorMessage, args);
+                    Exceptions.SetError(Exceptions.TypeError, errorMessage.ToString());
                     return null;
                 }
             }

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -599,6 +599,40 @@ namespace Python.Runtime
             return Invoke(inst, args, kw, info, null);
         }
 
+        protected static void AppendArgumentTypes(StringBuilder to, IntPtr args)
+        {
+            long argCount = Runtime.PyTuple_Size(args);
+            to.Append("(");
+            for (long argIndex = 0; argIndex < argCount; argIndex++)
+            {
+                var arg = Runtime.PyTuple_GetItem(args, argIndex);
+                if (arg != IntPtr.Zero)
+                {
+                    var type = Runtime.PyObject_Type(arg);
+                    if (type != IntPtr.Zero)
+                    {
+                        try
+                        {
+                            var description = Runtime.PyObject_Unicode(type);
+                            if (description != IntPtr.Zero)
+                            {
+                                to.Append(Runtime.GetManagedString(description));
+                                Runtime.XDecref(description);
+                            }
+                        }
+                        finally
+                        {
+                            Runtime.XDecref(type);
+                        }
+                    }
+                }
+
+                if (argIndex + 1 < argCount)
+                    to.Append(", ");
+            }
+            to.Append(')');
+        }
+
         internal virtual IntPtr Invoke(IntPtr inst, IntPtr args, IntPtr kw, MethodBase info, MethodInfo[] methodinfo)
         {
             Binding binding = Bind(inst, args, kw, info, methodinfo);
@@ -613,29 +647,8 @@ namespace Python.Runtime
                     value.Append($" for {methodinfo[0].Name}");
                 }
 
-                long argCount = Runtime.PyTuple_Size(args);
-                value.Append(": (");
-                for(long argIndex = 0; argIndex < argCount; argIndex++) {
-                    var arg = Runtime.PyTuple_GetItem(args, argIndex);
-                    if (arg != IntPtr.Zero) {
-                        var type = Runtime.PyObject_Type(arg);
-                        if (type != IntPtr.Zero) {
-                            try {
-                                var description = Runtime.PyObject_Unicode(type);
-                                if (description != IntPtr.Zero) {
-                                    value.Append(Runtime.GetManagedString(description));
-                                    Runtime.XDecref(description);
-                                }
-                            } finally {
-                                Runtime.XDecref(type);
-                            }
-                        }
-                    }
-
-                    if (argIndex + 1 < argCount)
-                        value.Append(", ");
-                }
-                value.Append(')');
+                value.Append(": ");
+                AppendArgumentTypes(to: value, args);
                 Exceptions.SetError(Exceptions.TypeError, value.ToString());
                 return IntPtr.Zero;
             }


### PR DESCRIPTION
Similar to #900, but for constructors (reuses the same code moved around)

### What does this implement/fix? Explain your changes.

This adds more details to "No constructor matches given arguments" message.

#### Was

> No constructor matches given arguments

#### Now

> No constructor matches given arguments for IntPtr: (int, list)

### Does this close any currently open issues?

Does not close any issue, but is related to: #811, #265, #1116