### PR TITLE
Use Type.DefaultBinder for overload resolution

### DIFF
--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -22,5 +22,7 @@ namespace Python.Runtime
         {
             this.pointer = pointer;
         }
+
+        public static BorrowedReference Null => new BorrowedReference();
     }
 }

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -117,6 +117,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp">
+      <Version>4.7.0</Version>
+    </PackageReference>
     <PackageReference Include="System.Security.Permissions" Version="4.4.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -52,7 +52,7 @@ namespace Python.Runtime
             var cls = GetManagedObject(tp) as ClassDerivedObject;
 
             // call the managed constructor
-            object obj = cls.binder.InvokeRaw(IntPtr.Zero, args, kw);
+            object obj = cls.binder.InvokeRaw(IntPtr.Zero, args, new BorrowedReference(kw));
             if (obj == null)
             {
                 return IntPtr.Zero;

--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -97,7 +97,7 @@ namespace Python.Runtime
                 return IntPtr.Zero;
             }
 
-            object obj = self.binder.InvokeRaw(IntPtr.Zero, args, kw);
+            object obj = self.binder.InvokeRaw(IntPtr.Zero, args, new BorrowedReference(kw));
             if (obj == null)
             {
                 return IntPtr.Zero;

--- a/src/runtime/constructorbinder.cs
+++ b/src/runtime/constructorbinder.cs
@@ -29,7 +29,7 @@ namespace Python.Runtime
         /// object - the reason is that only the caller knows the correct
         /// Python type to use when wrapping the result (may be a subclass).
         /// </summary>
-        internal object InvokeRaw(IntPtr inst, IntPtr args, IntPtr kw)
+        internal object InvokeRaw(IntPtr inst, IntPtr args, BorrowedReference kw)
         {
             return InvokeRaw(inst, args, kw, null);
         }
@@ -49,7 +49,7 @@ namespace Python.Runtime
         /// Binding binding = this.Bind(inst, args, kw, info);
         /// to take advantage of Bind()'s ability to use a single MethodBase (CI or MI).
         /// </remarks>
-        internal object InvokeRaw(IntPtr inst, IntPtr args, IntPtr kw, MethodBase info)
+        internal object InvokeRaw(IntPtr inst, IntPtr args, BorrowedReference kw, MethodBase info)
         {
             object result;
 
@@ -90,7 +90,7 @@ namespace Python.Runtime
                 // any extra args are intended for the subclass' __init__.
 
                 IntPtr eargs = Runtime.PyTuple_New(0);
-                binding = Bind(inst, eargs, IntPtr.Zero);
+                binding = Bind(inst, eargs, BorrowedReference.Null);
                 Runtime.XDecref(eargs);
 
                 if (binding == null)

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -211,7 +211,7 @@ namespace Python.Runtime
             }*/
             // Bind using ConstructorBinder.Bind and invoke the ctor providing a null instancePtr
             // which will fire self.ctorInfo using ConstructorInfo.Invoke().
-            object obj = self.ctorBinder.InvokeRaw(IntPtr.Zero, args, kw, self.ctorInfo);
+            object obj = self.ctorBinder.InvokeRaw(IntPtr.Zero, args, new BorrowedReference(kw), self.ctorInfo);
             if (obj == null)
             {
                 // XXX set an error

--- a/src/runtime/delegateobject.cs
+++ b/src/runtime/delegateobject.cs
@@ -90,7 +90,7 @@ namespace Python.Runtime
             {
                 return Exceptions.RaiseTypeError("invalid argument");
             }
-            return self.binder.Invoke(ob, args, kw);
+            return self.binder.Invoke(ob, args, new BorrowedReference(kw));
         }
 
 

--- a/src/runtime/indexer.cs
+++ b/src/runtime/indexer.cs
@@ -46,13 +46,13 @@ namespace Python.Runtime
 
         internal IntPtr GetItem(IntPtr inst, IntPtr args)
         {
-            return GetterBinder.Invoke(inst, args, IntPtr.Zero);
+            return GetterBinder.Invoke(inst, args, BorrowedReference.Null);
         }
 
 
         internal void SetItem(IntPtr inst, IntPtr args)
         {
-            SetterBinder.Invoke(inst, args, IntPtr.Zero);
+            SetterBinder.Invoke(inst, args, BorrowedReference.Null);
         }
 
         internal bool NeedsDefaultArgs(IntPtr args)

--- a/src/runtime/methodbinding.cs
+++ b/src/runtime/methodbinding.cs
@@ -185,7 +185,7 @@ namespace Python.Runtime
                     }
                 }
 
-                return self.m.Invoke(target, args, kw, self.info);
+                return self.m.Invoke(target, args, new BorrowedReference(kw), self.info);
             }
             finally
             {

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -49,12 +49,12 @@ namespace Python.Runtime
             }
         }
 
