### PR TITLE
Add more more tests for in, out and ref parameters

### DIFF
--- a/src/domain_tests/test_domain_reload.py
+++ b/src/domain_tests/test_domain_reload.py
@@ -84,5 +84,17 @@ def test_out_to_ref_param():
     _run_test("out_to_ref_param")
 
 @pytest.mark.skipif(platform.system() == 'Darwin', reason='FIXME: macos can\'t find the python library')
+def test_ref_to_out_param():
+    _run_test("ref_to_out_param")
+
+@pytest.mark.skipif(platform.system() == 'Darwin', reason='FIXME: macos can\'t find the python library')
+def test_ref_to_in_param():
+    _run_test("ref_to_in_param")
+
+@pytest.mark.skipif(platform.system() == 'Darwin', reason='FIXME: macos can\'t find the python library')
+def test_in_to_ref_param():
+    _run_test("in_to_ref_param")
+
+@pytest.mark.skipif(platform.system() == 'Darwin', reason='FIXME: macos can\'t find the python library')
 def test_nested_type():
     _run_test("nested_type")

--- a/src/runtime/StateSerialization/MaybeMethodBase.cs
+++ b/src/runtime/StateSerialization/MaybeMethodBase.cs
@@ -35,11 +35,11 @@ namespace Python.Runtime
                 Name = tp.ParameterType.AssemblyQualifiedName;
                 Modifier = TypeModifier.None;
 
-                if (tp.IsIn)
+                if (tp.IsIn && tp.ParameterType.IsByRef)
                 {
                     Modifier = TypeModifier.In;
                 }
-                else if (tp.IsOut)
+                else if (tp.IsOut && tp.ParameterType.IsByRef)
                 {
                     Modifier = TypeModifier.Out;
                 }


### PR DESCRIPTION
As Discussed in #1287, this is an extra PR to add more tests cases, and a small fix, for the reload of methods with `in`, `out` and/or `ref` parameters
...

### Does this close any currently open issues?
No
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
