### PR TITLE
Fixed CollectBasicObject test

### DIFF
--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -288,7 +288,7 @@ test_obj_call()
 
                     GC.Collect();
                     GC.WaitForPendingFinalizers(); // <- this will put former `num` into Finalizer queue
-                    Finalizer.Instance.Collect(forceDispose: true);
+                    Finalizer.Instance.Collect();
                     // ^- this will call PyObject.Dispose, which will call XDecref on `num.Handle`,
                     // but Python interpreter from "run" 1 is long gone, so it will corrupt memory instead.
                     Assert.False(numRef.IsAlive);
@@ -333,7 +333,7 @@ test_obj_call()
                     PythonEngine.Initialize(); // <- "run" 2 starts
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
-                    Finalizer.Instance.Collect(forceDispose: true);
+                    Finalizer.Instance.Collect();
                     Assert.False(objRef.IsAlive);
                 }
                 finally

--- a/src/embed_tests/TestDomainReload.cs
+++ b/src/embed_tests/TestDomainReload.cs
@@ -191,7 +191,7 @@ from Python.EmbeddingTest.Domain import MyClass
 def test_obj_call():
     obj = MyClass()
     obj.Method()
-    obj.StaticMethod()
+    MyClass.StaticMethod()
     obj.Property = 1
     obj.Field = 10
 

--- a/src/embed_tests/TestFinalizer.cs
+++ b/src/embed_tests/TestFinalizer.cs
@@ -2,9 +2,9 @@ using NUnit.Framework;
 using Python.Runtime;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Python.EmbeddingTest
@@ -28,26 +28,14 @@ namespace Python.EmbeddingTest
             PythonEngine.Shutdown();
         }
 
