### PR TITLE
Better error messages for method argument mismatch and others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ details about the cause of the failure
 -   `PyObject` now implements `IEnumerable<PyObject>` in addition to `IEnumerable`
 -   floating point values passed from Python are no longer silently truncated
 when .NET expects an integer [#1342][i1342]
+-   More specific error messages for method argument mismatch
 
 ### Fixed
 
@@ -49,6 +50,7 @@ when .NET expects an integer [#1342][i1342]
 -    Fixed objects returned by enumerating `PyObject` being disposed too soon
 -    Incorrectly using a non-generic type with type parameters now produces a helpful Python error instead of throwing NullReferenceException
 -   `import` may now raise errors with more detail than "No module named X"
+-    Providing an invalid type parameter to a generic type or method produces a helpful Python error
 
 ### Removed
 

--- a/src/clrmodule/ClrModule.cs
+++ b/src/clrmodule/ClrModule.cs
@@ -62,9 +62,9 @@ public class clrModule
             pythonRuntime = Assembly.Load(pythonRuntimeName);
             DebugPrint("Success loading 'Python.Runtime' using standard binding rules.");
         }
-        catch (IOException)
+        catch (IOException ex)
         {
-            DebugPrint("'Python.Runtime' not found using standard binding rules.");
+            DebugPrint($"'Python.Runtime' not found using standard binding rules: {ex}");
             try
             {
                 // If the above fails for any reason, we fallback to attempting to load "Python.Runtime.dll"

--- a/src/domain_tests/test_domain_reload.py
+++ b/src/domain_tests/test_domain_reload.py
@@ -57,6 +57,7 @@ def test_property_visibility_change():
 def test_class_visibility_change():
     _run_test("class_visibility_change")
 
+@pytest.mark.skip(reason='FIXME: Domain reload fails when Python points to a .NET object which points back to Python objects')
 @pytest.mark.skipif(platform.system() == 'Darwin', reason='FIXME: macos can\'t find the python library')
 def test_method_parameters_change():
     _run_test("method_parameters_change")

--- a/src/embed_tests/TestPythonException.cs
+++ b/src/embed_tests/TestPythonException.cs
@@ -97,6 +97,7 @@ namespace Python.EmbeddingTest
             try
             {
                 PythonEngine.Exec("a=b\n");
+                Assert.Fail("Exception should have been raised");
             }
             catch (PythonException ex)
             {
@@ -134,6 +135,15 @@ class TestException(NameError):
                     Assert.AreEqual("invalid literal for int() with base 10: 'dummy string'", strObj.ToString());
                 }
             }
+        }
+
+        [Test]
+        public void TestPythonException_Normalize_ThrowsWhenErrorSet()
+        {
+            Exceptions.SetError(Exceptions.TypeError, "Error!");
+            var pythonException = new PythonException();
+            Exceptions.SetError(Exceptions.TypeError, "Another error");
+            Assert.Throws<InvalidOperationException>(() => pythonException.Normalize());
         }
     }
 }

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -66,7 +66,16 @@ namespace Python.Runtime
 
             if (target != null)
             {
-                Type t = target.MakeGenericType(types);
+                Type t;
+                try
+                {
+                    // MakeGenericType can throw ArgumentException
+                    t = target.MakeGenericType(types);
+                }
+                catch (ArgumentException e)
+                {
+                    return Exceptions.RaiseTypeError(e.Message);
+                }
                 ManagedType c = ClassManager.GetClass(t);
                 Runtime.XIncref(c.pyHandle);
                 return c.pyHandle;
@@ -263,14 +272,14 @@ namespace Python.Runtime
         /// <summary>
         /// Standard __hash__ implementation for instances of reflected types.
         /// </summary>
-        public static IntPtr tp_hash(IntPtr ob)
+        public static nint tp_hash(IntPtr ob)
         {
             var co = GetManagedObject(ob) as CLRObject;
             if (co == null)
             {
                 return Exceptions.RaiseTypeError("unhashable type");
             }
-            return new IntPtr(co.inst.GetHashCode());
+            return co.inst.GetHashCode();
         }
 
 

--- a/src/runtime/eventbinding.cs
+++ b/src/runtime/eventbinding.cs
@@ -68,35 +68,27 @@ namespace Python.Runtime
         /// <summary>
         /// EventBinding  __hash__ implementation.
         /// </summary>
-        public static IntPtr tp_hash(IntPtr ob)
+        public static nint tp_hash(IntPtr ob)
         {
             var self = (EventBinding)GetManagedObject(ob);
-            long x = 0;
-            long y = 0;
+            nint x = 0;
 
             if (self.target != IntPtr.Zero)
             {
-                x = Runtime.PyObject_Hash(self.target).ToInt64();
+                x = Runtime.PyObject_Hash(self.target);
                 if (x == -1)
                 {
-                    return new IntPtr(-1);
+                    return x;
                 }
             }
 
-            y = Runtime.PyObject_Hash(self.e.pyHandle).ToInt64();
+            nint y = Runtime.PyObject_Hash(self.e.pyHandle);
             if (y == -1)
             {
-                return new IntPtr(-1);
+                return y;
             }
 
-            x ^= y;
-
-            if (x == -1)
-            {
-                x = -1;
-            }
-
-            return new IntPtr(x);
+            return x ^ y;
         }
 
 

--- a/src/runtime/eventobject.cs
+++ b/src/runtime/eventobject.cs
@@ -86,7 +86,7 @@ namespace Python.Runtime
             }
 
             nint hash = Runtime.PyObject_Hash(handler);
