### PR TITLE
Fixed dllLocal not being initialized.

### DIFF
--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -2155,7 +2155,7 @@ namespace Python.Runtime
         internal static void SetNoSiteFlag()
         {
             var loader = LibraryLoader.Get(NativeCodePageHelper.OperatingSystem);
-            IntPtr dllLocal;
+            IntPtr dllLocal = IntPtr.Zero;
             if (_PythonDll != "__Internal")
             {
                 dllLocal = loader.Load(_PythonDll);


### PR DESCRIPTION
This fixes a compile error which must be a merge bug from the soft-reload branch landing.