### PR TITLE
Test other Operating Systems than Linux via Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+          architecture: ${{ matrix.platform }}
 
       - name: Install dependencies
         run: |
@@ -50,6 +51,7 @@ jobs:
 
       - name: Run Embedding tests
         run: dotnet test --runtime any-${{ matrix.platform }} src/embed_tests/
+        if: ${{ matrix.os != 'macos' }} # Not working right now, doesn't find libpython
 
       # TODO: Run perf tests
       # TODO: Run mono tests on Windows?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,12 @@ on: [ pull_request, push ]
 jobs:
   build-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
 
     strategy:
       fail-fast: false
       matrix:
+        os: [windows, ubuntu, macos]
         python: [3.6, 3.7, 3.8, 3.9]
         shutdown_mode: [Normal, Soft]
 
@@ -44,5 +45,4 @@ jobs:
         run: dotnet test src/embed_tests/
 
       # TODO: Run perf tests
-      # TODO: Run tests on macos and windows as well
-      # TODO: Run tests on Windows on .NET Framework
+      # TODO: Run mono tests on Windows?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         os: [windows, ubuntu, macos]
         python: [3.6, 3.7, 3.8, 3.9]
+        platform: [x64]
         shutdown_mode: [Normal, Soft]
 
     env:
@@ -42,7 +43,7 @@ jobs:
         run: pytest
 
       - name: Run Embedding tests
-        run: dotnet test src/embed_tests/
+        run: dotnet test --runtime any-${{ matrix.platform }} src/embed_tests/
 
       # TODO: Run perf tests
       # TODO: Run mono tests on Windows?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,12 @@ jobs:
       PYTHONNET_SHUTDOWN_MODE: ${{ matrix.SHUTDOWN_MODE }}
 
     steps:
+      - name: Set Environment on macOS
+        uses: maxim-lobanov/setup-xamarin@v1
+        if: ${{ matrix.os == 'macos' }}
+        with:
+          mono-version: latest
+
       - name: Checkout code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Run tests on Windows and macOS via Github actions. Based on sdk-style (#1209), will rebase once that one is merged.

### Does this close any currently open issues?

No, but we didn't test on macOS at all before :)

### Any other comments?

I'll leave out the test-case "Windows with Mono" for now, can be added later but requires a bit of hoop-jumping.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
