### PR TITLE
Support comparison operators

### DIFF
--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -149,6 +149,58 @@ namespace Python.EmbeddingTest
                 return new OperableObject(a.Num ^ b);
             }
 
+            public static bool operator <=(int a, OperableObject b)
+            {
+                return (a <= b.Num);
+            }
+            public static bool operator <=(OperableObject a, OperableObject b)
+            {
+                return (a.Num <= b.Num);
+            }
+            public static bool operator <=(OperableObject a, int b)
+            {
+                return (a.Num <= b);
+            }
+
+            public static bool operator >=(int a, OperableObject b)
+            {
+                return (a >= b.Num);
+            }
+            public static bool operator >=(OperableObject a, OperableObject b)
+            {
+                return (a.Num >= b.Num);
+            }
+            public static bool operator >=(OperableObject a, int b)
+            {
+                return (a.Num >= b);
+            }
+
+            public static bool operator<(int a, OperableObject b)
+            {
+                return (a < b.Num);
+            }
+            public static bool operator<(OperableObject a, OperableObject b)
+            {
+                return (a.Num < b.Num);
+            }
+            public static bool operator<(OperableObject a, int b)
+            {
+                return (a.Num < b);
+            }
+
+            public static bool operator>(int a, OperableObject b)
+            {
+                return (a > b.Num);
+            }
+            public static bool operator>(OperableObject a, OperableObject b)
+            {
+                return (a.Num > b.Num);
+            }
+            public static bool operator >(OperableObject a, int b)
+            {
+                return (a.Num > b);
+            }
+
             public static OperableObject operator <<(OperableObject a, int offset)
             {
                 return new OperableObject(a.Num << offset);
@@ -161,7 +213,7 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
-        public void OperatorOverloads()
+        public void SymmetricalOperatorOverloads()
         {
             string name = string.Format("{0}.{1}",
                 typeof(OperableObject).DeclaringType.Name,
@@ -206,6 +258,18 @@ assert c.Num == a.Num | b.Num
 
 c = a ^ b
 assert c.Num == a.Num ^ b.Num
+
+c = a <= b
+assert c == (a.Num <= b.Num)
+
+c = a >= b
+assert c == (a.Num >= b.Num)
+
+c = a < b
+assert c == (a.Num < b.Num)
+
+c = a > b
+assert c == (a.Num > b.Num)
 ");
         }
 
@@ -263,6 +327,18 @@ assert c.Num == a.Num | b
 
 c = a ^ b
 assert c.Num == a.Num ^ b
+
+c = a <= b
+assert c == (a.Num <= b)
+
+c = a >= b
+assert c == (a.Num >= b)
+
+c = a < b
+assert c == (a.Num < b)
+
+c = a > b
+assert c == (a.Num > b)
 ");
         }
 
@@ -304,6 +380,18 @@ assert c.Num == a | b.Num
 
 c = a ^ b
 assert c.Num == a ^ b.Num
+
+c = a <= b
+assert c == (a <= b.Num)
+
+c = a >= b
+assert c == (a >= b.Num)
+
+c = a < b
+assert c == (a < b.Num)
+
+c = a > b
+assert c == (a > b.Num)
 ");
 
         }

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -212,6 +212,25 @@ namespace Python.EmbeddingTest
                 return (a.Num >= b);
             }
 
+            public static bool operator >=(OperableObject a, PyObject b)
+            {
+                using (Py.GIL())
+                {
+                    // Assuming b is a tuple, take the first element.
+                    int bNum = (int)b.ToArray()[0].AsManagedObject(typeof(int));
+                    return a.Num >= bNum;
+                }
+            }
+            public static bool operator <=(OperableObject a, PyObject b)
+            {
+                using (Py.GIL())
+                {
+                    // Assuming b is a tuple, take the first element.
+                    int bNum = (int)b.ToArray()[0].AsManagedObject(typeof(int));
+                    return a.Num <= bNum;
+                }
+            }
+
             public static bool operator <(int a, OperableObject b)
             {
                 return (a < b.Num);
@@ -388,6 +407,27 @@ assert c == (a.Num < b)
 
 c = a > b
 assert c == (a.Num > b)
+");
+        }
+
+        [Test]
+        public void TupleComparisonOperatorOverloads()
+        {
+                string name = string.Format("{0}.{1}",
+                typeof(OperableObject).DeclaringType.Name,
+                typeof(OperableObject).Name);
+            string module = MethodBase.GetCurrentMethod().DeclaringType.Namespace;
+                PythonEngine.Exec($@"
+from {module} import *
+cls = {name}
+a = cls(2)
+b = (1, 2)
+
+c = a >= b
+assert c == (a.Num >= b[0])
+
+c = a <= b
+assert c == (a.Num <= b[0])
 ");
         }
 

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -149,6 +149,32 @@ namespace Python.EmbeddingTest
                 return new OperableObject(a.Num ^ b);
             }
 
