### PR TITLE
DLR-based overload resolution

### DIFF
--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -94,7 +94,7 @@ clr.AddReference('{0}')
 from Python.EmbeddingTest.Domain import MyClass
 obj = MyClass()
 obj.Method()
-obj.StaticMethod()
+MyClass.StaticMethod()
 obj.Property = 1
 obj.Field = 10
 ", Assembly.GetExecutingAssembly().FullName);
@@ -137,16 +137,18 @@ obj.Field = 10
                         Assert.That(tp_clear, Is.Not.Null);
 
                         using (PyObject obj = new PyObject(handle))
+                        using (PyObject myClass = new PyObject(new BorrowedReference(tp)))
                         {
                             obj.InvokeMethod("Method");
-                            obj.InvokeMethod("StaticMethod");
+                            myClass.InvokeMethod("StaticMethod");
 
                             using (var scope = Py.CreateScope())
                             {
                                 scope.Set("obj", obj);
+                                scope.Set("myClass", myClass);
                                 scope.Exec(@"
 obj.Method()
-obj.StaticMethod()
+myClass.StaticMethod()
 obj.Property += 1
 obj.Field += 10
 ");
@@ -191,7 +193,7 @@ from Python.EmbeddingTest.Domain import MyClass
 def test_obj_call():
     obj = MyClass()
     obj.Method()
-    obj.StaticMethod()
+    MyClass.StaticMethod()
     obj.Property = 1
     obj.Field = 10
 

--- a/src/runtime/BorrowedReference.cs
+++ b/src/runtime/BorrowedReference.cs
@@ -11,9 +11,11 @@ namespace Python.Runtime
         public bool IsNull => this.pointer == IntPtr.Zero;
 
 
-        /// <summary>Gets a raw pointer to the Python object</summary>
+        /// <summary>Gets a raw pointer to the Python object. Performs null check</summary>
         public IntPtr DangerousGetAddress()
             => this.IsNull ? throw new NullReferenceException() : this.pointer;
+        /// <summary>Gets a raw pointer to the Python object</summary>
+        public IntPtr DangerousGetAddressOrNull() => this.pointer;
 
         /// <summary>
         /// Creates new instance of <see cref="BorrowedReference"/> from raw pointer. Unsafe.
@@ -22,5 +24,7 @@ namespace Python.Runtime
         {
             this.pointer = pointer;
         }
+
+        public static BorrowedReference Null => default;
     }
 }

--- a/src/runtime/Native/PyFrameObjectReference.cs
+++ b/src/runtime/Native/PyFrameObjectReference.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Python.Runtime.Native
+{
+    readonly ref struct PyFrameObjectReference
+    {
+        readonly IntPtr pointer;
+
+        public bool IsNull => this.pointer == IntPtr.Zero;
+    }
+}

--- a/src/runtime/Python.Runtime.15.csproj
+++ b/src/runtime/Python.Runtime.15.csproj
@@ -122,6 +122,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp">
+      <Version>4.7.0</Version>
+    </PackageReference>
     <PackageReference Include="System.Security.Permissions" Version="4.4.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -92,6 +92,7 @@
     <Compile Include="assemblymanager.cs" />
     <Compile Include="BorrowedReference.cs" />
     <Compile Include="bufferinterface.cs" />
+    <Compile Include="callsitebinder.cs" />
     <Compile Include="classderived.cs" />
     <Compile Include="classbase.cs" />
     <Compile Include="classmanager.cs" />

--- a/src/runtime/Util.cs
+++ b/src/runtime/Util.cs
@@ -7,6 +7,8 @@ namespace Python.Runtime
     {
         internal const string UnstableApiMessage =
             "This API is unstable, and might be changed or removed in the next minor release";
+        internal const string UseReferenceOverloadMessage =
+            "This is a legacy overload. Please use an overload, that works with *Reference types";
 
         internal static Int64 ReadCLong(IntPtr tp, int offset)
         {

--- a/src/runtime/callsitebinder.cs
+++ b/src/runtime/callsitebinder.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+
+using Microsoft.CSharp.RuntimeBinder;
+
+using CSharpBinder = Microsoft.CSharp.RuntimeBinder.Binder;
+
+namespace Python.Runtime
+{
+    public class PythonNetCallSiteBinder : CallSiteBinder
+    {
+        readonly CallSiteBinder voidBinder;
+        readonly CallSiteBinder resultBinder;
+
+        PythonNetCallSiteBinder(string methodName,
+            IEnumerable<Type> typeArguments,
+            Type context,
+            IEnumerable<CSharpArgumentInfo> argumentInfo)
+        {
+            this.voidBinder = CSharpBinder.InvokeMember(CSharpBinderFlags.ResultDiscarded,
+                methodName,
+                typeArguments: typeArguments,
+                context: context,
+                argumentInfo
+            );
+            this.resultBinder = CSharpBinder.InvokeMember(CSharpBinderFlags.None,
+                methodName,
+                typeArguments: typeArguments,
+                context: context,
+                argumentInfo
+            );
+        }
+
+        public override Expression Bind(object[] args,
+            ReadOnlyCollection<ParameterExpression> parameters,
+            LabelTarget returnLabel)
+        {
+            var result = this.resultBinder.Bind(args, parameters, returnLabel);
+            if (result.Type == typeof(void))
+            {
+                var voidExpr = this.voidBinder.Bind(args, parameters, returnLabel);
+                return Expression.Block(
+                    voidExpr,
+                    Expression.Return(returnLabel, Expression.Constant(null))
+                );
+            }
+
+            return result;
+        }
+
+        public static PythonNetCallSiteBinder InvokeMember(string methodName,
+            IEnumerable<Type> typeArguments,
+            Type context,
+            IEnumerable<CSharpArgumentInfo> argumentInfo)
+            => new PythonNetCallSiteBinder(methodName, typeArguments, context, argumentInfo);
+    }
+}

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -52,7 +52,7 @@ namespace Python.Runtime
             var cls = GetManagedObject(tp) as ClassDerivedObject;
 
             // call the managed constructor
-            object obj = cls.binder.InvokeRaw(IntPtr.Zero, args, kw);
+            object obj = cls.binder.InvokeRaw(IntPtr.Zero, new BorrowedReference(args), kw);
             if (obj == null)
             {
                 return IntPtr.Zero;

--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -32,7 +32,7 @@ namespace Python.Runtime
         /// </summary>
         internal IntPtr GetDocString()
         {
-            MethodBase[] methods = binder.GetMethods();
+            var methods = binder.GetMethods();
             var str = "";
             foreach (MethodBase t in methods)
             {

--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -49,8 +49,9 @@ namespace Python.Runtime
         /// <summary>
         /// Implements __new__ for reflected classes and value types.
         /// </summary>
-        public static IntPtr tp_new(IntPtr tp, IntPtr args, IntPtr kw)
+        public static IntPtr tp_new(IntPtr tp, IntPtr rawArgs, IntPtr kw)
         {
+            var args = new BorrowedReference(rawArgs);
             var self = GetManagedObject(tp) as ClassObject;
 
             // Sanity check: this ensures a graceful error if someone does
@@ -74,7 +75,7 @@ namespace Python.Runtime
                     return IntPtr.Zero;
                 }
 
-                IntPtr op = Runtime.PyTuple_GetItem(args, 0);
+                BorrowedReference op = Runtime.PyTuple_GetItem(args, 0);
                 object result;
 
                 if (!Converter.ToManaged(op, type, out result, true))

--- a/src/runtime/constructorbinder.cs
+++ b/src/runtime/constructorbinder.cs
@@ -29,7 +29,7 @@ namespace Python.Runtime
         /// object - the reason is that only the caller knows the correct
         /// Python type to use when wrapping the result (may be a subclass).
         /// </summary>
-        internal object InvokeRaw(IntPtr inst, IntPtr args, IntPtr kw)
+        internal object InvokeRaw(IntPtr inst, BorrowedReference args, IntPtr kw)
         {
             return InvokeRaw(inst, args, kw, null);
         }
@@ -49,7 +49,7 @@ namespace Python.Runtime
         /// Binding binding = this.Bind(inst, args, kw, info);
         /// to take advantage of Bind()'s ability to use a single MethodBase (CI or MI).
         /// </remarks>
-        internal object InvokeRaw(IntPtr inst, IntPtr args, IntPtr kw, MethodBase info)
+        internal object InvokeRaw(IntPtr inst, BorrowedReference args, IntPtr kw, MethodBase info)
         {
             object result;
 
@@ -78,7 +78,7 @@ namespace Python.Runtime
                 return result;
             }
 
-            Binding binding = Bind(inst, args, kw, info);
+            Binding binding = Bind(inst, args.DangerousGetAddress(), kw, info);
 
             if (binding == null)
             {

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -121,7 +121,7 @@ namespace Python.Runtime
                 Runtime.XIncref(self.repr);
                 return self.repr;
             }
-            MethodBase[] methods = self.ctorBinder.GetMethods();
+            var methods = self.ctorBinder.GetMethods();
             string name = self.type.FullName;
             var doc = "";
             foreach (MethodBase t in methods)

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -211,7 +211,7 @@ namespace Python.Runtime
             }*/
             // Bind using ConstructorBinder.Bind and invoke the ctor providing a null instancePtr
             // which will fire self.ctorInfo using ConstructorInfo.Invoke().
-            object obj = self.ctorBinder.InvokeRaw(IntPtr.Zero, args, kw, self.ctorInfo);
+            object obj = self.ctorBinder.InvokeRaw(IntPtr.Zero, new BorrowedReference(args), kw, self.ctorInfo);
             if (obj == null)
             {
                 // XXX set an error

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -298,11 +298,18 @@ namespace Python.Runtime
             return ToPython(value, objectType);
         }
 
+        /// <summary>
+        /// Return a managed object for the given Python object, taking funny
+        /// byref types into account.
+        /// </summary>
+        internal static bool ToManaged(BorrowedReference value, Type type, out object result, bool setError)
+            => ToManaged(value.DangerousGetAddress(), type, out result, setError);
 
         /// <summary>
         /// Return a managed object for the given Python object, taking funny
         /// byref types into account.
         /// </summary>
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         internal static bool ToManaged(IntPtr value, Type type,
             out object result, bool setError)
         {

--- a/src/runtime/delegateobject.cs
+++ b/src/runtime/delegateobject.cs
@@ -72,10 +72,11 @@ namespace Python.Runtime
         /// <summary>
         /// Implements __call__ for reflected delegate types.
         /// </summary>
-        public static IntPtr tp_call(IntPtr ob, IntPtr args, IntPtr kw)
+        public static IntPtr tp_call(IntPtr obRaw, IntPtr args, IntPtr kw)
         {
+            var ob = new BorrowedReference(obRaw);
             // TODO: add fast type check!
-            IntPtr pytype = Runtime.PyObject_TYPE(ob);
+            BorrowedReference pytype = Runtime.PyObject_Type(ob);
             var self = (DelegateObject)GetManagedObject(pytype);
             var o = GetManagedObject(ob) as CLRObject;
 
@@ -90,7 +91,7 @@ namespace Python.Runtime
             {
                 return Exceptions.RaiseTypeError("invalid argument");
             }
-            return self.binder.Invoke(ob, args, kw);
+            return self.binder.Invoke(ob, new BorrowedReference(args), new BorrowedReference(kw));
         }
 
 

--- a/src/runtime/indexer.cs
+++ b/src/runtime/indexer.cs
@@ -44,15 +44,15 @@ namespace Python.Runtime
             }
         }
 
-        internal IntPtr GetItem(IntPtr inst, IntPtr args)
+        internal IntPtr GetItem(BorrowedReference inst, BorrowedReference args)
         {
-            return GetterBinder.Invoke(inst, args, IntPtr.Zero);
+            return GetterBinder.Invoke(inst, args, BorrowedReference.Null);
         }
 
 
-        internal void SetItem(IntPtr inst, IntPtr args)
+        internal void SetItem(BorrowedReference inst, BorrowedReference args)
         {
-            SetterBinder.Invoke(inst, args, IntPtr.Zero);
+            SetterBinder.Invoke(inst, args, BorrowedReference.Null);
         }
 
         internal bool NeedsDefaultArgs(IntPtr args)

--- a/src/runtime/indexer.cs
+++ b/src/runtime/indexer.cs
@@ -58,8 +58,8 @@ namespace Python.Runtime
         internal bool NeedsDefaultArgs(IntPtr args)
         {
             var pynargs = Runtime.PyTuple_Size(args);
-            MethodBase[] methods = SetterBinder.GetMethods();
-            if (methods.Length == 0)
+            var methods = SetterBinder.GetMethods();
+            if (methods.Count == 0)
             {
                 return false;
             }
@@ -99,7 +99,7 @@ namespace Python.Runtime
             var pynargs = Runtime.PyTuple_Size(args);
 
             // Get the default arg tuple
-            MethodBase[] methods = SetterBinder.GetMethods();
+            var methods = SetterBinder.GetMethods();
             MethodBase mi = methods[0];
             ParameterInfo[] pi = mi.GetParameters();
             int clrnargs = pi.Length - 1;

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -75,6 +75,9 @@ namespace Python.Runtime
             }
         }
 
+        internal static ManagedType GetManagedObject(BorrowedReference ob)
+            => ob.IsNull ? null : GetManagedObject(ob.DangerousGetAddress());
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         /// <summary>
         /// Given a Python object, return the associated managed object or null.
         /// </summary>

--- a/src/runtime/methodbinding.cs
+++ b/src/runtime/methodbinding.cs
@@ -185,7 +185,7 @@ namespace Python.Runtime
                     }
                 }
 
-                return self.m.Invoke(target, args, kw, self.info);
+                return self.m.Invoke(new BorrowedReference(target), new BorrowedReference(args), new BorrowedReference(kw), self.info);
             }
             finally
             {

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -70,7 +70,7 @@ namespace Python.Runtime
             }
             var str = "";
             Type marker = typeof(DocStringAttribute);
