### PR TITLE
Increase ob's ref count in tp_repr to avoid accidental free

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -73,4 +73,5 @@
 -   ([@rmadsen-ks](https://github.com/rmadsen-ks))
 -   ([@stonebig](https://github.com/stonebig))
 -   ([@testrunner123](https://github.com/testrunner123))
+-   ([@DanBarzilian](https://github.com/DanBarzilian))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Fixed
 
+-    Fix incorrect dereference of wrapper object in tp_repr, which may result in a program crash
+
 ## [2.5.0][] - 2020-06-14
 
 This version improves performance on benchmarks significantly compared to 2.3.

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -266,6 +266,7 @@ namespace Python.Runtime
 
                 //otherwise use the standard object.__repr__(inst)
                 IntPtr args = Runtime.PyTuple_New(1);
+                Runtime.XIncref(ob);
                 Runtime.PyTuple_SetItem(args, 0, ob);
                 IntPtr reprFunc = Runtime.PyObject_GetAttrString(Runtime.PyBaseObjectType, "__repr__");
                 var output =  Runtime.PyObject_Call(reprFunc, args, IntPtr.Zero);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fix incorrect dereferencing wrapper object in tp_repr function, which causes the program to crash.

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
