### PR TITLE
Remove non-existent PInvoke functions

### DIFF
--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -847,12 +847,6 @@ namespace Python.Runtime
         internal static extern IntPtr PyCFunction_Call(IntPtr func, IntPtr args, IntPtr kw);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyInstance_New(IntPtr cls, IntPtr args, IntPtr kw);
-
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyInstance_NewRaw(IntPtr cls, IntPtr dict);
-
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyMethod_New(IntPtr func, IntPtr self, IntPtr cls);
 
 
@@ -1017,9 +1011,6 @@ namespace Python.Runtime
         //====================================================================
         // Python buffer API
         //====================================================================
-
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyObject_CheckBuffer(IntPtr obj);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyObject_GetBuffer(IntPtr exporter, ref Py_buffer view, int flags);
@@ -1793,7 +1784,7 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr _PyObject_GetDictPtr(IntPtr obj);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "_PyObject_GC_New")]
         internal static extern IntPtr PyObject_GC_New(IntPtr tp);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1784,9 +1784,6 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr _PyObject_GetDictPtr(IntPtr obj);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "_PyObject_GC_New")]
-        internal static extern IntPtr PyObject_GC_New(IntPtr tp);
-
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyObject_GC_Del(IntPtr tp);
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Deprecated Python2 API:
* PyInstance_New
* PyInstance_NewRaw

Mere macros on C side:
* PyObject_CheckBuffer
* PyObject_GC_New (refer to `_PyObject_GC_New`)

Check method:
https://gist.github.com/amos402/fb41571856bc77a2bada8056e429b312

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