-            MethodBase[] methods = binder.GetMethods();
+            var methods = binder.GetMethods();
             foreach (MethodBase method in methods)
             {
                 if (str.Length > 0)

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -49,12 +49,12 @@ namespace Python.Runtime
             }
         }
 
-        public virtual IntPtr Invoke(IntPtr inst, IntPtr args, IntPtr kw)
+        public virtual IntPtr Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw)
         {
             return Invoke(inst, args, kw, null);
         }
 
-        public virtual IntPtr Invoke(IntPtr target, IntPtr args, IntPtr kw, MethodBase info)
+        public virtual IntPtr Invoke(BorrowedReference target, BorrowedReference args, BorrowedReference kw, MethodBase info)
         {
             return binder.Invoke(target, args, kw, info, this.info);
         }

--- a/src/runtime/modulefunctionobject.cs
+++ b/src/runtime/modulefunctionobject.cs
@@ -22,10 +22,11 @@ namespace Python.Runtime
         /// <summary>
         /// __call__ implementation.
         /// </summary>
-        public static IntPtr tp_call(IntPtr ob, IntPtr args, IntPtr kw)
+        public static IntPtr tp_call(IntPtr obRaw, IntPtr args, IntPtr kw)
         {
+            var ob = new BorrowedReference(obRaw);
             var self = (ModuleFunctionObject)GetManagedObject(ob);
-            return self.Invoke(ob, args, kw);
+            return self.Invoke(ob, new BorrowedReference(args), new BorrowedReference(kw));
         }
 
         /// <summary>

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1031,6 +1031,15 @@ namespace Python.Runtime
             return tp;
         }
 
