### PR TITLE
Make it possible to use inherited indexers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ details about the cause of the failure
 -    Fix incorrect choice of method to invoke when using keyword arguments.
 -    Fix non-delegate types incorrectly appearing as callable.
 -    Indexers can now be used with interface objects
+-    Fixed a bug where indexers could not be used if they were inherited
 
 ## [2.5.0][] - 2020-06-14
 

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -389,6 +389,25 @@ namespace Python.Runtime
                 ci.members[name] = ob;
             }
 
+            if (ci.indexer == null && type.IsClass)
+            {
+                // Indexer may be inherited.
+                var parent = type.BaseType;
+                while (parent != null && ci.indexer == null)
+                {
+                    foreach (var prop in parent.GetProperties()) {
+                        var args = prop.GetIndexParameters();
+                        if (args.GetLength(0) > 0)
+                        {
+                            ci.indexer = new Indexer();
+                            ci.indexer.AddProperty(prop);
+                            break;
+                        }
+                    }
+                    parent = parent.BaseType;
+                }
+            }
+
             return ci;
         }
     }

--- a/src/testing/indexertest.cs
+++ b/src/testing/indexertest.cs
@@ -411,4 +411,29 @@ namespace Python.Test
             }
         }
     }
+
+    public class PublicInheritedIndexerTest : PublicIndexerTest { }
+
+    public class ProtectedInheritedIndexerTest : ProtectedIndexerTest { }
+
+    public class PrivateInheritedIndexerTest : ProtectedIndexerTest { }
+
+    public class InternalInheritedIndexerTest : InternalIndexerTest { }
+
+    public interface IIndexer
+    {
+        string this[int index] { get; set; }
+    }
+
+    public interface IInheritedIndexer : IIndexer { }
+
+    public class InterfaceInheritedIndexerTest :IndexerBase,  IInheritedIndexer  {
+        private System.Collections.Generic.IDictionary<int, string> d = new System.Collections.Generic.Dictionary<int, string>();
+
+        public string this[int index]
+        {
+            get { return GetValue(index); }
+            set { t[index] = value; }
+        }
+    }
 }

--- a/src/tests/test_indexer.py
+++ b/src/tests/test_indexer.py
@@ -614,3 +614,35 @@ def test_using_indexer_on_object_without_indexer():
 
     with pytest.raises(TypeError):
         o[0] = 1
+
+
+def test_inherited_indexer():
+    """Test that inherited indexers are accessible"""
+    from Python.Test import PublicInheritedIndexerTest
+    from Python.Test import ProtectedInheritedIndexerTest
+    from Python.Test import PrivateInheritedIndexerTest
+    from Python.Test import InternalInheritedIndexerTest
+
+    pub = PublicInheritedIndexerTest()
+    pub[0] = "zero"
+    assert pub[0] == "zero"
+
+    def assert_no_indexer(obj):
+        with pytest.raises(TypeError):
+            obj[0]
+        with pytest.raises(TypeError):
+            obj[0] = "zero"
+
+    assert_no_indexer(PrivateInheritedIndexerTest)
+    assert_no_indexer(ProtectedInheritedIndexerTest)
+    assert_no_indexer(InternalInheritedIndexerTest)
+
+
+def test_inherited_indexer_interface():
+    """Test that indexers inherited from other interfaces are accessible"""
+    from Python.Test import InterfaceInheritedIndexerTest, IInheritedIndexer
+
+    impl = InterfaceInheritedIndexerTest()
+    ifc = IInheritedIndexer(impl)
+    ifc[0] = "zero"
+    assert ifc[0] == "zero"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

If a class A had indexer, and class B derived from it, Python.NET would
not consider class B to have any indexer.

### Does this close any currently open issues?

No

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
