### PR TITLE
Fixed polyfill for TypeBuilder.CreateType

### DIFF
--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -123,7 +123,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Security.Permissions" Version="4.4.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">

--- a/src/runtime/polyfill/ReflectionPolifills.cs
+++ b/src/runtime/polyfill/ReflectionPolifills.cs
@@ -16,7 +16,7 @@ namespace Python.Runtime
 
         public static Type CreateType(this TypeBuilder typeBuilder)
         {
-            return typeBuilder.GetTypeInfo().GetType();
+            return typeBuilder.CreateTypeInfo();
         }
 #endif
         public static T GetCustomAttribute<T>(this Type type) where T: Attribute


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The `TypeBuilder.CreateType()` polyfill was incorrectly returning `typeof(TypeBuilder)` instead of the new type created using `TypeBuilder`.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1228

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