+        /// <summary>
+        /// Managed version of the standard Python C API PyObject_Type call.
+        /// This version avoids a managed  &lt;-&gt; unmanaged transition.
+        /// </summary>
+        internal static BorrowedReference PyObject_Type(BorrowedReference op)
+        {
+            return new BorrowedReference(PyObject_TYPE(op.DangerousGetAddress()));
+        }
+
         internal static string PyObject_GetTypeName(IntPtr op)
         {
             IntPtr pyType = Marshal.ReadIntPtr(op, ObjectOffset.ob_type);
@@ -1150,6 +1159,9 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
             EntryPoint = "PyObject_Str")]
         internal static extern IntPtr PyObject_Unicode(IntPtr pointer);
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
+            EntryPoint = "PyObject_Str")]
+        internal static extern NewReference PyObject_Unicode(BorrowedReference pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyObject_Dir(IntPtr pointer);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Collections.Generic;
 using Python.Runtime.Platform;
 using System.Linq;
+using Python.Runtime.Native;
 
 namespace Python.Runtime
 {
@@ -899,10 +900,16 @@ namespace Python.Runtime
         internal static extern IntPtr PyEval_GetBuiltins();
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern PyFrameObjectReference PyEval_GetFrame();
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyEval_GetGlobals();
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyEval_GetLocals();
+
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int PyFrame_GetLineNumber(PyFrameObjectReference frame);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr Py_GetProgramName();
@@ -1605,7 +1612,7 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyUnicode_Compare(IntPtr left, IntPtr right);
 
-        internal static string GetManagedString(in BorrowedReference borrowedReference)
+        internal static string GetManagedString(BorrowedReference borrowedReference)
             => GetManagedString(borrowedReference.DangerousGetAddress());
         /// <summary>
         /// Function to access the internal PyUnicode/PyString object and
@@ -1691,9 +1698,15 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyMapping_HasKey(IntPtr pointer, IntPtr key);
 
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyDict_Keys(IntPtr pointer);
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NewReference PyDict_Keys(BorrowedReference pointer);
 
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NewReference PyDict_Values(BorrowedReference pointer);
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyDict_Values(IntPtr pointer);
 
@@ -1709,6 +1722,8 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyDict_Clear(IntPtr pointer);
 
+        internal static long PyDict_Size(BorrowedReference dict) => PyDict_Size(dict.DangerousGetAddress());
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         internal static long PyDict_Size(IntPtr pointer)
         {
             return (long)_PyDict_Size(pointer);
@@ -1827,6 +1842,9 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr PyTuple_New(IntPtr size);
 
+        internal static BorrowedReference PyTuple_GetItem(BorrowedReference pointer, long index)
+            => new BorrowedReference(PyTuple_GetItem(pointer.DangerousGetAddress(), new IntPtr(index)));
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         internal static IntPtr PyTuple_GetItem(IntPtr pointer, long index)
         {
             return PyTuple_GetItem(pointer, new IntPtr(index));
@@ -1835,6 +1853,11 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr PyTuple_GetItem(IntPtr pointer, IntPtr index);
 
+        internal static int PyTuple_SetItem(BorrowedReference tuple, long index, IntPtr value)
+        {
+            return PyTuple_SetItem(tuple.DangerousGetAddress(), new IntPtr(index), value);
+        }
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         internal static int PyTuple_SetItem(IntPtr pointer, long index, IntPtr value)
         {
             return PyTuple_SetItem(pointer, new IntPtr(index), value);
@@ -1851,13 +1874,19 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr PyTuple_GetSlice(IntPtr pointer, IntPtr start, IntPtr end);
 
+        internal static long PyTuple_Size(BorrowedReference tuple)
+        {
+            return (long)_PyTuple_Size(tuple);
+        }
+
+        [Obsolete(Util.UseReferenceOverloadMessage)]
         internal static long PyTuple_Size(IntPtr pointer)
         {
-            return (long)_PyTuple_Size(pointer);
+            return (long)_PyTuple_Size(new BorrowedReference(pointer));
         }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl, EntryPoint = "PyTuple_Size")]
-        private static extern IntPtr _PyTuple_Size(IntPtr pointer);
+        private static extern IntPtr _PyTuple_Size(BorrowedReference pointer);
 
 
         //====================================================================

--- a/src/runtime/typemethod.cs
+++ b/src/runtime/typemethod.cs
@@ -18,21 +18,17 @@ namespace Python.Runtime
         {
         }
 
-        public override IntPtr Invoke(IntPtr ob, IntPtr args, IntPtr kw)
+        public override IntPtr Invoke(BorrowedReference ob, BorrowedReference args, BorrowedReference kw)
         {
             MethodInfo mi = info[0];
             var arglist = new object[3];
-            arglist[0] = ob;
-            arglist[1] = args;
-            arglist[2] = kw;
+            arglist[0] = ob.DangerousGetAddressOrNull();
+            arglist[1] = args.DangerousGetAddress();
+            arglist[2] = kw.DangerousGetAddressOrNull();
 
             try
             {
-                object inst = null;
-                if (ob != IntPtr.Zero)
-                {
-                    inst = GetManagedObject(ob);
-                }
+                object inst = ob.IsNull ? null : GetManagedObject(ob);
                 return (IntPtr)mi.Invoke(inst, BindingFlags.Default, null, arglist, null);
             }
             catch (Exception e)

--- a/src/testing/Python.Test.15.csproj
+++ b/src/testing/Python.Test.15.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This is an attempt to replace our custom (and in many cases borked) overload resolution with C# [`RuntimeBinder`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.csharp.runtimebinder.binder?view=netframework-4.8), that is used to implement C#'s `dynamic` keyword.

This should make our overload resolution nearly identical to C# overload resolution. It has full handling for: `params`, implicit conversions, type hierarchy, generics, overload prioritization, keyword arguments.

A bonus feature is that supporting newer C# features in method binding should be as easy as simply updating the `Microsoft.CSharp` NuGet.

### Major consequences and further TODO

1. During overload selection, there will be no more multiple attempts to marshal Python objects to C# (was: one per attempted overload). All parameters will be decoded exactly once, and then C# binder will be used to pick the correct overload.
2. Because of 1, decoders should return object instances, that are compatible with expected .NET types. For example: decode of `builtins.int` should return an instance of `PyInt`, which then should implement static or dynamic (e.g. [`TryConvert`](https://docs.microsoft.com/en-us/dotnet/api/system.dynamic.dynamicobject.tryconvert)) conversion to `System.Int32` and/or `System.Int64` in order to be used with `void Foo(int arg)`.
3. The mechanism to select a specific overload from Python would have to be reworked. We need a clear separation between explicitly specifying generic parameters vs explicitly specifying parameter types.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1099 , specifically https://github.com/pythonnet/pythonnet/issues/1099#issuecomment-640605647

### Other comments

I am not sure how we could approach getting this done. Until the entirety of binding features are re-implemented with DLR, current tests will be failing. Perhaps a separate branch would be a good approach, where changes could be reviewed incrementally. @amos402 , @filmor , thoughts?

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