+            public static bool operator ==(int a, OperableObject b)
+            {
+                return (a == b.Num);
+            }
+            public static bool operator ==(OperableObject a, OperableObject b)
+            {
+                return (a.Num == b.Num);
+            }
+            public static bool operator ==(OperableObject a, int b)
+            {
+                return (a.Num == b);
+            }
+
+            public static bool operator !=(int a, OperableObject b)
+            {
+                return (a != b.Num);
+            }
+            public static bool operator !=(OperableObject a, OperableObject b)
+            {
+                return (a.Num != b.Num);
+            }
+            public static bool operator !=(OperableObject a, int b)
+            {
+                return (a.Num != b);
+            }
+
             public static bool operator <=(int a, OperableObject b)
             {
                 return (a <= b.Num);

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -201,24 +201,24 @@ namespace Python.EmbeddingTest
                 return (a.Num >= b);
             }
 
-            public static bool operator<(int a, OperableObject b)
+            public static bool operator <(int a, OperableObject b)
             {
                 return (a < b.Num);
             }
-            public static bool operator<(OperableObject a, OperableObject b)
+            public static bool operator <(OperableObject a, OperableObject b)
             {
                 return (a.Num < b.Num);
             }
-            public static bool operator<(OperableObject a, int b)
+            public static bool operator <(OperableObject a, int b)
             {
                 return (a.Num < b);
             }
 
-            public static bool operator>(int a, OperableObject b)
+            public static bool operator >(int a, OperableObject b)
             {
                 return (a > b.Num);
             }
-            public static bool operator>(OperableObject a, OperableObject b)
+            public static bool operator >(OperableObject a, OperableObject b)
             {
                 return (a.Num > b.Num);
             }
@@ -285,6 +285,12 @@ assert c.Num == a.Num | b.Num
 c = a ^ b
 assert c.Num == a.Num ^ b.Num
 
+c = a == b
+assert c == (a.Num == b.Num)
+
+c = a != b
+assert c == (a.Num != b.Num)
+
 c = a <= b
 assert c == (a.Num <= b.Num)
 
@@ -296,12 +302,6 @@ assert c == (a.Num < b.Num)
 
 c = a > b
 assert c == (a.Num > b.Num)
-
-c = a == b
-assert c == (a.Num == b.Num)
-
-c = a != b
-assert c == (a.Num != b.Num)
 ");
         }
 
@@ -360,6 +360,12 @@ assert c.Num == a.Num | b
 c = a ^ b
 assert c.Num == a.Num ^ b
 
+c = a == b
+assert c == (a.Num == b)
+
+c = a != b
+assert c == (a.Num != b)
+
 c = a <= b
 assert c == (a.Num <= b)
 
@@ -371,12 +377,6 @@ assert c == (a.Num < b)
 
 c = a > b
 assert c == (a.Num > b)
-
-c = a == b
-assert c == (a.Num == b)
-
-c = a != b
-assert c == (a.Num != b)
 ");
         }
 
@@ -419,6 +419,12 @@ assert c.Num == a | b.Num
 c = a ^ b
 assert c.Num == a ^ b.Num
 
+c = a == b
+assert c == (a == b.Num)
+
+c = a != b
+assert c == (a != b.Num)
+
 c = a <= b
 assert c == (a <= b.Num)
 
@@ -430,12 +436,6 @@ assert c == (a < b.Num)
 
 c = a > b
 assert c == (a > b.Num)
-
-c = a == b
-assert c == (a == b.Num)
-
-c = a != b
-assert c == (a != b.Num)
 ");
 
         }

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -217,7 +217,7 @@ namespace Python.EmbeddingTest
                 using (Py.GIL())
                 {
                     // Assuming b is a tuple, take the first element.
-                    int bNum = (int)b.ToArray()[0].AsManagedObject(typeof(int));
+                    int bNum = b[0].As<int>();
                     return a.Num >= bNum;
                 }
             }
@@ -226,7 +226,7 @@ namespace Python.EmbeddingTest
                 using (Py.GIL())
                 {
                     // Assuming b is a tuple, take the first element.
-                    int bNum = (int)b.ToArray()[0].AsManagedObject(typeof(int));
+                    int bNum = b[0].As<int>();
                     return a.Num <= bNum;
                 }
             }

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -428,6 +428,12 @@ assert c == (a.Num >= b[0])
 
 c = a <= b
 assert c == (a.Num <= b[0])
