### PR TITLE
PyIter: do not force dispose previous object upon moving to the next one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ details about the cause of the failure
 -   BREAKING: Parameters marked with `ParameterAttributes.Out` are no longer returned in addition
      to the regular method return value (unless they are passed with `ref` or `out` keyword).
 -   BREAKING: Drop support for the long-deprecated CLR.* prefix.
+-   `PyObject` now implements `IEnumerable<PyObject>` in addition to `IEnumerable`
 
 ### Fixed
 
@@ -40,6 +41,7 @@ details about the cause of the failure
 -    Fixed a bug where indexers could not be used if they were inherited
 -    Made it possible to use `__len__` also on `ICollection<>` interface objects
 -    Made it possible to call `ToString`, `GetHashCode`, and `GetType` on inteface objects
+-    Fixed objects returned by enumerating `PyObject` being disposed too soon
 
 ### Removed
 

--- a/src/embed_tests/TestPyIter.cs
+++ b/src/embed_tests/TestPyIter.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Text;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    class TestPyIter
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void KeepOldObjects()
+        {
+            using (Py.GIL())
+            using (var testString = new PyString("hello world! !$%&/()=?"))
+            {
+                PyObject[] chars = testString.ToArray();
+                Assert.IsTrue(chars.Length > 1);
+                string reconstructed = string.Concat(chars.Select(c => c.As<string>()));
+                Assert.AreEqual(testString.As<string>(), reconstructed);
+            }
+        }
+    }
+}

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -16,7 +16,7 @@ namespace Python.Runtime
     /// for details.
     /// </summary>
     [Serializable]
-    public partial class PyObject : DynamicObject, IEnumerable, IDisposable
+    public partial class PyObject : DynamicObject, IEnumerable<PyObject>, IDisposable
     {
 #if TRACE_ALLOC
         /// <summary>
@@ -705,10 +705,11 @@ namespace Python.Runtime
         /// python object to be iterated over in C#. A PythonException will be
         /// raised if the object is not iterable.
         /// </remarks>
-        public IEnumerator GetEnumerator()
+        public IEnumerator<PyObject> GetEnumerator()
         {
             return PyIter.GetIter(this);
         }
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
 
         /// <summary>

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1854,6 +1854,8 @@ namespace Python.Runtime
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyIter_Next(IntPtr pointer);
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NewReference PyIter_Next(BorrowedReference pointer);
 
 
         //====================================================================


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Prior to this change trying to use object returned by iterating over `PyObject` would fail after iterator is closed, because iterator would dispose previously returned objects on close/moving to the next one.

This also adds error handling for `PyIter_Next` calls, which can have other reasons to fail beyond reaching the end of collection.

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
