### PR TITLE
Disable implicit conversion from PyFloat to uint64

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -701,16 +701,12 @@ namespace Python.Runtime
                         op = value;
                         if (Runtime.PyObject_TYPE(value) != Runtime.PyLongType)
                         {
-                            op = Runtime.PyNumber_Long(value);
-                            if (op == IntPtr.Zero)
-                            {
-                                goto convert_error;
-                            }
+                            goto type_error;
                         }
                         ulong num = Runtime.PyLong_AsUnsignedLongLong(op);
                         if (num == ulong.MaxValue && Exceptions.ErrorOccurred())
                         {
-                            goto overflow;
+                            goto convert_error;
                         }
                         result = num;
                         return true;

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -698,12 +698,7 @@ namespace Python.Runtime
 
                 case TypeCode.UInt64:
                     {
-                        op = value;
-                        if (Runtime.PyObject_TYPE(value) != Runtime.PyLongType)
-                        {
-                            goto type_error;
-                        }
-                        ulong num = Runtime.PyLong_AsUnsignedLongLong(op);
+                        ulong num = Runtime.PyLong_AsUnsignedLongLong(value);
                         if (num == ulong.MaxValue && Exceptions.ErrorOccurred())
                         {
                             goto convert_error;

--- a/src/tests/test_conversion.py
+++ b/src/tests/test_conversion.py
@@ -382,7 +382,10 @@ def test_uint64_conversion():
     ob.UInt64Field = System.UInt64(0)
     assert ob.UInt64Field == 0
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
+        ConversionTest().UInt64Field = 0.5
+
+    with pytest.raises(TypeError):
         ConversionTest().UInt64Field = "spam"
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fixes an oversight in #1343 that allows PyFloat to continue being converted to uint64.

### Does this close any currently open issues?

Fixes the test failures in #1361

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