+
+c = b >= a
+assert c == (b[0] >= a.Num)
+
+c = b <= a
+assert c == (b[0] <= a.Num)
 ");
         }
 

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -27,7 +27,7 @@ namespace Python.EmbeddingTest
 
             public override int GetHashCode()
             {
-                return 159832395 + Num.GetHashCode();
+                return unchecked(159832395 + Num.GetHashCode());
             }
 
             public override bool Equals(object obj)

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -270,6 +270,12 @@ assert c == (a.Num < b.Num)
 
 c = a > b
 assert c == (a.Num > b.Num)
+
+c = a == b
+assert c == (a.Num == b.Num)
+
+c = a != b
+assert c == (a.Num != b.Num)
 ");
         }
 
@@ -339,6 +345,12 @@ assert c == (a.Num < b)
 
 c = a > b
 assert c == (a.Num > b)
+
+c = a == b
+assert c == (a.Num == b)
+
+c = a != b
+assert c == (a.Num != b)
 ");
         }
 
@@ -392,6 +404,12 @@ assert c == (a < b.Num)
 
 c = a > b
 assert c == (a > b.Num)
+
+c = a == b
+assert c == (a == b.Num)
+
+c = a != b
+assert c == (a != b.Num)
 ");
 
         }

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -25,6 +25,17 @@ namespace Python.EmbeddingTest
         {
             public int Num { get; set; }
 
+            public override int GetHashCode()
+            {
+                return 159832395 + Num.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is OperableObject @object &&
+                       Num == @object.Num;
+            }
+
             public OperableObject(int num)
             {
                 Num = num;

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -40,10 +40,10 @@ namespace Python.Runtime
         {
             [Runtime.Py_EQ] = "op_Equality",
             [Runtime.Py_NE] = "op_Inequality",
-            [Runtime.Py_GT] = "op_GreaterThan",
+            [Runtime.Py_LE] = "op_LessThanOrEqual",
             [Runtime.Py_GE] = "op_GreaterThanOrEqual",
             [Runtime.Py_LT] = "op_LessThan",
-            [Runtime.Py_LE] = "op_LessThanOrEqual",
+            [Runtime.Py_GT] = "op_GreaterThan",
         };
 
         /// <summary>

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -89,16 +89,10 @@ namespace Python.Runtime
             // otherwise fallback to checking if an IComparable interface is handled.
             if (cls.richcompare.TryGetValue(op, out var methodObject))
             {
-                IntPtr args = other;
-                var free = false;
-                if (true)
-                {
-                    // Wrap the `other` argument of a binary comparison operator in a PyTuple.
-                    args = Runtime.PyTuple_New(1);
-                    Runtime.XIncref(other);
-                    Runtime.PyTuple_SetItem(args, 0, other);
-                    free = true;
-                }
+                // Wrap the `other` argument of a binary comparison operator in a PyTuple.
+                IntPtr args = Runtime.PyTuple_New(1);
+                Runtime.XIncref(other);
+                Runtime.PyTuple_SetItem(args, 0, other);
 
                 IntPtr value;
                 try
@@ -107,10 +101,7 @@ namespace Python.Runtime
                 }
                 finally
                 {
-                    if (free)
-                    {
-                        Runtime.XDecref(args);  // Free args pytuple
-                    }
+                    Runtime.XDecref(args);  // Free args pytuple
                 }
                 return value;
             }

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -557,8 +557,7 @@ namespace Python.Runtime
                 {
                     string pyName = OperatorMethod.GetPyMethodName(name);
                     string pyNameReverse = OperatorMethod.ReversePyMethodName(pyName);
-                    MethodInfo[] forwardMethods, reverseMethods;
-                    OperatorMethod.FilterMethods(mlist, out forwardMethods, out reverseMethods);
+                    OperatorMethod.FilterMethods(mlist, out var forwardMethods, out var reverseMethods);
                     // Only methods where the left operand is the declaring type.
                     if (forwardMethods.Length > 0)
                         ci.members[pyName] = new MethodObject(type, name, forwardMethods);

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -259,6 +259,7 @@ namespace Python.Runtime
             ClassInfo info = GetClassInfo(type);
 
             impl.indexer = info.indexer;
+            impl.richcompare = new Hashtable();
 
             // Now we allocate the Python type object to reflect the given
             // managed type, filling the Python type slots with thunks that
@@ -284,6 +285,9 @@ namespace Python.Runtime
                 Runtime.PyDict_SetItemString(dict, name, item.pyHandle);
                 // Decref the item now that it's been used.
                 item.DecrRefCount();
+                if (ClassBase.PyToCilOpMap.ContainsValue(name)) {
+                    impl.richcompare.Add(name, iter.Value);
+                }
             }
 
             // If class has constructors, generate an __doc__ attribute.

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -259,7 +259,7 @@ namespace Python.Runtime
             ClassInfo info = GetClassInfo(type);
 
             impl.indexer = info.indexer;
-            impl.richcompare = new Hashtable();
+            impl.richcompare = new Dictionary<int, MethodObject>();
 
             // Now we allocate the Python type object to reflect the given
             // managed type, filling the Python type slots with thunks that
@@ -285,8 +285,8 @@ namespace Python.Runtime
                 Runtime.PyDict_SetItemString(dict, name, item.pyHandle);
                 // Decref the item now that it's been used.
                 item.DecrRefCount();
-                if (ClassBase.PyToCilOpMap.ContainsValue(name)) {
-                    impl.richcompare.Add(name, iter.Value);
+                if (ClassBase.CilToPyOpMap.TryGetValue(name, out var pyOp)) {
+                    impl.richcompare.Add(pyOp, (MethodObject)item);
                 }
             }
 

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -354,16 +354,17 @@ namespace Python.Runtime
                 int kwargsMatched;
                 int defaultsNeeded;
                 bool isOperator = OperatorMethod.IsOperatorMethod(mi);
-                int clrnargs = pi.Length;
                 // Binary operator methods will have 2 CLR args but only one Python arg
                 // (unary operators will have 1 less each), since Python operator methods are bound.
-                isOperator = isOperator && pynargs == clrnargs - 1;
+                isOperator = isOperator && pynargs == pi.Length - 1;
+                bool isReverse = isOperator && OperatorMethod.IsReverse((MethodInfo)mi);  // Only cast if isOperator.
+                if (isReverse && OperatorMethod.IsComparisonOp((MethodInfo)mi))
+                    continue;  // Comparison operators in Python have no reverse mode.
                 if (!MatchesArgumentCount(pynargs, pi, kwargDict, out paramsArray, out defaultArgList, out kwargsMatched, out defaultsNeeded) && !isOperator)
                 {
                     continue;
                 }
                 // Preprocessing pi to remove either the first or second argument.
-                bool isReverse = isOperator && OperatorMethod.IsReverse((MethodInfo)mi);  // Only cast if isOperator.
                 if (isOperator && !isReverse) {
                     // The first Python arg is the right operand, while the bound instance is the left.
                     // We need to skip the first (left operand) CLR argument.

--- a/src/runtime/operatormethod.cs
+++ b/src/runtime/operatormethod.cs
@@ -49,6 +49,11 @@ namespace Python.Runtime
                 ["op_OnesComplement"] = new SlotDefinition("__invert__", TypeOffset.nb_invert),
                 ["op_UnaryNegation"] = new SlotDefinition("__neg__", TypeOffset.nb_negative),
                 ["op_UnaryPlus"] = new SlotDefinition("__pos__", TypeOffset.nb_positive),
+                ["op_OneComplement"] = new SlotDefinition("__invert__", TypeOffset.nb_invert),
+                ["op_GreaterThan"] = new SlotDefinition("__gt__", TypeOffset.tp_richcompare),
+                ["op_GreaterThanOrEqual"] = new SlotDefinition("__ge__", TypeOffset.tp_richcompare),
+                ["op_LessThan"] = new SlotDefinition("__lt__", TypeOffset.tp_richcompare),
+                ["op_LessThanOrEqual"] = new SlotDefinition("__le__", TypeOffset.tp_richcompare)
             };
         }
 

