### PR TITLE
Better error messages from PyObject.AsManagedObject and DelegateManager.TrueDispatch

### DIFF
--- a/src/embed_tests/TestPyObject.cs
+++ b/src/embed_tests/TestPyObject.cs
@@ -59,9 +59,17 @@ a = MemberNamesTest()
         }
 
         [Test]
-        public void InvokeNull() {
+        public void InvokeNull()
+        {
             var list = PythonEngine.Eval("list");
             Assert.Throws<ArgumentNullException>(() => list.Invoke(new PyObject[] {null}));
+        }
+
+        [Test]
+        public void AsManagedObjectInvalidCast()
+        {
+            var list = PythonEngine.Eval("list");
+            Assert.Throws<InvalidCastException>(() => list.AsManagedObject(typeof(int)));
         }
     }
 }

--- a/src/runtime/delegatemanager.cs
+++ b/src/runtime/delegatemanager.cs
@@ -221,19 +221,17 @@ namespace Python.Runtime
         public object Dispatch(ArrayList args)
         {
             IntPtr gs = PythonEngine.AcquireLock();
-            object ob = null;
+            object ob;
 
             try
             {
                 ob = TrueDispatch(args);
             }
-            catch (Exception e)
+            finally
             {
                 PythonEngine.ReleaseLock(gs);
-                throw e;
             }
 
-            PythonEngine.ReleaseLock(gs);
             return ob;
         }
 
@@ -266,27 +264,15 @@ namespace Python.Runtime
                 return null;
             }
 
-            object result = null;
-            if (!Converter.ToManaged(op, rtype, out result, false))
+            object result;
+            if (!Converter.ToManaged(op, rtype, out result, true))
             {
                 Runtime.XDecref(op);
-                throw new ConversionException($"could not convert Python result to {rtype}");
+                throw new PythonException();
             }
 
             Runtime.XDecref(op);
             return result;
-        }
-    }
-
-
-    public class ConversionException : Exception
-    {
-        public ConversionException()
-        {
-        }
-
-        public ConversionException(string msg) : base(msg)
-        {
         }
     }
 }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -134,9 +134,9 @@ namespace Python.Runtime
         public object AsManagedObject(Type t)
         {
             object result;
-            if (!Converter.ToManaged(obj, t, out result, false))
+            if (!Converter.ToManaged(obj, t, out result, true))
             {
-                throw new InvalidCastException("cannot convert object to target type");
+                throw new InvalidCastException("cannot convert object to target type", new PythonException());
             }
             return result;
         }
@@ -154,12 +154,7 @@ namespace Python.Runtime
             {
                 return (T)(this as object);
             }
-            object result;
-            if (!Converter.ToManaged(obj, typeof(T), out result, false))
-            {
-                throw new InvalidCastException("cannot convert object to target type");
-            }
-            return (T)result;
+            return (T)AsManagedObject(typeof(T));
         }
 
 

--- a/src/tests/test_delegate.py
+++ b/src/tests/test_delegate.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# TODO: Add test for ObjectDelegate
 
 """Test CLR delegate support."""
 
@@ -256,6 +255,26 @@ def test_bool_delegate():
 
     assert not d()
     assert not ob.CallBoolDelegate(d)
+
+def test_object_delegate():
+    """Test object delegate."""
+    from Python.Test import ObjectDelegate
+
+    def create_object():
+        return DelegateTest()
+
+    d = ObjectDelegate(create_object)
+    ob = DelegateTest()
+    ob.CallObjectDelegate(d)
+
+def test_invalid_object_delegate():
+    """Test invalid object delegate with mismatched return type."""
+    from Python.Test import ObjectDelegate
+
+    d = ObjectDelegate(hello_func)
+    ob = DelegateTest()
+    with pytest.raises(TypeError):
+        ob.CallObjectDelegate(d)
 
     # test async delegates
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When Converter.ToManaged is called in a context where it must succeed, we can get a more precise error message by calling it with setError=true.  This PR makes that change in two places.

### Does this close any currently open issues?

No

### Any other comments?

There are a few other places where a similar change could be made.

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