-            if (hash == -1 || Exceptions.ErrorOccurred())
+            if (hash == -1 && Exceptions.ErrorOccurred())
             {
                 return false;
             }

--- a/src/runtime/eventobject.cs
+++ b/src/runtime/eventobject.cs
@@ -72,6 +72,12 @@ namespace Python.Runtime
         /// </summary>
         internal bool RemoveEventHandler(IntPtr target, IntPtr handler)
         {
+            if (reg == null)
+            {
+                Exceptions.SetError(Exceptions.ValueError, "unknown event handler");
+                return false;
+            }
+
             object obj = null;
             if (target != IntPtr.Zero)
             {
@@ -79,10 +85,9 @@ namespace Python.Runtime
                 obj = co.inst;
             }
 
-            IntPtr hash = Runtime.PyObject_Hash(handler);
-            if (Exceptions.ErrorOccurred() || reg == null)
+            nint hash = Runtime.PyObject_Hash(handler);
+            if (hash == -1 || Exceptions.ErrorOccurred())
             {
-                Exceptions.SetError(Exceptions.ValueError, "unknown event handler");
                 return false;
             }
 

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -72,31 +72,18 @@ namespace Python.Runtime
                 return Exceptions.RaiseTypeError("invalid object");
             }
 
-            string message = string.Empty;
-            if (e.Message != string.Empty)
+            string message = e.ToString();
+            string fullTypeName = e.GetType().FullName;
+            string prefix = fullTypeName + ": ";
+            if (message.StartsWith(prefix))
             {
-                message = e.Message;
+                message = message.Substring(prefix.Length);
             }
-            if (e is AggregateException ae)
+            else if (message.StartsWith(fullTypeName))
             {
-                message += GetAggregateExceptionString(ae);
-            }
-            if (!string.IsNullOrEmpty(e.StackTrace))
-            {
-                message = message + "\n" + e.StackTrace;
+                message = message.Substring(fullTypeName.Length);
             }
             return Runtime.PyUnicode_FromString(message);