--- a/src/runtime/operatormethod.cs
+++ b/src/runtime/operatormethod.cs
@@ -99,7 +99,9 @@ namespace Python.Runtime
             Debug.Assert(_opType != null);
             foreach (var method in clrType.GetMethods(flags))
             {
-                if (!IsOperatorMethod(method) || IsComparisonOp(method))  // We don't want to override ClassBase.tp_richcompare.
+                // We don't want to override slots for either non-operators or
+                // comparison operators, which are handled by ClassBase.tp_richcompare.
+                if (!IsOperatorMethod(method) || IsComparisonOp(method))
                 {
                     continue;
                 }

--- a/src/runtime/operatormethod.cs
+++ b/src/runtime/operatormethod.cs
@@ -50,6 +50,8 @@ namespace Python.Runtime
                 ["op_UnaryNegation"] = new SlotDefinition("__neg__", TypeOffset.nb_negative),
                 ["op_UnaryPlus"] = new SlotDefinition("__pos__", TypeOffset.nb_positive),
                 ["op_OneComplement"] = new SlotDefinition("__invert__", TypeOffset.nb_invert),
+                ["op_Equality"] = new SlotDefinition("__eq__", TypeOffset.tp_richcompare),
+                ["op_Inequality"] = new SlotDefinition("__ne__", TypeOffset.tp_richcompare),
                 ["op_GreaterThan"] = new SlotDefinition("__gt__", TypeOffset.tp_richcompare),
                 ["op_GreaterThanOrEqual"] = new SlotDefinition("__ge__", TypeOffset.tp_richcompare),
                 ["op_LessThan"] = new SlotDefinition("__lt__", TypeOffset.tp_richcompare),
@@ -79,6 +81,12 @@ namespace Python.Runtime
             }
             return OpMethodMap.ContainsKey(method.Name);
         }
