### PR TITLE
Use .NET Core 3.1 LTS for tests (instead of 2.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ python:
 
 env:
   matrix:
-    - BUILD_OPTS=--xplat NUNIT_PATH="~/.nuget/packages/nunit.consolerunner/3.*/tools/nunit3-console.exe" RUN_TESTS=dotnet EMBED_TESTS_PATH=netcoreapp2.0_publish/ PERF_TESTS_PATH=net461/
+    - BUILD_OPTS=--xplat NUNIT_PATH="~/.nuget/packages/nunit.consolerunner/3.*/tools/nunit3-console.exe" RUN_TESTS=dotnet EMBED_TESTS_PATH=netcoreapp3.1_publish/ PERF_TESTS_PATH=net461/
     - BUILD_OPTS="" NUNIT_PATH="./packages/NUnit.*/tools/nunit3-console.exe" RUN_TESTS="mono $NUNIT_PATH" EMBED_TESTS_PATH="" PERF_TESTS_PATH=""
-    - PYTHONNET_SHUTDOWN_MODE="Soft" BUILD_OPTS=--xplat NUNIT_PATH="~/.nuget/packages/nunit.consolerunner/3.*/tools/nunit3-console.exe" RUN_TESTS=dotnet EMBED_TESTS_PATH=netcoreapp2.0_publish/ PERF_TESTS_PATH=net461/
+    - PYTHONNET_SHUTDOWN_MODE="Soft" BUILD_OPTS=--xplat NUNIT_PATH="~/.nuget/packages/nunit.consolerunner/3.*/tools/nunit3-console.exe" RUN_TESTS=dotnet EMBED_TESTS_PATH=netcoreapp3.1_publish/ PERF_TESTS_PATH=net461/
     - PYTHONNET_SHUTDOWN_MODE="Soft" BUILD_OPTS="" NUNIT_PATH="./packages/NUnit.*/tools/nunit3-console.exe" RUN_TESTS="mono $NUNIT_PATH" EMBED_TESTS_PATH="" PERF_TESTS_PATH=""
 
   global:
@@ -29,9 +29,7 @@ addons:
     packages:
       - mono-devel
       - ca-certificates-mono
-      - dotnet-hostfxr-2.2
-      - dotnet-runtime-2.2
-      - dotnet-sdk-2.2
+      - dotnet-sdk-3.1
 
 before_install:
   # Set-up dll path for embedded tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{branch}-{build}'
 build: off
 
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
 
 platform:
   - x86

--- a/ci/appveyor_run_tests.ps1
+++ b/ci/appveyor_run_tests.ps1
@@ -99,12 +99,12 @@ if ($XPLAT){
          $DOTNET_CMD = "c:\Program Files (x86)\dotnet\dotnet"
     }
 
-    # Run Embedded tests for netcoreapp2.0 (OpenCover currently does not supports dotnet core)
-    Write-Host ("Starting embedded tests for netcoreapp2.0") -ForegroundColor "Green"
-    &$DOTNET_CMD ".\src\embed_tests\bin\netcoreapp2.0_publish\Python.EmbeddingTest.dll"
+    # Run Embedded tests for netcoreapp3.1 (OpenCover currently does not supports dotnet core)
+    Write-Host ("Starting embedded tests for netcoreapp3.1") -ForegroundColor "Green"
+    &$DOTNET_CMD ".\src\embed_tests\bin\netcoreapp3.1_publish\Python.EmbeddingTest.dll"
     $CS_STATUS = $LastExitCode
     if ($CS_STATUS -ne 0) {
-        Write-Host "Embedded tests for netcoreapp2.0 failed" -ForegroundColor "Red"
+        Write-Host "Embedded tests for netcoreapp3.1 failed" -ForegroundColor "Red"
         ReportTime ""
     } else {
         ReportTime ".NET Core 2.0 tests completed"

--- a/setup.py
+++ b/setup.py
@@ -351,7 +351,7 @@ class BuildExtPythonnet(build_ext.build_ext):
                     cmd
                     + [
                         '"/t:Console_15:publish;Python_EmbeddingTest_15:publish"',
-                        "/p:TargetFramework=netcoreapp2.0",
+                        "/p:TargetFramework=netcoreapp3.1",
                     ]
                 ),
                 shell=use_shell,

--- a/src/console/Console.15.csproj
+++ b/src/console/Console.15.csproj
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <TargetFrameworks>net40;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp3.1</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <Configurations>DebugMono;DebugMonoPY3;ReleaseMono;ReleaseMonoPY3;DebugWin;DebugWinPY3;ReleaseWin;ReleaseWinPY3</Configurations>
     <OutputType>Exe</OutputType>

--- a/src/embed_tests/Python.EmbeddingTest.15.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.15.csproj
@@ -2,7 +2,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp3.1</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <Configurations>DebugMono;DebugMonoPY3;ReleaseMono;ReleaseMonoPY3;DebugWin;DebugWinPY3;ReleaseWin;ReleaseWinPY3</Configurations>
     <OutputType Condition="'$(TargetFramework)' != 'net40' OR '$(PYTHONNET_VS_ENV)' == 'true'">Exe</OutputType>
@@ -28,7 +28,7 @@
     <CustomDefineConstants Condition="'$(CustomDefineConstants)' == ''">$(PYTHONNET_DEFINE_CONSTANTS)</CustomDefineConstants>
     <BaseDefineConstants>XPLAT</BaseDefineConstants>
     <DefineConstants>$(DefineConstants);$(CustomDefineConstants);$(BaseDefineConstants);</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)'=='netcoreapp2.0'">$(DefineConstants);NETCOREAPP</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)'=='netcoreapp3.1'">$(DefineConstants);NETCOREAPP</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)'=='netstandard2.0'">$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(CustomDefineConstants)' != '' AND $(Configuration.Contains('Debug'))">$(DefineConstants);TRACE;DEBUG</DefineConstants>
     <FrameworkPathOverride Condition="'$(TargetFramework)'=='net40' AND $(Configuration.Contains('Mono'))">$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.5\1.0.1\lib\net45\</FrameworkPathOverride>
@@ -87,7 +87,7 @@
     </PackageReference>
     <PackageReference Include="NUnitLite" Version="3.12.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

.NET Core 2.0 is no longer supported. This moves tests to .NET Core 3.1 LTS, which should be supported [until Dec 2022](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).