### PR TITLE
Select correct method to invoke when keyword arguments are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ details about the cause of the failure
 -    Fix incorrect dereference in params array handling
 -    Fix `object[]` parameters taking precedence when should not in overload resolution
 -    Fixed a bug where all .NET class instances were considered Iterable
+-    Fix incorrect choice of method to invoke when using keyword arguments.
 
 ## [2.5.0][] - 2020-06-14
 

--- a/src/runtime/constructorbinder.cs
+++ b/src/runtime/constructorbinder.cs
@@ -89,7 +89,7 @@ namespace Python.Runtime
                 // any extra args are intended for the subclass' __init__.
 
                 IntPtr eargs = Runtime.PyTuple_New(0);
-                binding = Bind(inst, eargs, kw);
+                binding = Bind(inst, eargs, IntPtr.Zero);
                 Runtime.XDecref(eargs);
 
                 if (binding == null)

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -580,7 +580,7 @@ namespace Python.Runtime
             var match = false;
             paramsArray = parameters.Length > 0 ? Attribute.IsDefined(parameters[parameters.Length - 1], typeof(ParamArrayAttribute)) : false;
 
-            if (positionalArgumentCount == parameters.Length)
+            if (positionalArgumentCount == parameters.Length && kwargDict.Count == 0)
             {
                 match = true;
             }

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -699,6 +699,12 @@ namespace Python.Test
             return echo;
         }
     }
+
+    public class MethodArityTest
+    {
+        public string Foo(int a) { return "Arity 1"; }
+        public string Foo(int a, int b) { return "Arity 2"; }
+    }
 }
 
 namespace PlainOldNamespace

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -1149,3 +1149,10 @@ def test_optional_and_default_params():
 
     res = MethodTest.OptionalAndDefaultParams2(b=2, c=3)
     assert res == "0232"
+
+def test_keyword_arg_method_resolution():
+    from Python.Test import MethodArityTest
+
+    ob = MethodArityTest()
+    assert ob.Foo(1, b=2) == "Arity 2"
+


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

If there were two methods with the same name, but with different arity,
`Foo(a)` and `Foo(a,b)`, and the latter was called with a keyword
argument `some.Foo(0, b=1)`, `Foo(0)` would be called instead of
`Foo(0,1)`.

### Does this close any currently open issues?

Fixes #1235.

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [] If an enhancement PR, please create docs and at best an example
-   [] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
