### PR TITLE
Return interface objects when iterating over interface collections

### DIFF
--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
@@ -184,7 +185,6 @@ namespace Python.Runtime
 
             var e = co.inst as IEnumerable;
             IEnumerator o;
-
             if (e != null)
             {
                 o = e.GetEnumerator();
@@ -199,7 +199,22 @@ namespace Python.Runtime
                 }
             }
 
-            return new Iterator(o).pyHandle;
+            var elemType = typeof(object);
+            var iterType = co.inst.GetType();
+            foreach(var ifc in iterType.GetInterfaces())
+            {
+                if (ifc.IsGenericType)
+                {
+                    var genTypeDef = ifc.GetGenericTypeDefinition();
+                    if (genTypeDef == typeof(IEnumerable<>) || genTypeDef == typeof(IEnumerator<>))
+                    {
+                        elemType = ifc.GetGenericArguments()[0];
+                        break;
+                    }
+                }
+            }
+
+            return new Iterator(o, elemType).pyHandle;
         }
 
 

--- a/src/runtime/iterator.cs
+++ b/src/runtime/iterator.cs
@@ -10,10 +10,12 @@ namespace Python.Runtime
     internal class Iterator : ExtensionType
     {
         private IEnumerator iter;
+        private Type elemType;
 
-        public Iterator(IEnumerator e)
+        public Iterator(IEnumerator e, Type elemType)
         {
             iter = e;
+            this.elemType = elemType;
         }
 
 
@@ -41,7 +43,7 @@ namespace Python.Runtime
                 return IntPtr.Zero;
             }
             object item = self.iter.Current;
-            return Converter.ToPythonImplicit(item);
+            return Converter.ToPython(item, self.elemType);
         }
 
         public static IntPtr tp_iter(IntPtr ob)

--- a/src/tests/test_interface.py
+++ b/src/tests/test_interface.py
@@ -120,3 +120,19 @@ def test_implementation_access():
     assert 100 == i.__implementation__
     assert clrVal == i.__raw_implementation__
     assert i.__implementation__ != i.__raw_implementation__
+
+
+def test_interface_collection_iteration():
+    """Test interface type is used when iterating over interface collection"""
+    import System
+    from System.Collections.Generic import List
+    elem = System.IComparable(System.Int32(100))
+    typed_list = List[System.IComparable]()
+    typed_list.Add(elem)
+    for e in typed_list:
+        assert type(e).__name__ == "IComparable"
+
+    untyped_list = System.Collections.ArrayList()
+    untyped_list.Add(elem)
+    for e in untyped_list:
+        assert type(e).__name__ == "int"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Ensures that objects returned from an iterator are wrapped in an interface object if the iterator is for an interface type.

### Does this close any currently open issues?

No

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