-        private static bool FullGCCollect()
+        private static void FullGCCollect()
         {
-            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
-            try
-            {
-                return GC.WaitForFullGCComplete() == GCNotificationStatus.Succeeded;
-            }
-            catch (NotImplementedException)
-            {
-                // Some clr runtime didn't implement GC.WaitForFullGCComplete yet.
-                return false;
-            }
-            finally
-            {
-                GC.WaitForPendingFinalizers();
-            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
         }
 
         [Test]
-        [Ignore("Ignore temporarily")]
+        [Obsolete("GC tests are not guaranteed")]
         public void CollectBasicObject()
         {
             Assert.IsTrue(Finalizer.Instance.Enable);
@@ -104,18 +92,13 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
-        [Ignore("Ignore temporarily")]
+        [Obsolete("GC tests are not guaranteed")]
         public void CollectOnShutdown()
         {
             IntPtr op = MakeAGarbage(out var shortWeak, out var longWeak);
-            int hash = shortWeak.Target.GetHashCode();
-            List<WeakReference> garbage;
-            if (!FullGCCollect())
-            {
-                Assert.IsTrue(WaitForCollected(op, hash, 10000));
-            }
+            FullGCCollect();
             Assert.IsFalse(shortWeak.IsAlive);
-            garbage = Finalizer.Instance.GetCollectedObjects();
+            List<WeakReference> garbage = Finalizer.Instance.GetCollectedObjects();
             Assert.IsNotEmpty(garbage, "The garbage object should be collected");
             Assert.IsTrue(garbage.Any(r => ReferenceEquals(r.Target, longWeak.Target)),
                 "Garbage should contains the collected object");
@@ -125,12 +108,29 @@ namespace Python.EmbeddingTest
             Assert.IsEmpty(garbage);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)] // ensure lack of references to obj
+        [Obsolete("GC tests are not guaranteed")]
         private static IntPtr MakeAGarbage(out WeakReference shortWeak, out WeakReference longWeak)
         {
-            PyLong obj = new PyLong(1024);
-            shortWeak = new WeakReference(obj);
-            longWeak = new WeakReference(obj, true);
-            return obj.Handle;
+            IntPtr handle = IntPtr.Zero;
+            WeakReference @short = null, @long = null;
+            // must create Python object in the thread where we have GIL
+            IntPtr val = PyLong.FromLong(1024);
+            // must create temp object in a different thread to ensure it is not present
+            // when conservatively scanning stack for GC roots.
+            // see https://xamarin.github.io/bugzilla-archives/17/17593/bug.html
+            var garbageGen = new Thread(() =>
+            {
+                var obj = new PyObject(val, skipCollect: true);
+                @short = new WeakReference(obj);
+                @long = new WeakReference(obj, true);
+                handle = obj.Handle;
+            });
+            garbageGen.Start();
+            Assert.IsTrue(garbageGen.Join(TimeSpan.FromSeconds(5)), "Garbage creation timed out");
+            shortWeak = @short;
+            longWeak = @long;
+            return handle;
         }
 
         private static long CompareWithFinalizerOn(PyObject pyCollect, bool enbale)
@@ -211,6 +211,7 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
+        [Obsolete("GC tests are not guaranteed")]
         public void ErrorHandling()
         {
             bool called = false;
@@ -228,7 +229,7 @@ namespace Python.EmbeddingTest
                 WeakReference longWeak;
                 {
                     MakeAGarbage(out shortWeak, out longWeak);
-                    var obj = (PyLong)longWeak.Target;
+                    var obj = (PyObject)longWeak.Target;
                     IntPtr handle = obj.Handle;
                     shortWeak = null;
                     longWeak = null;
@@ -279,36 +280,13 @@ namespace Python.EmbeddingTest
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)] // ensure lack of references to s1 and s2
         private static IntPtr CreateStringGarbage()
         {
             PyString s1 = new PyString("test_string");
             // s2 steal a reference from s1
             PyString s2 = new PyString(s1.Handle);
             return s1.Handle;
-        }
-
-        private static bool WaitForCollected(IntPtr op, int hash, int milliseconds)
-        {
-            var stopwatch = Stopwatch.StartNew();
-            do
-            {
-                var garbage = Finalizer.Instance.GetCollectedObjects();
-                foreach (var item in garbage)
-                {
-                    // The validation is not 100% precise,
-                    // but it's rare that two conditions satisfied but they're still not the same object.
-                    if (item.Target.GetHashCode() != hash)
-                    {
-                        continue;
-                    }
-                    var obj = (IPyDisposable)item.Target;
-                    if (obj.GetTrackedHandles().Contains(op))
-                    {
-                        return true;
-                    }
-                }
-            } while (stopwatch.ElapsedMilliseconds < milliseconds);
-            return false;
         }
     }
 }

--- a/src/runtime/debughelper.cs
+++ b/src/runtime/debughelper.cs
@@ -137,5 +137,12 @@ namespace Python.Runtime
                 Console.WriteLine();
             }
         }
+
+        [Conditional("DEBUG")]
+        public static void AssertHasReferences(IntPtr obj)
+        {
+            long refcount = Runtime.Refcount(obj);
+            Debug.Assert(refcount > 0, "Object refcount is 0 or less");
+        }
     }
 }

--- a/src/runtime/delegatemanager.cs
+++ b/src/runtime/delegatemanager.cs
@@ -181,7 +181,7 @@ namespace Python.Runtime
        too "special" for this to work. It would be more work, so for now
        the 80/20 rule applies :) */
 
-    public class Dispatcher : IPyDisposable
+    public class Dispatcher
     {
         public IntPtr target;
         public Type dtype;
@@ -202,7 +202,7 @@ namespace Python.Runtime
                 return;
             }
             _finalized = true;
-            Finalizer.Instance.AddFinalizedObject(this);
+            Finalizer.Instance.AddFinalizedObject(ref target);
         }
 
         public void Dispose()
@@ -275,11 +275,6 @@ namespace Python.Runtime
 
             Runtime.XDecref(op);
             return result;
-        }
-
-        public IntPtr[] GetTrackedHandles()
-        {
-            return new IntPtr[] { target };
         }
     }
 

--- a/src/runtime/finalizer.cs
+++ b/src/runtime/finalizer.cs
@@ -27,7 +27,7 @@ namespace Python.Runtime
         public int Threshold { get; set; }
         public bool Enable { get; set; }
 
