### PR TITLE
Fix illegal delegate usage

### DIFF
--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -491,6 +491,9 @@ namespace Python.Runtime
             return pmap[name] as Type;
         }
 
+
+        internal static Dictionary<IntPtr, Delegate> allocatedThunks = new Dictionary<IntPtr, Delegate>();
+
         internal static ThunkInfo GetThunk(MethodInfo method, string funcType = null)
         {
             Type dt;
@@ -505,6 +508,7 @@ namespace Python.Runtime
             }
             Delegate d = Delegate.CreateDelegate(dt, method);
             var info = new ThunkInfo(d);
+            allocatedThunks[info.Address] = d;
             return info;
         }
 

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -178,7 +178,7 @@ namespace Python.Runtime
             {
                 return 0;
             }
-            var visitFunc = (Interop.ObjObjFunc)Marshal.GetDelegateForFunctionPointer(visit, typeof(Interop.ObjObjFunc));
+            var visitFunc = NativeCall.GetDelegate<Interop.ObjObjFunc>(visit);
             return visitFunc(ob, arg);
         }
 
@@ -196,7 +196,7 @@ namespace Python.Runtime
             {
                 return;
             }
-            var clearFunc = (Interop.InquiryFunc)Marshal.GetDelegateForFunctionPointer(clearPtr, typeof(Interop.InquiryFunc));
+            var clearFunc = NativeCall.GetDelegate<Interop.InquiryFunc>(clearPtr);
             clearFunc(pyHandle);
         }
 
@@ -214,7 +214,8 @@ namespace Python.Runtime
             {
                 return;
             }
-            var traverseFunc = (Interop.ObjObjArgFunc)Marshal.GetDelegateForFunctionPointer(traversePtr, typeof(Interop.ObjObjArgFunc));
+            var traverseFunc = NativeCall.GetDelegate<Interop.ObjObjArgFunc>(traversePtr);
+
             var visiPtr = Marshal.GetFunctionPointerForDelegate(visitproc);
             traverseFunc(pyHandle, visiPtr, arg);
         }

--- a/src/runtime/nativecall.cs
+++ b/src/runtime/nativecall.cs
@@ -45,8 +45,8 @@ namespace Python.Runtime
             Delegate d = null;
             if (!Interop.allocatedThunks.TryGetValue(fp, out d))
             {
-                // Use Marshal.GetDelegateForFunctionPointer<> directly after upgrade the framework
-                d = Marshal.GetDelegateForFunctionPointer(fp, typeof(T));
+                // We don't cache this delegate because this is a pure delegate ot unmanaged.
+                d = Marshal.GetDelegateForFunctionPointer<T>(fp);
             }
             return (T)d;
         }

--- a/src/runtime/nativecall.cs
+++ b/src/runtime/nativecall.cs
@@ -40,10 +40,15 @@ namespace Python.Runtime
             return d(a1, a2, a3);
         }
 
-        private static T GetDelegate<T>(IntPtr fp) where T: Delegate
+        internal static T GetDelegate<T>(IntPtr fp) where T: Delegate
         {
-            // Use Marshal.GetDelegateForFunctionPointer<> directly after upgrade the framework
-            return (T)Marshal.GetDelegateForFunctionPointer(fp, typeof(T));
+            Delegate d = null;
+            if (!Interop.allocatedThunks.TryGetValue(fp, out d))
+            {
+                // Use Marshal.GetDelegateForFunctionPointer<> directly after upgrade the framework
+                d = Marshal.GetDelegateForFunctionPointer(fp, typeof(T));
+            }
+            return (T)d;
         }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Cache the delegates to native code we've created so that when we need to
call that delegate, we don't ask for a delegate from a native pointer
(that is a delegate to managed code.)

### Does this close any currently open issues?
This fixes issue #1323 .

### Any other comments?

This is needed in order for #1287 to pass the domain reload tests on Mono.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