-        public virtual IntPtr Invoke(IntPtr inst, IntPtr args, IntPtr kw)
+        public virtual IntPtr Invoke(IntPtr inst, IntPtr args, BorrowedReference kw)
         {
             return Invoke(inst, args, kw, null);
         }
 
-        public virtual IntPtr Invoke(IntPtr target, IntPtr args, IntPtr kw, MethodBase info)
+        public virtual IntPtr Invoke(IntPtr target, IntPtr args, BorrowedReference kw, MethodBase info)
         {
             return binder.Invoke(target, args, kw, info, this.info);
         }

--- a/src/runtime/modulefunctionobject.cs
+++ b/src/runtime/modulefunctionobject.cs
@@ -25,7 +25,7 @@ namespace Python.Runtime
         public static IntPtr tp_call(IntPtr ob, IntPtr args, IntPtr kw)
         {
             var self = (ModuleFunctionObject)GetManagedObject(ob);
-            return self.Invoke(ob, args, kw);
+            return self.Invoke(ob, args, new BorrowedReference(kw));
         }
 
         /// <summary>

--- a/src/runtime/pydict.cs
+++ b/src/runtime/pydict.cs
@@ -103,12 +103,12 @@ namespace Python.Runtime
         /// </remarks>
         public PyObject Keys()
         {
-            IntPtr items = Runtime.PyDict_Keys(obj);
-            if (items == IntPtr.Zero)
+            var items = Runtime.PyDict_Keys(this.Reference);
+            if (items.IsNull())
             {
                 throw new PythonException();
             }
-            return new PyObject(items);
+            return items.MoveToPyObject();
         }
 
 
@@ -120,12 +120,12 @@ namespace Python.Runtime
         /// </remarks>
         public PyObject Values()
         {
-            IntPtr items = Runtime.PyDict_Values(obj);
-            if (items == IntPtr.Zero)
+            var items = Runtime.PyDict_Values(this.Reference);
+            if (!items.IsNull())
             {
                 throw new PythonException();
             }
-            return new PyObject(items);
+            return items.MoveToPyObject();
         }
 
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1685,10 +1685,10 @@ namespace Python.Runtime
         internal static extern int PyMapping_HasKey(IntPtr pointer, IntPtr key);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyDict_Keys(IntPtr pointer);
+        internal static extern NewReference PyDict_Keys(BorrowedReference pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyDict_Values(IntPtr pointer);
+        internal static extern NewReference PyDict_Values(BorrowedReference pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern NewReference PyDict_Items(IntPtr pointer);
@@ -1702,13 +1702,13 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyDict_Clear(IntPtr pointer);
 
-        internal static long PyDict_Size(IntPtr pointer)
+        internal static long PyDict_Size(BorrowedReference pointer)
         {
             return (long)_PyDict_Size(pointer);
         }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyDict_Size")]
-        internal static extern IntPtr _PyDict_Size(IntPtr pointer);
+        internal static extern IntPtr _PyDict_Size(BorrowedReference pointer);
 
 
         /// <summary>

--- a/src/runtime/runtime_state.cs
+++ b/src/runtime/runtime_state.cs
@@ -162,11 +162,11 @@ namespace Python.Runtime
         public static IEnumerable<IntPtr> GetModuleNames()
         {
             var modules = PyImport_GetModuleDict();
-            var names = PyDict_Keys(modules);
+            var names = PyDict_Keys(new BorrowedReference(modules)).DangerousGetAddress();
             var length = PyList_Size(new BorrowedReference(names));
             for (int i = 0; i < length; i++)
             {
-                var name = PyList_GetItem(new BorrowedReference(names), i);
+                BorrowedReference name = PyList_GetItem(new BorrowedReference(names), i);
                 yield return name.DangerousGetAddress();
             }
             XDecref(names);

--- a/src/runtime/typemethod.cs
+++ b/src/runtime/typemethod.cs
@@ -18,13 +18,13 @@ namespace Python.Runtime
         {
         }
 
-        public override IntPtr Invoke(IntPtr ob, IntPtr args, IntPtr kw)
+        public override IntPtr Invoke(IntPtr ob, IntPtr args, BorrowedReference kw)
         {
             MethodInfo mi = info[0];
             var arglist = new object[3];
             arglist[0] = ob;
             arglist[1] = args;
-            arglist[2] = kw;
+            arglist[2] = kw.DangerousGetAddress();
 
             try
             {

--- a/src/testing/Python.Test.15.csproj
+++ b/src/testing/Python.Test.15.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This replaces our custom overload binding code with the .NET default method binder.

Currently, default binder does not support generic type parameter inference.

### Does this close any currently open issues?

This could let us remove large chunks of code, that duplicates standard .NET functionality.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)