-        }
-
-        private static string GetAggregateExceptionString(AggregateException aggregateException)
-        {
-            StringBuilder stringBuilder = new StringBuilder();
-            foreach(var innerException in aggregateException.InnerExceptions)
-            {
-                stringBuilder.AppendLine();
-                stringBuilder.Append(innerException.Message);
-            }
-            return stringBuilder.ToString();
         }
     }
 

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -560,7 +560,8 @@ namespace Python.Runtime
 
         static AggregateException GetAggregateException(IEnumerable<MismatchedMethod> mismatchedMethods)
         {
-            return new AggregateException(mismatchedMethods.Select(m => new ArgumentException($"{m.Exception.Message} in method {m.Method}", m.Exception)));
+            // We cannot attach m.Exception as an InnerException here because it contains pointers to Python objects and therefore not serializable.
+            return new AggregateException(mismatchedMethods.Select(m => new ArgumentException($"{m.Exception.Message} in method {m.Method}")));
         }
 
         static IntPtr HandleParamsArray(IntPtr args, int arrayStart, int pyArgCount, out bool isNewReference)

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -560,8 +560,7 @@ namespace Python.Runtime
 
         static AggregateException GetAggregateException(IEnumerable<MismatchedMethod> mismatchedMethods)
         {
-            // We cannot attach m.Exception as an InnerException here because it contains pointers to Python objects and therefore not serializable.
-            return new AggregateException(mismatchedMethods.Select(m => new ArgumentException($"{m.Exception.Message} in method {m.Method}")));
+            return new AggregateException(mismatchedMethods.Select(m => new ArgumentException($"{m.Exception.Message} in method {m.Method}", m.Exception)));
         }
 
         static IntPtr HandleParamsArray(IntPtr args, int arrayStart, int pyArgCount, out bool isNewReference)

--- a/src/runtime/methodbinding.cs
+++ b/src/runtime/methodbinding.cs
@@ -201,35 +201,27 @@ namespace Python.Runtime
         /// <summary>
         /// MethodBinding  __hash__ implementation.
         /// </summary>
-        public static IntPtr tp_hash(IntPtr ob)
+        public static nint tp_hash(IntPtr ob)
         {
             var self = (MethodBinding)GetManagedObject(ob);
-            long x = 0;
-            long y = 0;
+            nint x = 0;
 
             if (self.target != IntPtr.Zero)
             {
-                x = Runtime.PyObject_Hash(self.target).ToInt64();
+                x = Runtime.PyObject_Hash(self.target);
                 if (x == -1)
                 {
-                    return new IntPtr(-1);
+                    return x;
                 }
             }
 
-            y = Runtime.PyObject_Hash(self.m.pyHandle).ToInt64();
+            nint y = Runtime.PyObject_Hash(self.m.pyHandle);
             if (y == -1)
             {
-                return new IntPtr(-1);
+                return y;
             }
 
-            x ^= y;
-
-            if (x == -1)
-            {
-                x = -1;
-            }
-
-            return new IntPtr(x);
+            return x ^ y;
         }
 
         /// <summary>

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -157,8 +157,16 @@ namespace Python.Runtime
         public void Normalize()
         {
             IntPtr gs = PythonEngine.AcquireLock();
-            Runtime.PyErr_NormalizeException(ref _pyType, ref _pyValue, ref _pyTB);
-            PythonEngine.ReleaseLock(gs);
+            try
+            {
+                if (Exceptions.ErrorOccurred()) throw new InvalidOperationException("Cannot normalize when an error is set");
+                // If an error is set and this PythonException is unnormalized, the error will be cleared and the PythonException will be replaced by a different error.
+                Runtime.PyErr_NormalizeException(ref _pyType, ref _pyValue, ref _pyTB);
+            }
+            finally
+            {
+                PythonEngine.ReleaseLock(gs);
+            }
         }
 
         /// <summary>

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -36,6 +36,7 @@ namespace Python.Runtime
 
                 _pythonTypeName = type;
 