-        private ConcurrentQueue<IPyDisposable> _objQueue = new ConcurrentQueue<IPyDisposable>();
+        private ConcurrentQueue<IntPtr> _objQueue = new ConcurrentQueue<IntPtr>();
         private int _throttled;
 
         #region FINALIZER_CHECK
@@ -42,7 +42,7 @@ namespace Python.Runtime
         public class IncorrectFinalizeArgs : EventArgs
         {
             public IntPtr Handle { get; internal set; }
-            public ICollection<IPyDisposable> ImpactedObjects { get; internal set; }
+            public ICollection<IntPtr> ImpactedObjects { get; internal set; }
         }
 
         public class IncorrectRefCountException : Exception
@@ -73,8 +73,6 @@ namespace Python.Runtime
             Threshold = 200;
         }
 
-        [Obsolete("forceDispose parameter is unused. All objects are disposed regardless.")]
-        public void Collect(bool forceDispose) => this.DisposeAll();
         public void Collect() => this.DisposeAll();
 
         internal void ThrottledCollect()
@@ -85,14 +83,14 @@ namespace Python.Runtime
             this.Collect();
         }
 
-        public List<WeakReference> GetCollectedObjects()
+        internal List<IntPtr> GetCollectedObjects()
         {
-            return _objQueue.Select(T => new WeakReference(T)).ToList();
+            return _objQueue.ToList();
         }
 
-        internal void AddFinalizedObject(IPyDisposable obj)
+        internal void AddFinalizedObject(ref IntPtr obj)
         {
-            if (!Enable)
+            if (!Enable || obj == IntPtr.Zero)
             {
                 return;
             }
@@ -103,6 +101,7 @@ namespace Python.Runtime
             {
                 this._objQueue.Enqueue(obj);
             }
+            obj = IntPtr.Zero;
         }
 
         internal static void Shutdown()
@@ -123,28 +122,43 @@ namespace Python.Runtime
 #if FINALIZER_CHECK
                 ValidateRefCount();
 #endif
-                IPyDisposable obj;
-                while (_objQueue.TryDequeue(out obj))
-                {
-                    try
-                    {
-                        obj.Dispose();
-                    }
-                    catch (Exception e)
-                    {
-                        var handler = ErrorHandler;
-                        if (handler is null)
-                        {
-                            throw new FinalizationException(
-                                "Python object finalization failed",
-                                disposable: obj, innerException: e);
-                        }
+                IntPtr obj;
+                Runtime.PyErr_Fetch(out var errType, out var errVal, out var traceback);
 
-                        handler.Invoke(this, new ErrorArgs()
+                try
+                {
+                    while (!_objQueue.IsEmpty)
+                    {
+                        if (!_objQueue.TryDequeue(out obj))
+                            continue;
+
+                        Runtime.XDecref(obj);
+                        try
                         {
-                            Error = e
-                        });
+                            Runtime.CheckExceptionOccurred();
+                        }
+                        catch (Exception e)
+                        {
+                            var handler = ErrorHandler;
+                            if (handler is null)
+                            {
+                                throw new FinalizationException(
+                                    "Python object finalization failed",
+                                    disposable: obj, innerException: e);
+                            }
+
+                            handler.Invoke(this, new ErrorArgs()
+                            {
+                                Error = e
+                            });
+                        }
                     }
+                }
+                finally
+                {
+                    // Python requires finalizers to preserve exception:
+                    // https://docs.python.org/3/extending/newtypes.html#finalization-and-de-allocation
+                    Runtime.PyErr_Restore(errType, errVal, traceback);
                 }
             }
         }
@@ -158,33 +172,26 @@ namespace Python.Runtime
             }
             var counter = new Dictionary<IntPtr, long>();
             var holdRefs = new Dictionary<IntPtr, long>();