+
+        public static bool IsComparisonOp(MethodInfo method)
+        {
+            return OpMethodMap[method.Name].TypeOffset == TypeOffset.tp_richcompare;
+        }
+
         /// <summary>
         /// For the operator methods of a CLR type, set the special slots of the
         /// corresponding Python type's operator methods.
@@ -91,7 +99,7 @@ namespace Python.Runtime
             Debug.Assert(_opType != null);
             foreach (var method in clrType.GetMethods(flags))
             {
-                if (!IsOperatorMethod(method))
+                if (!IsOperatorMethod(method) || IsComparisonOp(method))  // We don't want to override ClassBase.tp_richcompare.
                 {
                     continue;
                 }

--- a/src/runtime/operatormethod.cs
+++ b/src/runtime/operatormethod.cs
@@ -104,9 +104,9 @@ namespace Python.Runtime
             Debug.Assert(_opType != null);
             foreach (var method in clrType.GetMethods(flags))
             {
-                // We don't want to override slots for either non-operators or
+                // We only want to override slots for operators excluding
                 // comparison operators, which are handled by ClassBase.tp_richcompare.
-                if (!IsOperatorMethod(method) || IsComparisonOp(method))
+                if (!OpMethodMap.ContainsKey(method.Name))
                 {
                     continue;
                 }

--- a/src/runtime/operatormethod.cs
+++ b/src/runtime/operatormethod.cs
@@ -52,10 +52,10 @@ namespace Python.Runtime
                 ["op_OneComplement"] = new SlotDefinition("__invert__", TypeOffset.nb_invert),
                 ["op_Equality"] = new SlotDefinition("__eq__", TypeOffset.tp_richcompare),
                 ["op_Inequality"] = new SlotDefinition("__ne__", TypeOffset.tp_richcompare),
-                ["op_GreaterThan"] = new SlotDefinition("__gt__", TypeOffset.tp_richcompare),
+                ["op_LessThanOrEqual"] = new SlotDefinition("__le__", TypeOffset.tp_richcompare),
                 ["op_GreaterThanOrEqual"] = new SlotDefinition("__ge__", TypeOffset.tp_richcompare),
                 ["op_LessThan"] = new SlotDefinition("__lt__", TypeOffset.tp_richcompare),
-                ["op_LessThanOrEqual"] = new SlotDefinition("__le__", TypeOffset.tp_richcompare)
+                ["op_GreaterThan"] = new SlotDefinition("__gt__", TypeOffset.tp_richcompare),
             };
         }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Continuation of https://github.com/pythonnet/pythonnet/pull/1324/files but specifically for comparison operators e.g. >, >=, <, == etc. based on a discussion with @tminka --- in a nutshell, we want to check each C# class for any comparison `operator` methods when calling `ClassBase.tp_richcompare`, before proceeding with the usual logic (see https://github.com/pythonnet/pythonnet/pull/294) which handles C# classes that implement an `IComparable` interface.

Would appreciate a review from @lostmsu who helped with the previous PR that this builds on. Thanks!

### Does this close any currently open issues?
Closes https://github.com/pythonnet/pythonnet/issues/1312
More concrete examples can also be found in other Infer.NET tutorials e.g. having to use `op_GreaterThan` https://github.com/dotnet/infer/blob/67b4f80d97018460bcb817f76ec874d0f33f1651/test/TestPython/test_tutorials.py#L31
### Any other comments?

Some remaining tasks could be:
- Add tests for derived objects, and for other edge cases (e.g. if truly no operator methods defined, asserting good error messages)
- When C# class defines `operator ==()`, the class should also define .Equals and .GetHashCode() https://stackoverflow.com/questions/10790370/whats-wrong-with-defining-operator-but-not-defining-equals-or-gethashcode

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)

The tests pass in net472 but not on netcoreapp3.1 