+                // TODO: If pyValue has a __cause__ attribute, then we could set this.InnerException to the equivalent managed exception.
                 Runtime.XIncref(_pyValue);
                 using (var pyValue = new PyObject(_pyValue))
                 {
@@ -146,6 +147,18 @@ namespace Python.Runtime
         public string PythonTypeName
         {
             get { return _pythonTypeName; }
+        }
+
+        /// <summary>
+        /// Replaces PyValue with an instance of PyType, if PyValue is not already an instance of PyType.
+        /// Often PyValue is a string and this method will replace it with a proper exception object.
+        /// Must not be called when an error is set.
+        /// </summary>
+        public void Normalize()
+        {
+            IntPtr gs = PythonEngine.AcquireLock();
+            Runtime.PyErr_NormalizeException(ref _pyType, ref _pyValue, ref _pyTB);
+            PythonEngine.ReleaseLock(gs);
         }
 
         /// <summary>

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1114,7 +1114,7 @@ namespace Python.Runtime
         private static extern IntPtr _PyObject_Size(IntPtr pointer);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyObject_Hash(IntPtr op);
+        internal static extern nint PyObject_Hash(IntPtr op);
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr PyObject_Repr(IntPtr pointer);
@@ -1947,8 +1947,11 @@ namespace Python.Runtime
             return (type == ofType) || PyType_IsSubtype(type, ofType);
         }
 