-            var indexer = new Dictionary<IntPtr, List<IPyDisposable>>();
+            var indexer = new Dictionary<IntPtr, List<IntPtr>>();
             foreach (var obj in _objQueue)
             {
-                IntPtr[] handles = obj.GetTrackedHandles();
-                foreach (var handle in handles)
+                var handle = obj;
+                if (!counter.ContainsKey(handle))
                 {
-                    if (handle == IntPtr.Zero)
-                    {
-                        continue;
-                    }
-                    if (!counter.ContainsKey(handle))
-                    {
-                        counter[handle] = 0;
-                    }
-                    counter[handle]++;
-                    if (!holdRefs.ContainsKey(handle))
-                    {
-                        holdRefs[handle] = Runtime.Refcount(handle);
-                    }
-                    List<IPyDisposable> objs;
-                    if (!indexer.TryGetValue(handle, out objs))
-                    {
-                        objs = new List<IPyDisposable>();
-                        indexer.Add(handle, objs);
-                    }
-                    objs.Add(obj);
+                    counter[handle] = 0;
                 }
+                counter[handle]++;
+                if (!holdRefs.ContainsKey(handle))
+                {
+                    holdRefs[handle] = Runtime.Refcount(handle);
+                }
+                List<IntPtr> objs;
+                if (!indexer.TryGetValue(handle, out objs))
+                {
+                    objs = new List<IntPtr>();
+                    indexer.Add(handle, objs);
+                }
+                objs.Add(obj);
             }
             foreach (var pair in counter)
             {
@@ -227,12 +234,13 @@ namespace Python.Runtime
 
     public class FinalizationException : Exception
     {
-        public IPyDisposable Disposable { get; }
+        public IntPtr PythonObject { get; }
 
-        public FinalizationException(string message, IPyDisposable disposable, Exception innerException)
+        public FinalizationException(string message, IntPtr disposable, Exception innerException)
             : base(message, innerException)
         {
-            this.Disposable = disposable ?? throw new ArgumentNullException(nameof(disposable));
+            if (disposable == IntPtr.Zero) throw new ArgumentNullException(nameof(disposable));
+            this.PythonObject = disposable;
         }
     }
 }

--- a/src/runtime/pybuffer.cs
+++ b/src/runtime/pybuffer.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Python.Runtime
 {
-    public sealed class PyBuffer : IPyDisposable
+    public sealed class PyBuffer : IDisposable
     {
         private PyObject _exporter;
         private Py_buffer _view;
@@ -236,7 +236,7 @@ namespace Python.Runtime
             {
                 return;
             }
-            Finalizer.Instance.AddFinalizedObject(this);
+            Finalizer.Instance.AddFinalizedObject(ref _view.obj);
         }
 
         /// <summary>
@@ -247,11 +247,6 @@ namespace Python.Runtime
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        public IntPtr[] GetTrackedHandles()
-        {
-            return new IntPtr[] { _view.obj };
         }
     }
 }

--- a/src/runtime/pylong.cs
+++ b/src/runtime/pylong.cs
@@ -74,7 +74,7 @@ namespace Python.Runtime
         }
 
 
-        private static IntPtr FromLong(long value)
+        internal static IntPtr FromLong(long value)
         {
             IntPtr val = Runtime.PyLong_FromLongLong(value);
             PythonException.ThrowIfIsNull(val);

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -8,11 +8,6 @@ using System.Linq.Expressions;
 
 namespace Python.Runtime
 {
-    public interface IPyDisposable : IDisposable
-    {
-        IntPtr[] GetTrackedHandles();
-    }
-
     /// <summary>
     /// Represents a generic Python object. The methods of this class are
     /// generally equivalent to the Python "abstract object API". See
@@ -21,7 +16,7 @@ namespace Python.Runtime
     /// for details.
     /// </summary>
     [Serializable]
-    public partial class PyObject : DynamicObject, IEnumerable, IPyDisposable
+    public partial class PyObject : DynamicObject, IEnumerable, IDisposable
     {
 #if TRACE_ALLOC
         /// <summary>
@@ -91,7 +86,7 @@ namespace Python.Runtime
             {
                 return;
             }
-            Finalizer.Instance.AddFinalizedObject(this);
+            Finalizer.Instance.AddFinalizedObject(ref obj);
         }
 
 
@@ -215,6 +210,10 @@ namespace Python.Runtime
                     Runtime.XDecref(this.obj);
                 }
             }
