### PR TITLE
Bad params object[] precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ project adheres to [Semantic Versioning][].
 
 This document follows the conventions laid out in [Keep a CHANGELOG][].
 
+
+## Unreleased
+
+### Fixed
+-    Fix `object[]` parameters taking precedence when should not in overload resolution
+
 ## [2.5.1][] - 2020-06-18
 
 Bugfix release.

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -203,6 +203,16 @@ namespace Python.Runtime
                 return 3000;
             }
 
+            if (t.IsArray)
+            {
+                Type e = t.GetElementType();
+                if (e == objectType)
+                {
+                    return 2500;
+                }
+                return 100 + ArgPrecedence(e);
+            }
+
             TypeCode tc = Type.GetTypeCode(t);
             // TODO: Clean up
             switch (tc)
@@ -248,16 +258,6 @@ namespace Python.Runtime
 
                 case TypeCode.Boolean:
                     return 40;
-            }
-
-            if (t.IsArray)
-            {
-                Type e = t.GetElementType();
-                if (e == objectType)
-                {
-                    return 2500;
-                }
-                return 100 + ArgPrecedence(e);
             }
 
             return 2000;

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Python.Test
@@ -84,7 +85,7 @@ namespace Python.Test
 
         public static string[] TestStringParamsArg(params string[] args)
         {
-            return args;
+            return args.Concat(new []{"tail"}).ToArray();
         }
 
         public static object[] TestObjectParamsArg(params object[] args)

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -208,17 +208,20 @@ def test_null_array_conversion():
 def test_string_params_args():
     """Test use of string params."""
     result = MethodTest.TestStringParamsArg('one', 'two', 'three')
-    assert result.Length == 3
-    assert len(result) == 3, result
+    assert result.Length == 4
+    assert len(result) == 4, result
     assert result[0] == 'one'
     assert result[1] == 'two'
     assert result[2] == 'three'
+    # ensures params string[] overload takes precedence over params object[]
+    assert result[3] == 'tail'
 
     result = MethodTest.TestStringParamsArg(['one', 'two', 'three'])
-    assert len(result) == 3
+    assert len(result) == 4
     assert result[0] == 'one'
     assert result[1] == 'two'
     assert result[2] == 'three'
+    assert result[3] == 'tail'
 
 
 def test_object_params_args():


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

A bug in `ArgsPrecedence` caused parameters of type `object[]` to have the highest precedence, which affected `params object[]` handling, and also preferred `params object[]` to `params string[]` when a `string` argument was given.

### Does this close any currently open issues?

#1211

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
