### PR TITLE
TestPythonEngineProperties.SetPythonPath avoids corrupting the module search path for later tests

### DIFF
--- a/src/embed_tests/TestPythonEngineProperties.cs
+++ b/src/embed_tests/TestPythonEngineProperties.cs
@@ -194,13 +194,8 @@ namespace Python.EmbeddingTest
                 importShouldSucceed = false;
             }
 
-            dynamic sys = Py.Import("sys");
-            var locals = new PyDict();
-            locals.SetItem("sys", sys);
-            var result = PythonEngine.Eval($"'{System.IO.Path.PathSeparator}'.join(sys.path)", null, locals.Handle);
-            // This does not work:
-            //var result = PythonEngine.Eval("import sys\n';'.join(sys.path)");
-            string path = (string)result.AsManagedObject(typeof(string));
+            string[] paths = Py.Import("sys").GetAttr("path").As<string[]>();
+            string path = string.Join(System.IO.Path.PathSeparator.ToString(), paths);
 
             // path should not be set to PythonEngine.PythonPath here.
             // PythonEngine.PythonPath gets the default module search path, not the full search path.

--- a/src/embed_tests/TestPythonEngineProperties.cs
+++ b/src/embed_tests/TestPythonEngineProperties.cs
@@ -182,10 +182,22 @@ namespace Python.EmbeddingTest
         {
             PythonEngine.Initialize();
 
+            const string moduleName = "pytest";
+            bool importShouldSucceed;
+            try
+            {
+                Py.Import(moduleName);
+                importShouldSucceed = true;
+            }
+            catch
+            {
+                importShouldSucceed = false;
+            }
+
             dynamic sys = Py.Import("sys");
             var locals = new PyDict();
             locals.SetItem("sys", sys);
-            var result = PythonEngine.Eval("';'.join(sys.path)", null, locals.Handle);
+            var result = PythonEngine.Eval($"'{System.IO.Path.PathSeparator}'.join(sys.path)", null, locals.Handle);
             // This does not work:
             //var result = PythonEngine.Eval("import sys\n';'.join(sys.path)");
             string path = (string)result.AsManagedObject(typeof(string));
@@ -203,6 +215,8 @@ namespace Python.EmbeddingTest
             PythonEngine.Initialize();
 
             Assert.AreEqual(path, PythonEngine.PythonPath);
+            if (importShouldSucceed) Py.Import(moduleName);
+
             PythonEngine.Shutdown();
         }
     }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Improves the test suite of Python.NET

### Does this close any currently open issues?

Fixes #1335 

### Any other comments?

This change is not visible to the end user so it doesn't make sense to add it to the CHANGELOG.

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
