### PR TITLE
Test for non-ASCII encoded method name

### DIFF
--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1024,16 +1024,13 @@ namespace Python.Runtime
         }
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyObject_HasAttrString(IntPtr pointer, string name);
+        internal static extern int PyObject_HasAttrString(IntPtr pointer, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyObject_GetAttrString(IntPtr pointer, string name);
+        internal static extern IntPtr PyObject_GetAttrString(IntPtr pointer, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string name);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyObject_GetAttrString(IntPtr pointer, IntPtr name);
-
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyObject_SetAttrString(IntPtr pointer, string name, IntPtr value);
+        internal static extern int PyObject_SetAttrString(IntPtr pointer, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string name, IntPtr value);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyObject_HasAttr(IntPtr pointer, IntPtr name);
@@ -1648,7 +1645,7 @@ namespace Python.Runtime
         /// Return value: Borrowed reference.
         /// </summary>
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyDict_GetItemString(IntPtr pointer, string key);
+        internal static extern IntPtr PyDict_GetItemString(IntPtr pointer, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string key);
 
         /// <summary>
         /// Return 0 on success or -1 on failure.
@@ -1660,13 +1657,13 @@ namespace Python.Runtime
         ///  Return 0 on success or -1 on failure.
         /// </summary>
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyDict_SetItemString(IntPtr pointer, string key, IntPtr value);
+        internal static extern int PyDict_SetItemString(IntPtr pointer, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string key, IntPtr value);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyDict_DelItem(IntPtr pointer, IntPtr key);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyDict_DelItemString(IntPtr pointer, string key);
+        internal static extern int PyDict_DelItemString(IntPtr pointer, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string key);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyMapping_HasKey(IntPtr pointer, IntPtr key);
@@ -2018,7 +2015,7 @@ namespace Python.Runtime
         //====================================================================
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void PyErr_SetString(IntPtr ob, string message);
+        internal static extern void PyErr_SetString(IntPtr ob, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))] string message);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyErr_SetObject(BorrowedReference type, BorrowedReference exceptionObject);

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -713,6 +713,10 @@ namespace Python.Test
         {
             return "with params-array";
         }
+
+        public static void EncodingTestÅngström()
+        {
+        }
     }
 
 

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -1221,3 +1221,5 @@ def test_params_array_overload():
     # res = MethodTest.ParamsArrayOverloaded(paramsArray=[], i=1)
     # assert res == "with params-array"
 
+def test_method_encoding():
+    MethodTest.EncodingTestÅngström()


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Use UTF8 explicitly to marshal strings towards Python C-API functions ending in `String`.

### Does this close any currently open issues?

#979.

### Any other comments?

Runs fine for me both with 2.5.1 as well as current master on Linux.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
