### PR TITLE
Disable implicit conversion from PyFloat to .NET integer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ details about the cause of the failure
      to the regular method return value (unless they are passed with `ref` or `out` keyword).
 -   BREAKING: Drop support for the long-deprecated CLR.* prefix.
 -   `PyObject` now implements `IEnumerable<PyObject>` in addition to `IEnumerable`
+-   floating point values passed from Python are no longer silently truncated
+when .NET expects an integer [#1342][i1342]
 
 ### Fixed
 
@@ -807,3 +809,4 @@ This version improves performance on benchmarks significantly compared to 2.3.
 [i755]: https://github.com/pythonnet/pythonnet/pull/755
 [p534]: https://github.com/pythonnet/pythonnet/pull/534
 [i449]: https://github.com/pythonnet/pythonnet/issues/449
+[i1342]: https://github.com/pythonnet/pythonnet/issues/1342

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -4,6 +4,7 @@
     <Platforms>AnyCPU</Platforms>
     <RootNamespace>Python.Runtime</RootNamespace>
     <AssemblyName>Python.Runtime</AssemblyName>
+    <LangVersion>9.0</LangVersion>
     <PackageId>pythonnet</PackageId>
     <PackageLicenseUrl>https://github.com/pythonnet/pythonnet/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/pythonnet/pythonnet</RepositoryUrl>

--- a/src/runtime/arrayobject.cs
+++ b/src/runtime/arrayobject.cs
@@ -49,7 +49,7 @@ namespace Python.Runtime
             // create single dimensional array
             if (Runtime.PyInt_Check(op))
             {
-                dimensions[0] = Runtime.PyLong_AsLongLong(op);
+                dimensions[0] = Runtime.PyLong_AsSignedSize_t(op);
                 if (dimensions[0] == -1 && Exceptions.ErrorOccurred())
                 {
                     Exceptions.Clear();
@@ -84,7 +84,7 @@ namespace Python.Runtime
                     return default;
                 }
 
-                dimensions[dimIndex] = Runtime.PyLong_AsLongLong(dimObj);
+                dimensions[dimIndex] = Runtime.PyLong_AsSignedSize_t(dimObj);
                 if (dimensions[dimIndex] == -1 && Exceptions.ErrorOccurred())
                 {
                     Exceptions.RaiseTypeError("array constructor expects integer dimensions");

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -511,7 +511,7 @@ namespace Python.Runtime
                 case TypeCode.Int32:
                     {
                         // Python3 always use PyLong API
-                        long num = Runtime.PyLong_AsLongLong(value);
+                        nint num = Runtime.PyLong_AsSignedSize_t(value);
                         if (num == -1 && Exceptions.ErrorOccurred())
                         {
                             goto convert_error;
@@ -541,7 +541,7 @@ namespace Python.Runtime
                             goto type_error;
                         }
 
-                        int num = Runtime.PyLong_AsLong(value);
+                        nint num = Runtime.PyLong_AsSignedSize_t(value);
                         if (num == -1 && Exceptions.ErrorOccurred())
                         {
                             goto convert_error;
@@ -567,7 +567,7 @@ namespace Python.Runtime
                             goto type_error;
                         }
 
-                        int num = Runtime.PyLong_AsLong(value);
+                        nint num = Runtime.PyLong_AsSignedSize_t(value);
                         if (num == -1 && Exceptions.ErrorOccurred())
                         {
                             goto convert_error;
@@ -604,7 +604,7 @@ namespace Python.Runtime
                             }
                             goto type_error;
                         }
-                        int num = Runtime.PyLong_AsLong(value);
+                        nint num = Runtime.PyLong_AsSignedSize_t(value);
                         if (num == -1 && Exceptions.ErrorOccurred())
                         {
                             goto convert_error;
@@ -619,7 +619,7 @@ namespace Python.Runtime
 
                 case TypeCode.Int16:
                     {
-                        int num = Runtime.PyLong_AsLong(value);
+                        nint num = Runtime.PyLong_AsSignedSize_t(value);
                         if (num == -1 && Exceptions.ErrorOccurred())
                         {
                             goto convert_error;
@@ -634,18 +634,35 @@ namespace Python.Runtime
 
                 case TypeCode.Int64:
                     {
-                        long num = (long)Runtime.PyLong_AsLongLong(value);
-                        if (num == -1 && Exceptions.ErrorOccurred())
+                        if (Runtime.Is32Bit)
                         {
-                            goto convert_error;
+                            if (!Runtime.PyLong_Check(value))
+                            {
+                                goto type_error;
+                            }
+                            long num = Runtime.PyExplicitlyConvertToInt64(value);
+                            if (num == -1 && Exceptions.ErrorOccurred())
+                            {
+                                goto convert_error;
+                            }
+                            result = num;
+                            return true;
                         }
-                        result = num;
-                        return true;
+                        else
+                        {
+                            nint num = Runtime.PyLong_AsSignedSize_t(value);
+                            if (num == -1 && Exceptions.ErrorOccurred())
+                            {
+                                goto convert_error;
+                            }
+                            result = (long)num;
+                            return true;
+                        }
                     }
 
                 case TypeCode.UInt16:
                     {
-                        long num = Runtime.PyLong_AsLong(value);
+                        nint num = Runtime.PyLong_AsSignedSize_t(value);
                         if (num == -1 && Exceptions.ErrorOccurred())
                         {
                             goto convert_error;
@@ -660,43 +677,16 @@ namespace Python.Runtime
 
                 case TypeCode.UInt32:
                     {
-                        op = value;
-                        if (Runtime.PyObject_TYPE(value) != Runtime.PyLongType)
+                        nuint num = Runtime.PyLong_AsUnsignedSize_t(value);
+                        if (num == unchecked((nuint)(-1)) && Exceptions.ErrorOccurred())
                         {
-                            op = Runtime.PyNumber_Long(value);
-                            if (op == IntPtr.Zero)
-                            {
-                                goto convert_error;
-                            }
+                            goto convert_error;
                         }
-                        if (Runtime.Is32Bit || Runtime.IsWindows)
+                        if (num > UInt32.MaxValue)
                         {
-                            uint num = Runtime.PyLong_AsUnsignedLong32(op);
-                            if (num == uint.MaxValue && Exceptions.ErrorOccurred())
-                            {
-                                goto convert_error;
-                            }
-                            result = num;
+                            goto overflow;
                         }
-                        else
-                        {
-                            ulong num = Runtime.PyLong_AsUnsignedLong64(op);
-                            if (num == ulong.MaxValue && Exceptions.ErrorOccurred())
-                            {
-                                goto convert_error;
-                            }
-                            try
-                            {
-                                result = Convert.ToUInt32(num);
-                            }
-                            catch (OverflowException)
-                            {
-                                // Probably wasn't an overflow in python but was in C# (e.g. if cpython
-                                // longs are 64 bit then 0xFFFFFFFF + 1 will not overflow in
-                                // PyLong_AsUnsignedLong)
-                                goto overflow;
-                            }
-                        }
+                        result = (uint)num;
                         return true;
                     }
 

--- a/src/runtime/pylong.cs
+++ b/src/runtime/pylong.cs
@@ -246,7 +246,7 @@ namespace Python.Runtime
         /// </remarks>
         public long ToInt64()
         {
-            return Runtime.PyLong_AsLongLong(obj);
+            return Runtime.PyExplicitlyConvertToInt64(obj);
         }
     }
 }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1251,30 +1251,27 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyLong_FromString(string value, IntPtr end, int radix);
 
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PyLong_AsLong(IntPtr value);
-
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
-            EntryPoint = "PyLong_AsUnsignedLong")]
-        internal static extern uint PyLong_AsUnsignedLong32(IntPtr value);
-
+                   EntryPoint = "PyLong_AsSize_t")]
+        internal static extern nuint PyLong_AsUnsignedSize_t(IntPtr value);
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
-            EntryPoint = "PyLong_AsUnsignedLong")]
-        internal static extern ulong PyLong_AsUnsignedLong64(IntPtr value);
+                   EntryPoint = "PyLong_AsSsize_t")]
+        internal static extern nint PyLong_AsSignedSize_t(IntPtr value);
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
+                   EntryPoint = "PyLong_AsSsize_t")]
+        internal static extern nint PyLong_AsSignedSize_t(BorrowedReference value);
 
