### PR TITLE
Non-delegate types should not be callable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -77,3 +77,4 @@
 -   ([@stonebig](https://github.com/stonebig))
 -   ([@testrunner123](https://github.com/testrunner123))
 -   ([@DanBarzilian](https://github.com/DanBarzilian))
+-   ([@alxnull](https://github.com/alxnull))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ details about the cause of the failure
 -    Fix `object[]` parameters taking precedence when should not in overload resolution
 -    Fixed a bug where all .NET class instances were considered Iterable
 -    Fix incorrect choice of method to invoke when using keyword arguments.
+-    Fix non-delegate types incorrectly appearing as callable.
 
 ## [2.5.0][] - 2020-06-14
 

--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -278,36 +278,5 @@ namespace Python.Runtime
 
             return 0;
         }
-
-
-        /// <summary>
-        /// This is a hack. Generally, no managed class is considered callable
-        /// from Python - with the exception of System.Delegate. It is useful
-        /// to be able to call a System.Delegate instance directly, especially
-        /// when working with multicast delegates.
-        /// </summary>
-        public static IntPtr tp_call(IntPtr ob, IntPtr args, IntPtr kw)
-        {
-            //ManagedType self = GetManagedObject(ob);
-            IntPtr tp = Runtime.PyObject_TYPE(ob);
-            var cb = (ClassBase)GetManagedObject(tp);
-
-            if (cb.type != typeof(Delegate))
-            {
-                Exceptions.SetError(Exceptions.TypeError, "object is not callable");
-                return IntPtr.Zero;
-            }
-
-            var co = (CLRObject)GetManagedObject(ob);
-            var d = co.inst as Delegate;
-            BindingFlags flags = BindingFlags.Public |
-                                 BindingFlags.NonPublic |
-                                 BindingFlags.Instance |
-                                 BindingFlags.Static;
-
-            MethodInfo method = d.GetType().GetMethod("Invoke", flags);
-            var binder = new MethodBinder(method);
-            return binder.Invoke(ob, args, kw);
-        }
     }
 }

--- a/src/tests/test_class.py
+++ b/src/tests/test_class.py
@@ -315,3 +315,13 @@ def test_method_inheritance():
 
     assert base.IsBase() == True
     assert derived.IsBase() == False
+
+
+def test_callable():
+    """Test that only delegate subtypes are callable"""
+
+    def foo():
+        pass
+
+    assert callable(System.String("foo")) == False
+    assert callable(System.Action(foo)) == True


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

As mentioned in #1180, non-delegate types should not be appear as callable. Removed the `ClassObject.tp_call` method which seemed to be unused. Also added a test case.

### Does this close any currently open issues?

Closes #1180.


### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
