### PR TITLE
Python tests can now be debugged by running them as embedded tests within NUnit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,9 @@ jobs:
         run: dotnet test --runtime any-${{ matrix.platform }} src/embed_tests/
         if: ${{ matrix.os != 'macos' }} # Not working right now, doesn't find libpython
 
-      - name: Python tests runner
+      - name: Python tests run from .NET
         run: dotnet test --runtime any-${{ matrix.platform }} src/python_tests_runner/
-        if: ${{ matrix.os != 'macos' }} # Not working right now, doesn't find libpython
+        if: ${{ matrix.os == 'windows' }} # Not working for others right now
 
       # TODO: Run perf tests
       # TODO: Run mono tests on Windows?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,12 @@ jobs:
       - name: Python Tests
         run: pytest
 
-      - name: Run Embedding tests
+      - name: Embedding tests
         run: dotnet test --runtime any-${{ matrix.platform }} src/embed_tests/
+        if: ${{ matrix.os != 'macos' }} # Not working right now, doesn't find libpython
+
+      - name: Python tests runner
+        run: dotnet test --runtime any-${{ matrix.platform }} src/python_tests_runner/
         if: ${{ matrix.os != 'macos' }} # Not working right now, doesn't find libpython
 
       # TODO: Run perf tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ details about the cause of the failure
 -    Made it possible to call `ToString`, `GetHashCode`, and `GetType` on inteface objects
 -    Fixed objects returned by enumerating `PyObject` being disposed too soon
 -    Incorrectly using a non-generic type with type parameters now produces a helpful Python error instead of throwing NullReferenceException
+-   `import` may now raise errors with more detail than "No module named X"
 
 ### Removed
 

--- a/pythonnet.sln
+++ b/pythonnet.sln
@@ -47,6 +47,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{BC426F42
 		tools\geninterop\geninterop.py = tools\geninterop\geninterop.py
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Python.PythonTestsRunner", "src\python_tests_runner\Python.PythonTestsRunner.csproj", "{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +131,30 @@ Global
 		{4F2EA4A1-7ECA-48B5-8077-7A3C366F9931}.Release|x64.Build.0 = Release|x64
 		{4F2EA4A1-7ECA-48B5-8077-7A3C366F9931}.Release|x86.ActiveCfg = Release|x86
 		{4F2EA4A1-7ECA-48B5-8077-7A3C366F9931}.Release|x86.Build.0 = Release|x86
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Debug|x64.Build.0 = Debug|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Debug|x86.Build.0 = Debug|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Release|x64.ActiveCfg = Release|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Release|x64.Build.0 = Release|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Release|x86.ActiveCfg = Release|Any CPU
+		{6CF9EEA0-F865-4536-AABA-739AE3DA971E}.Release|x86.Build.0 = Release|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Debug|x64.Build.0 = Debug|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Debug|x86.Build.0 = Debug|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Release|x64.ActiveCfg = Release|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Release|x64.Build.0 = Release|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Release|x86.ActiveCfg = Release|Any CPU
+		{35CBBDEB-FC07-4D04-9D3E-F88FC180110B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/python_tests_runner/Python.PythonTestsRunner.csproj
+++ b/src/python_tests_runner/Python.PythonTestsRunner.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\runtime\Python.Runtime.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Condition="$(MSBuildRuntimeType) == 'Core'">
+      <Version>1.0.0</Version>
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/python_tests_runner/PythonTestRunner.cs
+++ b/src/python_tests_runner/PythonTestRunner.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.PythonTestsRunner
+{
+    public class PythonTestRunner
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        /// <summary>
+        /// Selects the Python tests to be run as embedded tests.
+        /// </summary>
+        /// <returns></returns>
+        static IEnumerable<string[]> PythonTestCases()
+        {
+            // Add the test that you want to debug here.
+            yield return new[] { "test_enum", "test_enum_standard_attrs" };
+            yield return new[] { "test_generic", "test_missing_generic_type" };
+        }
+
+        /// <summary>
+        /// Runs a test in src/tests/*.py as an embedded test.  This facilitates debugging.
+        /// </summary>
+        /// <param name="testFile">The file name without extension</param>
+        /// <param name="testName">The name of the test method</param>
+        [TestCaseSource(nameof(PythonTestCases))]
+        public void RunPythonTest(string testFile, string testName)
+        {
+            // Find the tests directory
+            string folder = typeof(PythonTestRunner).Assembly.Location;
+            while (Path.GetFileName(folder) != "src")
+            {
+                folder = Path.GetDirectoryName(folder);
+            }
+            folder = Path.Combine(folder, "tests");
+            string path = Path.Combine(folder, testFile + ".py");
+            if (!File.Exists(path)) throw new FileNotFoundException("Cannot find test file", path);
+
+            // We could use 'import' below, but importlib gives more helpful error messages than 'import'
+            // https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+            // Because the Python tests sometimes have relative imports, the module name must be inside the tests package
+            PythonEngine.Exec($@"
+import sys
+import os
+sys.path.append(os.path.dirname(r'{folder}'))
+sys.path.append(os.path.join(r'{folder}', 'fixtures'))
+import clr
+clr.AddReference('Python.Test')
+import tests
+module_name = 'tests.{testFile}'
+file_path = r'{path}'
+import importlib.util
+spec = importlib.util.spec_from_file_location(module_name, file_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[module_name] = module
+try:
+  spec.loader.exec_module(module)
+except ImportError as error:
+  raise ImportError(str(error) + ' when sys.path=' + os.pathsep.join(sys.path))
+module.{testName}()
+");
+        }
+    }
+}

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -293,7 +293,6 @@ namespace Python.Runtime
             }
             // Save the exception
             var originalException = new PythonException();
-            var originalExceptionMessage = originalException.ToString();
             // Otherwise,  just clear the it.
             Exceptions.Clear();
 
@@ -345,7 +344,7 @@ namespace Python.Runtime
                 ManagedType mt = tail.GetAttribute(name, true);
                 if (!(mt is ModuleObject))
                 {
-                    Exceptions.SetError(Exceptions.ImportError, originalExceptionMessage);
+                    originalException.Restore();
                     return IntPtr.Zero;
                 }
                 if (head == null)

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -291,6 +291,9 @@ namespace Python.Runtime
                 // We don't support them anyway
                 return IntPtr.Zero;
             }
+            // Save the exception
+            var originalException = new PythonException();
+            var originalExceptionMessage = originalException.ToString();
             // Otherwise,  just clear the it.
             Exceptions.Clear();
 
@@ -342,7 +345,7 @@ namespace Python.Runtime
                 ManagedType mt = tail.GetAttribute(name, true);
                 if (!(mt is ModuleObject))
                 {
-                    Exceptions.SetError(Exceptions.ImportError, $"No module named {name}");
+                    Exceptions.SetError(Exceptions.ImportError, originalExceptionMessage);
                     return IntPtr.Zero;
                 }
                 if (head == null)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When debugging a problem such as issue #1325, it is immensely useful to have the Visual Studio debugger stop at the location of the error.  This is tricky to do with pytest, even when running pytest from Visual Studio.  Running the test via Python.Exec makes debugging simple and easy.  You don't need to re-install Python.NET every time you make a change.  You don't need to edit project options, and you don't need to figure out how to run pytest from Visual Studio.

With this change, you can just type in the name of the python test you want to debug, build the solution, and debug the new NUnit test that appears.

### Does this close any currently open issues?

No

### Any other comments?

No

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