+        /// <summary>
+        /// Generic handler for the tp_new slot of a type object. Create a new instance using the type’s tp_alloc slot.
+        /// </summary>
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr PyType_GenericNew(IntPtr type, IntPtr args, IntPtr kw);
+        internal static extern IntPtr PyType_GenericNew(IntPtr type, IntPtr args, IntPtr kwds);
 
         internal static IntPtr PyType_GenericAlloc(IntPtr type, long n)
         {
@@ -2034,6 +2037,14 @@ namespace Python.Runtime
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int PyErr_GivenExceptionMatches(IntPtr ob, IntPtr val);
 
+        /// <summary>
+        /// Under certain circumstances, the values returned by PyErr_Fetch() below can be “unnormalized”,
+        /// meaning that *exc is a class object but *val is not an instance of the same class.
+        /// This function can be used to instantiate the class in that case.
+        /// If the values are already normalized, nothing happens.
+        /// The delayed normalization is implemented to improve performance.
+        /// Must not be called when an error is set.
+        /// </summary>
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyErr_NormalizeException(ref IntPtr ob, ref IntPtr val, ref IntPtr tb);
 
@@ -2051,6 +2062,12 @@ namespace Python.Runtime
 
         [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void PyErr_Print();
+
+        /// <summary>
+        /// Set the cause associated with the exception to cause. Use NULL to clear it. There is no type check to make sure that cause is either an exception instance or None. This steals a reference to cause.
+        /// </summary>
+        [DllImport(_PythonDll, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void PyException_SetCause(IntPtr ex, IntPtr cause);
 
         //====================================================================
         // Cell API

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -332,7 +332,7 @@ namespace Python.Runtime
                 {
                     if (Exceptions.ErrorOccurred()) return IntPtr.Zero;
                 }
-                else if (!Converter.ToManagedValue(assemblyPtr, typeof(string), out assembly, false))
+                else if (!Converter.ToManagedValue(assemblyPtr, typeof(string), out assembly, true))
                 {
                     return Exceptions.RaiseTypeError("Couldn't convert __assembly__ value to string");
                 }
@@ -344,7 +344,7 @@ namespace Python.Runtime
                     {
                         if (Exceptions.ErrorOccurred()) return IntPtr.Zero;
                     }
-                    else if (!Converter.ToManagedValue(pyNamespace, typeof(string), out namespaceStr, false))
+                    else if (!Converter.ToManagedValue(pyNamespace, typeof(string), out namespaceStr, true))
                     {
                         return Exceptions.RaiseTypeError("Couldn't convert __namespace__ value to string");
                     }

--- a/src/testing/Python.Test.csproj
+++ b/src/testing/Python.Test.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/testing/Python.Test.csproj
+++ b/src/testing/Python.Test.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\runtime\Python.Runtime.csproj" />

--- a/src/testing/generictest.cs
+++ b/src/testing/generictest.cs
@@ -35,6 +35,9 @@ namespace Python.Test
         }
     }
 
+    public class GenericTypeWithConstraint<T>
+        where T: struct
+    { }
 
     public class GenericNameTest1
     {
@@ -123,6 +126,14 @@ namespace Python.Test
         public static string Overloaded<Q>(int arg1, int arg2, string arg3)
         {
             return arg3;
+        }
+    }
+
+    public class GenericArrayConversionTest
+    {
+        public static T[] EchoRange<T>(T[] items)
+        {
+            return items;
         }
     }
 }

--- a/src/testing/indexertest.cs
+++ b/src/testing/indexertest.cs
@@ -427,10 +427,20 @@ namespace Python.Test
 
     public interface IInheritedIndexer : IIndexer { }
 
-    public class InterfaceInheritedIndexerTest :IndexerBase,  IInheritedIndexer  {
+    public class InterfaceInheritedIndexerTest : IndexerBase,  IInheritedIndexer
+    {
         private System.Collections.Generic.IDictionary<int, string> d = new System.Collections.Generic.Dictionary<int, string>();
 
         public string this[int index]
+        {
+            get { return GetValue(index); }
+            set { t[index] = value; }
+        }
+    }
+
+    public class PublicInheritedOverloadedIndexer : PublicIndexerTest
+    {
+        public string this[string index]
         {
             get { return GetValue(index); }
             set { t[index] = value; }

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -85,7 +85,7 @@ namespace Python.Test
 
         public static string[] TestStringParamsArg(params string[] args)
         {
-            return args.Concat(new []{"tail"}).ToArray();
+            return args.Concat(new[] { "tail" }).ToArray();
         }
 
         public static object[] TestObjectParamsArg(params object[] args)
@@ -654,32 +654,32 @@ namespace Python.Test
             return "Casesensitive";
         }
 
-        public static string DefaultParams(int a=0, int b=0, int c=0, int d=0)
+        public static string DefaultParams(int a = 0, int b = 0, int c = 0, int d = 0)
         {
             return string.Format("{0}{1}{2}{3}", a, b, c, d);
         }
 
-        public static string OptionalParams([Optional]int a, [Optional]int b, [Optional]int c, [Optional] int d)
+        public static string OptionalParams([Optional] int a, [Optional] int b, [Optional] int c, [Optional] int d)
         {
             return string.Format("{0}{1}{2}{3}", a, b, c, d);
         }
 
-        public static bool OptionalParams_TestMissing([Optional]object a)
+        public static bool OptionalParams_TestMissing([Optional] object a)
         {
             return a == Type.Missing;
         }
 
-        public static bool OptionalParams_TestReferenceType([Optional]string a)
+        public static bool OptionalParams_TestReferenceType([Optional] string a)
         {
             return a == null;
         }
 
-        public static string OptionalAndDefaultParams([Optional]int a, [Optional]int b, int c=0, int d=0)
+        public static string OptionalAndDefaultParams([Optional] int a, [Optional] int b, int c = 0, int d = 0)
         {
             return string.Format("{0}{1}{2}{3}", a, b, c, d);
         }
 
-        public static string OptionalAndDefaultParams2([Optional]int a, [Optional]int b, [Optional, DefaultParameterValue(1)]int c, int d = 2)
+        public static string OptionalAndDefaultParams2([Optional] int a, [Optional] int b, [Optional, DefaultParameterValue(1)] int c, int d = 2)
         {
             return string.Format("{0}{1}{2}{3}", a, b, c, d);
         }
@@ -716,6 +716,13 @@ namespace Python.Test
 
         public static void EncodingTestÅngström()
         {
+        }
+
+        // This method can never be invoked from Python, but we want to test that any attempt fails gracefully instead of crashing.
+        unsafe
+        public static void PointerArray(int*[] array)
+        {
+
         }
     }
 

--- a/src/tests/test_indexer.py
+++ b/src/tests/test_indexer.py
@@ -646,3 +646,21 @@ def test_inherited_indexer_interface():
     ifc = IInheritedIndexer(impl)
     ifc[0] = "zero"
     assert ifc[0] == "zero"
+
+def test_public_inherited_overloaded_indexer():
+    """Test public indexers."""
+    ob = Test.PublicInheritedOverloadedIndexer()
+
+    ob[0] = "zero"
+    assert ob[0] == "zero"
+
+    ob[1] = "one"
+    assert ob[1] == "one"
+
+    assert ob[10] is None
+
+    ob["spam"] = "spam"
+    assert ob["spam"] == "spam"
+
+    with pytest.raises(TypeError):
+        ob[[]]

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -892,9 +892,16 @@ def test_object_in_multiparam():
 def test_object_in_multiparam_exception():
     """Test method with object multiparams behaves"""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
         MethodTest.TestOverloadedObjectThree("foo", "bar")
 
+    e = excinfo.value
+    c = e.__cause__
+    assert c.GetType().FullName == 'System.AggregateException'
+    assert len(c.InnerExceptions) == 2
+    message = 'One or more errors occurred.'
+    s = str(c)
+    assert s[0:len(message)] == message
 
 def test_case_sensitive():
     """Test that case-sensitivity is respected. GH#81"""

--- a/src/tests/test_method.py
+++ b/src/tests/test_method.py
@@ -810,6 +810,9 @@ def test_no_object_in_param():
     with pytest.raises(TypeError):
         MethodTest.TestOverloadedNoObject(5.5)
 
+    # Ensure that the top-level error is TypeError even if the inner error is an OverflowError
+    with pytest.raises(TypeError):
+        MethodTest.TestOverloadedNoObject(2147483648)
 
 def test_object_in_param():
     """Test regression introduced by #151 in which Object method overloads
@@ -1216,13 +1219,17 @@ def test_params_array_overload():
     res = MethodTest.ParamsArrayOverloaded(1, 2, 3, i=1)
     assert res == "with params-array"
 
-    # These two cases are still incorrectly failing:
+@pytest.mark.skip(reason="FIXME: incorrectly failing")
+def test_params_array_overloaded_failing():
+    res = MethodTest.ParamsArrayOverloaded(1, 2, i=1)
+    assert res == "with params-array"
 
-    # res = MethodTest.ParamsArrayOverloaded(1, 2, i=1)
-    # assert res == "with params-array"
-
-    # res = MethodTest.ParamsArrayOverloaded(paramsArray=[], i=1)
-    # assert res == "with params-array"
+    res = MethodTest.ParamsArrayOverloaded(paramsArray=[], i=1)
+    assert res == "with params-array"
 
 def test_method_encoding():
     MethodTest.EncodingTestÅngström()
+
+def test_method_with_pointer_array_argument():
+    with pytest.raises(TypeError):
+        MethodTest.PointerArray([0])

--- a/src/tests/test_subclass.py
+++ b/src/tests/test_subclass.py
@@ -57,6 +57,14 @@ def derived_class_fixture(subnamespace):
 
     return DerivedClass
 
+def broken_derived_class_fixture(subnamespace):
+    """Delay creation of class until test starts."""
+
+    class DerivedClass(SubClassTest):
+        """class that derives from a class deriving from IInterfaceTest"""
+        __namespace__ = 3
+
+    return DerivedClass
 
 def derived_event_test_class_fixture(subnamespace):
     """Delay creation of class until test starts."""
@@ -127,6 +135,11 @@ def test_derived_class():
     x = FunctionsTest.pass_through(ob)
     assert id(x) == id(ob)
 
+def test_broken_derived_class():
+    """Test python class derived from managed type with invalid namespace"""
+    with pytest.raises(TypeError):
+        DerivedClass = broken_derived_class_fixture(test_derived_class.__name__)
+        ob = DerivedClass()
 
 def test_derived_traceback():
     """Test python exception traceback in class derived from managed base"""


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This change produces more specific error messages by passing setError=true to Converter.ToManaged whenever possible, such as when there is only one method in methodbinder.  To support this:
- Converter.ToManaged is fixed to obey setError consistently
- Converter.ToArray catches exceptions
- RaiseTypeError appends any existing error message
- Fixed missing information on 'No method matches given arguments' by adding the method name.

### Does this close any currently open issues?

No, but it provides more information to the user when they come across issues like #1099 .  Instead of "No method matches" or "No match found" it now says `TypeError : 'int' value cannot be converted to System.Enum`

### Any other comments?

I added some failing test cases to test_array.py that should be addressed by a future PR.

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
