### PR TITLE
[Out] parameters no longer added to return tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 details about the cause of the failure
 -   `clr.AddReference` no longer adds ".dll" implicitly
 -   `PyIter(PyObject)` constructor replaced with static `PyIter.GetIter(PyObject)` method
--    Return values from .NET methods that return an interface are now automatically
+-   BREAKING: Return values from .NET methods that return an interface are now automatically
      wrapped in that interface. This is a breaking change for users that rely on being
      able to access members that are part of the implementation class, but not the
      interface.  Use the new __implementation__ or __raw_implementation__ properties to
      if you need to "downcast" to the implementation class.
+-   BREAKING: Parameters marked with `ParameterAttributes.Out` are no longer returned in addition
+     to the regular method return value (unless they are passed with `ref` or `out` keyword).
 
 ### Fixed
 

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -534,7 +534,7 @@ namespace Python.Runtime
                     Runtime.XDecref(op);
                 }
 
-                if (parameter.IsOut || isOut)
+                if (isOut)
                 {
                     outs++;
                 }

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -761,7 +761,7 @@ def test_we_can_bind_to_encoding_get_string():
     read = 1
 
     while read > 0:
-        read, _ = stream.Read(buff, 0, buff.Length)
+        read = stream.Read(buff, 0, buff.Length)
         temp = Encoding.UTF8.GetString(buff, 0, read)
         data.append(temp)
 


### PR DESCRIPTION
Parameters marked with `ParameterAttributes.Out` (aka `[Out]`) are no longer returned in addition to the regular method return value (unless they are passed with `ref` or `out` keyword).

### What does this implement/fix? Explain your changes.

As it is now possible to pass raw .NET objects to .NET methods, there's no need to marshal `[Out]` parameters back to Python manually. Python users can simply access modified object's data directly.

### Any other comments?

It was confusing to see `read, _ = stream.Read(buff, 0, buff.Length)` in the test code, as `Read` method does not really have any `out` or `ref` parameters. It also failed on some .NET implementations, as the corresponding parameter does not always have an `[Out]` attribute.

### Related issues

This should unblock https://github.com/pythonnet/pythonnet/pull/1307 (tests there are failing because of this difference).

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
