### PR TITLE
Fix appveyor would only test the PyPI package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ init:
 install:
   - python -m pip install -U pip
   - pip install --upgrade -r requirements.txt --quiet
+  - pip install pycparser --quiet
 
   # Install OpenCover. Can't put on `packages.config`, not Mono compatible
   - .\tools\nuget\nuget.exe install OpenCover -OutputDirectory packages -Verbosity quiet
@@ -51,7 +52,7 @@ build_script:
   - coverage run setup.py bdist_wheel %BUILD_OPTS%
 
 test_script:
-  - pip install --find-links=.\dist\ pythonnet
+  - pip install --no-index --find-links=.\dist\ pythonnet
   - ps: .\ci\appveyor_run_tests.ps1
 
 on_finish:


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fix Windows CI currently not running functionally, it only test the release package not the present branch sources.

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
