### PR TITLE
Ensure methods of Object are also available on interface objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ details about the cause of the failure
 -    Indexers can now be used with interface objects
 -    Fixed a bug where indexers could not be used if they were inherited
 -    Made it possible to use `__len__` also on `ICollection<>` interface objects
+-    Made it possible to call `ToString`, `GetHashCode`, and `GetType` on inteface objects
 
 ### Removed
 

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -341,6 +341,17 @@ namespace Python.Runtime
                         }
                     }
                 }
+
+                // All interface implementations inherit from Object,
+                // but GetMembers don't return them either.
+                var objFlags = BindingFlags.Public | BindingFlags.Instance;
+                foreach (var mi in typeof(object).GetMembers(objFlags))
+                {
+                    if (local[mi.Name] == null)
+                    {
+                        items.Add(mi);
+                    }
+                }
             }
 
             for (i = 0; i < items.Count; i++)

--- a/src/tests/test_interface.py
+++ b/src/tests/test_interface.py
@@ -136,3 +136,14 @@ def test_interface_collection_iteration():
     untyped_list.Add(elem)
     for e in untyped_list:
         assert type(e).__name__ == "int"
+
+
+def test_methods_of_Object_are_available():
+    """Test calling methods inherited from Object"""
+    import System
+    clrVal =  System.Int32(100)
+    i = System.IComparable(clrVal)
+    assert i.Equals(clrVal)
+    assert clrVal.GetHashCode() == i.GetHashCode()
+    assert clrVal.GetType() == i.GetType()
+    assert clrVal.ToString() == i.ToString()


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Allows users to call `ToString`, `GetHashCode` and `GetType` on objects wrapped in interface objects.

### Does this close any currently open issues?

No

### Any other comments?

No

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