-        internal static object PyLong_AsUnsignedLong(IntPtr value)
-        {
-            if (Is32Bit || IsWindows)
-                return PyLong_AsUnsignedLong32(value);
-            else
-                return PyLong_AsUnsignedLong64(value);
-        }
-
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern long PyLong_AsLongLong(BorrowedReference value);
-        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern long PyLong_AsLongLong(IntPtr value);
-
+        /// <summary>
+        /// This function is a rename of PyLong_AsLongLong, which has a commonly undesired
+        /// behavior to convert everything (including floats) to integer type, before returning
+        /// the value as <see cref="Int64"/>.
+        ///
+        /// <para>In most cases you need to check that value is an instance of PyLongObject
+        /// before using this function using <see cref="PyLong_Check(IntPtr)"/>.</para>
+        /// </summary>
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl,
+                   EntryPoint = "PyLong_AsLongLong")]
+        internal static extern long PyExplicitlyConvertToInt64(IntPtr value);
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ulong PyLong_AsUnsignedLongLong(IntPtr value);
 

--- a/src/tests/test_conversion.py
+++ b/src/tests/test_conversion.py
@@ -343,7 +343,7 @@ def test_uint32_conversion():
     ob.UInt32Field = System.UInt32(0)
     assert ob.UInt32Field == 0
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ConversionTest().UInt32Field = "spam"
 
     with pytest.raises(TypeError):

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -807,6 +807,9 @@ def test_no_object_in_param():
     with pytest.raises(TypeError):
         MethodTest.TestOverloadedNoObject("test")
 
+    with pytest.raises(TypeError):
+        MethodTest.TestOverloadedNoObject(5.5)
+
 
 def test_object_in_param():
     """Test regression introduced by #151 in which Object method overloads


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Previously, when a floating point value was passed to .NET parameter of integer type, it would be silently truncated. After this change it would no longer be permitted to pass a floating point value to integer parameter.

### Does this close any currently open issues?

#1342

### Any other comments?

I removed poorly-behaved `PyLong_As*` functions, as they would always implicitly convert argument to integer type, which in most cases is undesired behavior. Instead, to avoid roundtrips, `PyLong_AsSize_t` is used in most cases. The only exception is `Int64` which on 32 bit platforms is larger than `size_t`, so `PyLong_AsLongLong` function is used after explicit check for `PyLong`.

Draft because it depends on C# 9, which is not yet ready.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
