### PR TITLE
Fixed crash in finalizer of CLR types defined in Python, that survive  engine shutdown

### DIFF
--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -857,7 +857,7 @@ namespace Python.Runtime
             {
                 if (0 == Runtime.Py_IsInitialized() || Runtime.IsFinalizing)
                 {
-                    self.gcHandle.Free();
+                    if (self.gcHandle.IsAllocated) self.gcHandle.Free();
                     return;
                 }
             }
@@ -872,7 +872,7 @@ namespace Python.Runtime
                     // If python's been terminated then just free the gchandle.
                     if (0 == Runtime.Py_IsInitialized() || Runtime.IsFinalizing)
                     {
-                        self.gcHandle.Free();
+                        if (self.gcHandle.IsAllocated) self.gcHandle.Free();
                         return;
                     }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

During engine shutdown all links from Python to .NET instances are severed. If an instance of CLR class defined in Python survives the shutdown (for example, a reference is stored in static field) and later gets finalized, it will attempt to severe link again, which is an invalid operation.

The fix is to check if the link has already been severed and skip that step during finalization.

Additionally in this change: refactored `MoveClrInstancesOnwershipToPython`

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1256

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