+            else
+            {
+                throw new InvalidOperationException("Runtime is already finalizing");
+            }
             this.obj = IntPtr.Zero;
         }
 
@@ -222,11 +221,6 @@ namespace Python.Runtime
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        public IntPtr[] GetTrackedHandles()
-        {
-            return new IntPtr[] { obj };
         }
 
         /// <summary>

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -54,6 +54,19 @@ namespace Python.Runtime
 #endif
         }
 
+        [Obsolete("for testing purposes only")]
+        internal PyObject(IntPtr ptr, bool skipCollect)
+        {
+            if (ptr == IntPtr.Zero) throw new ArgumentNullException(nameof(ptr));
+
+            obj = ptr;
+            if (!skipCollect)
+                Finalizer.Instance.ThrottledCollect();
+#if TRACE_ALLOC
+            Traceback = new StackTrace(1);
+#endif
+        }
+
         /// <summary>
         /// Creates new <see cref="PyObject"/> pointing to the same object as
         /// the <paramref name="reference"/>. Increments refcount, allowing <see cref="PyObject"/>

--- a/src/runtime/pyscope.cs
+++ b/src/runtime/pyscope.cs
@@ -22,14 +22,14 @@ namespace Python.Runtime
     }
 
     [PyGIL]
-    public class PyScope : DynamicObject, IPyDisposable
+    public class PyScope : DynamicObject, IDisposable
     {
         public readonly string Name;
 
         /// <summary>
         /// the python Module object the scope associated with.
         /// </summary>
-        internal readonly IntPtr obj;
+        internal IntPtr obj;
 
         /// <summary>
         /// the variable dict of the scope.
@@ -522,11 +522,6 @@ namespace Python.Runtime
             this.OnDispose?.Invoke(this);
         }
 
-        public IntPtr[] GetTrackedHandles()
-        {
-            return new IntPtr[] { obj };
-        }
-
         ~PyScope()
         {
             if (_finalized || _isDisposed)
@@ -534,7 +529,7 @@ namespace Python.Runtime
                 return;
             }
             _finalized = true;
-            Finalizer.Instance.AddFinalizedObject(this);
+            Finalizer.Instance.AddFinalizedObject(ref obj);
         }
     }
 

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -8,7 +8,7 @@ namespace Python.Runtime
     /// Provides a managed interface to exceptions thrown by the Python
     /// runtime.
     /// </summary>
-    public class PythonException : System.Exception, IPyDisposable
+    public class PythonException : System.Exception, IDisposable
     {
         private IntPtr _pyType = IntPtr.Zero;
         private IntPtr _pyValue = IntPtr.Zero;
@@ -67,7 +67,9 @@ namespace Python.Runtime
                 return;
             }
             _finalized = true;
-            Finalizer.Instance.AddFinalizedObject(this);
+            Finalizer.Instance.AddFinalizedObject(ref _pyType);
+            Finalizer.Instance.AddFinalizedObject(ref _pyValue);
+            Finalizer.Instance.AddFinalizedObject(ref _pyTB);
         }
 
         /// <summary>
@@ -231,11 +233,6 @@ namespace Python.Runtime
                 GC.SuppressFinalize(this);
                 disposed = true;
             }
-        }
-
-        public IntPtr[] GetTrackedHandles()
-        {
-            return new IntPtr[] { _pyType, _pyValue, _pyTB };
         }
 
         /// <summary>


### PR DESCRIPTION
This contains two fixes, that must go along for the tests to pass:

1. Fixed the `CollectBasicObject` and `CollectOnShutdown` tests for Mono by fixing `MakeAGarbage` function to not keep the garbage on the stack during a conservative roots scan (looks like Mono scans some variables, that are already gone).
2. Fixed the crash during runtime shutdown by further simplifying `Finalizer` to only store raw pointers to python objects instead of instances of `IPyDisposable` and thus replacing Dispose with reliable and simple `DecRef`.

This removes some functions from `Finalizer`, which previously were public, but should not have been.