### PR TITLE
ABI.Initialize gives a helpful message when the TypeOffset interop class is not configured correctly

### DIFF
--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -12,6 +12,10 @@
     <None Include="fixtures/**/*.py" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);$(ConfiguredConstants)</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.*">

--- a/src/embed_tests/TestNativeTypeOffset.cs
+++ b/src/embed_tests/TestNativeTypeOffset.cs
@@ -7,21 +7,39 @@ using System.Threading.Tasks;
 
 using NUnit.Framework;
 
+using Python.Runtime;
+
 namespace Python.EmbeddingPythonTest
 {
     public class TestNativeTypeOffset
     {
-#if WINDOWS
-        // The code for NativeTypeOffset is not generated under Windows because sys.abiflags does not exist (see setup.py)
-#else
+        private Py.GILState _gs;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _gs = Py.GIL();
+        }
+
+        [TearDown]
+        public void Dispose()
+        {
+            _gs.Dispose();
+        }
+
         /// <summary>
         /// Tests that installation has generated code for NativeTypeOffset and that it can be loaded.
         /// </summary>        
         [Test]
         public void LoadNativeTypeOffsetClass()
         {
-            new Python.Runtime.NativeTypeOffset();
+            PyObject sys = Py.Import("sys");
+            string attributeName = "abiflags";
+            if (sys.HasAttr(attributeName) && !string.IsNullOrEmpty(sys.GetAttr(attributeName).ToString()))
+            {
+                string typeName = "Python.Runtime.NativeTypeOffset";
+                Assert.NotNull(Type.GetType(typeName), $"{typeName} does not exist and sys.{attributeName} is not empty");
+            }
         }
-#endif
     }
 }

--- a/src/embed_tests/TestNativeTypeOffset.cs
+++ b/src/embed_tests/TestNativeTypeOffset.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Python.EmbeddingPythonTest
+{
+    public class TestNativeTypeOffset
+    {
+#if WINDOWS
+        // The code for NativeTypeOffset is not generated under Windows because sys.abiflags does not exist (see setup.py)
+#else
+        /// <summary>
+        /// Tests that installation has generated code for NativeTypeOffset and that it can be loaded.
+        /// </summary>        
+        [Test]
+        public void LoadNativeTypeOffsetClass()
+        {
+            new Python.Runtime.NativeTypeOffset();
+        }
+#endif
+    }
+}

--- a/src/embed_tests/TestNativeTypeOffset.cs
+++ b/src/embed_tests/TestNativeTypeOffset.cs
@@ -37,7 +37,7 @@ namespace Python.EmbeddingPythonTest
             string attributeName = "abiflags";
             if (sys.HasAttr(attributeName) && !string.IsNullOrEmpty(sys.GetAttr(attributeName).ToString()))
             {
-                string typeName = "Python.Runtime.NativeTypeOffset";
+                string typeName = "Python.Runtime.NativeTypeOffset, Python.Runtime";
                 Assert.NotNull(Type.GetType(typeName), $"{typeName} does not exist and sys.{attributeName} is not empty");
             }
         }

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -19,6 +19,14 @@
     <DefineConstants>$(DefineConstants);$(ConfiguredConstants)</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(PythonInteropFile)' != '' ">
+    <!-- Remove any files that might conflict with PythonInteropFile -->
+    <Compile Remove="interop*.cs" />
+    <Compile Include="interop.cs" />
+    <!-- Explicitly include PythonInteropFile because it might not be in the src/runtime folder -->
+    <Compile Include="$(PythonInteropFile)" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Remove="resources\clr.py" />
     <EmbeddedResource Include="resources\clr.py">

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -19,14 +19,6 @@
     <DefineConstants>$(DefineConstants);$(ConfiguredConstants)</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(PythonInteropFile)' != '' ">
-    <!-- Remove any files that might conflict with PythonInteropFile -->
-    <Compile Remove="interop*.cs" />
-    <Compile Include="interop.cs" />
-    <!-- Explicitly include PythonInteropFile because it might not be in the src/runtime folder -->
-    <Compile Include="$(PythonInteropFile)" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Remove="resources\clr.py" />
     <EmbeddedResource Include="resources\clr.py">

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -19,12 +19,6 @@
     <DefineConstants>$(DefineConstants);$(ConfiguredConstants)</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(PythonInteropFile)' != '' ">
-    <Compile Remove="interop*.cs" />
-    <Compile Include="interop.cs" />
-    <Compile Include="$(PythonInteropFile)" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Remove="resources\clr.py" />
     <EmbeddedResource Include="resources\clr.py">

--- a/src/runtime/native/ABI.cs
+++ b/src/runtime/native/ABI.cs
@@ -25,7 +25,7 @@ namespace Python.Runtime.Native
             {
                 var types = thisAssembly.GetTypes().Select(type => type.Name).Where(name => name.StartsWith("TypeOffset"));
                 string message = $"Searching for {className}, found {string.Join(",", types)}. " +
-                    "If you are building Python.NET from source, make sure you have run 'python setup.py develop' to fill in configured.props";
+                    "If you are building Python.NET from source, make sure you have run 'python setup.py configure' to fill in configured.props";
                 throw new NotSupportedException($"Python ABI v{version} is not supported: {message}");
             }
             var typeOffsets = (ITypeOffsets)Activator.CreateInstance(typeOffsetsClass);

--- a/src/runtime/native/ABI.cs
+++ b/src/runtime/native/ABI.cs
@@ -22,7 +22,12 @@ namespace Python.Runtime.Native
                 thisAssembly.GetType(nativeTypeOffsetClassName, throwOnError: false)
                 ?? thisAssembly.GetType(className, throwOnError: false);
             if (typeOffsetsClass is null)
-                throw new NotSupportedException($"Python ABI v{version} is not supported");
+            {
+                var types = thisAssembly.GetTypes().Select(type => type.Name).Where(name => name.StartsWith("TypeOffset"));
+                string message = $"Searching for {className}, found {string.Join(",", types)}. " +
+                    "If you are building Python.NET from source, make sure you have run 'python setup.py develop' to fill in configured.props";
+                throw new NotSupportedException($"Python ABI v{version} is not supported: {message}");
+            }
             var typeOffsets = (ITypeOffsets)Activator.CreateInstance(typeOffsetsClass);
             TypeOffset.Use(typeOffsets);
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When changing Python versions, it is easy to put Python.NET into a misconfigured state.  This PR provides a helpful error message in that case.

### Does this close any currently open issues?

No

### Any other comments?

This change can be tested by manually editing `configured.props` to have an incorrect `PythonInteropFile`

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
