### PR TITLE
Support ByRef arguments in event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Ability to instantiate new .NET arrays using `Array[T](dim1, dim2, ...)` syntax
 -   Python operator method will call C# operator method for supported binary and unary operators ([#1324][p1324]).
 -   Add GetPythonThreadID and Interrupt methods in PythonEngine
+-   Ability to implement delegates with `ref` and `out` parameters in Python, by returning the modified parameter values in a tuple. ([#1355][i1355])
 
 ### Changed
 -   Drop support for Python 2, 3.4, and 3.5
@@ -32,6 +33,7 @@ details about the cause of the failure
 -   floating point values passed from Python are no longer silently truncated
 when .NET expects an integer [#1342][i1342]
 -   More specific error messages for method argument mismatch
+-   BREAKING: Methods with `ref` or `out` parameters and void return type return a tuple of only the `ref` and `out` parameters.
 
 ### Fixed
 
@@ -48,8 +50,8 @@ when .NET expects an integer [#1342][i1342]
 -    Fixed issue when calling PythonException.Format where another exception would be raise for unnormalized exceptions
 -    Made it possible to call `ToString`, `GetHashCode`, and `GetType` on inteface objects
 -    Fixed objects returned by enumerating `PyObject` being disposed too soon
--    Incorrectly using a non-generic type with type parameters now produces a helpful Python error instead of throwing NullReferenceException
--   `import` may now raise errors with more detail than "No module named X"
+-    Incorrectly using a non-generic type with type parameters now produces a helpful Python error instead of throwing NullReferenceException ([#1325][i1325])
+-    `import` may now raise errors with more detail than "No module named X"
 -    Providing an invalid type parameter to a generic type or method produces a helpful Python error
 
 ### Removed

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -338,9 +338,9 @@ namespace Python.Runtime
 
             if (mt != null)
             {
-                if (mt is CLRObject)
+                if (mt is CLRObject co)
                 {
-                    object tmp = ((CLRObject)mt).inst;
+                    object tmp = co.inst;
                     if (obType.IsInstanceOfType(tmp))
                     {
                         result = tmp;
@@ -348,13 +348,13 @@ namespace Python.Runtime
                     }
                     if (setError)
                     {
-                        Exceptions.SetError(Exceptions.TypeError, $"value cannot be converted to {obType}");
+                        string typeString = tmp is null ? "null" : tmp.GetType().ToString();
+                        Exceptions.SetError(Exceptions.TypeError, $"{typeString} value cannot be converted to {obType}");
                     }
                     return false;
                 }
-                if (mt is ClassBase)
+                if (mt is ClassBase cb)
                 {
-                    var cb = (ClassBase)mt;
                     if (!cb.type.Valid)
                     {
                         Exceptions.SetError(Exceptions.TypeError, cb.type.DeletedMessage);

--- a/src/testing/delegatetest.cs
+++ b/src/testing/delegatetest.cs
@@ -13,6 +13,12 @@ namespace Python.Test
 
     public delegate bool BoolDelegate();
 
+    public delegate void OutStringDelegate(out string value);
+    public delegate void RefStringDelegate(ref string value);
+    public delegate void OutIntDelegate(out int value);
+    public delegate void RefIntDelegate(ref int value);
+    public delegate void RefIntRefStringDelegate(ref int intValue, ref string stringValue);
+    public delegate int IntRefIntRefStringDelegate(ref int intValue, ref string stringValue);
 
     public class DelegateTest
     {
@@ -27,6 +33,8 @@ namespace Python.Test
         public StringDelegate stringDelegate;
         public ObjectDelegate objectDelegate;
         public BoolDelegate boolDelegate;
+        public OutStringDelegate outStringDelegate;
+        public RefStringDelegate refStringDelegate;
 
         public DelegateTest()
         {
@@ -42,6 +50,11 @@ namespace Python.Test
             return "hello";
         }
 
+        public void OutHello(out string value)
+        {
+            value = "hello";
+        }
+
         public string CallStringDelegate(StringDelegate d)
         {
             return d();
@@ -55,6 +68,36 @@ namespace Python.Test
         public bool CallBoolDelegate(BoolDelegate d)
         {
             return d();
+        }
+
+        public void CallOutIntDelegate(OutIntDelegate d, out int value)
+        {
+            d(out value);
+        }
+
+        public void CallRefIntDelegate(RefIntDelegate d, ref int value)
+        {
+            d(ref value);
+        }
+
+        public void CallOutStringDelegate(OutStringDelegate d, out string value)
+        {
+            d(out value);
+        }
+
+        public void CallRefStringDelegate(RefStringDelegate d, ref string value)
+        {
+            d(ref value);
+        }
+
+        public void CallRefIntRefStringDelegate(RefIntRefStringDelegate d, ref int intValue, ref string stringValue)
+        {
+            d(ref intValue, ref stringValue);
+        }
+
+        public int CallIntRefIntRefStringDelegate(IntRefIntRefStringDelegate d, ref int intValue, ref string stringValue)
+        {
+            return d(ref intValue, ref stringValue);
         }
     }
 }

--- a/src/testing/eventtest.cs
+++ b/src/testing/eventtest.cs
@@ -7,7 +7,6 @@ namespace Python.Test
     /// </summary>
     public delegate void EventHandlerTest(object sender, EventArgsTest e);
 
-
     #pragma warning disable 67 // Unused events, these are only accessed from Python
     public class EventTest
     {
@@ -27,6 +26,10 @@ namespace Python.Test
 
         private event EventHandlerTest PrivateEvent;
 
+        public event OutStringDelegate OutStringEvent;
+        public event OutIntDelegate OutIntEvent;
+        public event RefStringDelegate RefStringEvent;
+        public event RefIntDelegate RefIntEvent;
 
         public static int s_value;
         public int value;
@@ -77,6 +80,27 @@ namespace Python.Test
             }
         }
 
+        public void OnRefStringEvent(ref string data)
+        {
+            RefStringEvent?.Invoke(ref data);
+        }
+
+        public void OnRefIntEvent(ref int data)
+        {
+            RefIntEvent?.Invoke(ref data);
+        }
+
+        public void OnOutStringEvent(out string data)
+        {
+            data = default;
+            OutStringEvent?.Invoke(out data);
+        }
+
+        public void OnOutIntEvent(out int data)
+        {
+            data = default;
+            OutIntEvent?.Invoke(out data);
+        }
 
         public void GenericHandler(object sender, EventArgsTest e)
         {
@@ -86,6 +110,26 @@ namespace Python.Test
         public static void StaticHandler(object sender, EventArgsTest e)
         {
             s_value = e.value;
+        }
+
+        public void OutStringHandler(out string data)
+        {
+            data = value.ToString();
+        }
+
+        public void OutIntHandler(out int data)
+        {
+            data = value;
+        }
+
+        public void RefStringHandler(ref string data)
+        {
+            data += "!";
+        }
+
+        public void RefIntHandler(ref int data)
+        {
+            data++;
         }
 
         public static void ShutUpCompiler()

--- a/src/tests/test_delegate.py
+++ b/src/tests/test_delegate.py
@@ -276,6 +276,166 @@ def test_invalid_object_delegate():
     with pytest.raises(TypeError):
         ob.CallObjectDelegate(d)
 
+def test_out_int_delegate():
+    """Test delegate with an out int parameter."""
+    from Python.Test import OutIntDelegate
+    value = 7
+
+    def out_hello_func(ignored):
+        return 5
+
+    d = OutIntDelegate(out_hello_func)
+    result = d(value)
+    assert result == 5
+
+    ob = DelegateTest()
+    result = ob.CallOutIntDelegate(d, value)
+    assert result == 5
+
+    def invalid_handler(ignored):
+        return '5'
+
+    d = OutIntDelegate(invalid_handler)
+    with pytest.raises(TypeError):
+        result = d(value)
+
+def test_out_string_delegate():
+    """Test delegate with an out string parameter."""
+    from Python.Test import OutStringDelegate
+    value = 'goodbye'
+
+    def out_hello_func(ignored):
+        return 'hello'
+
+    d = OutStringDelegate(out_hello_func)
+    result = d(value)
+    assert result == 'hello'
+
+    ob = DelegateTest()
+    result = ob.CallOutStringDelegate(d, value)
+    assert result == 'hello'
+
+def test_ref_int_delegate():
+    """Test delegate with a ref string parameter."""
+    from Python.Test import RefIntDelegate
+    value = 7
+
+    def ref_hello_func(data):
+        assert data == value
+        return data + 1
+
+    d = RefIntDelegate(ref_hello_func)
+    result = d(value)
+    assert result == value + 1
+
+    ob = DelegateTest()
+    result = ob.CallRefIntDelegate(d, value)
+    assert result == value + 1
+
+def test_ref_string_delegate():
+    """Test delegate with a ref string parameter."""
+    from Python.Test import RefStringDelegate
+    value = 'goodbye'
+
+    def ref_hello_func(data):
+        assert data == value
+        return 'hello'
+
+    d = RefStringDelegate(ref_hello_func)
+    result = d(value)
+    assert result == 'hello'
+
+    ob = DelegateTest()
+    result = ob.CallRefStringDelegate(d, value)
+    assert result == 'hello'
+
+def test_ref_int_ref_string_delegate():
+    """Test delegate with a ref int and ref string parameter."""
+    from Python.Test import RefIntRefStringDelegate
+    intData = 7
+    stringData = 'goodbye'
+
+    def ref_hello_func(intValue, stringValue):
+        assert intData == intValue
+        assert stringData == stringValue
+        return (intValue + 1, stringValue + '!')
+
+    d = RefIntRefStringDelegate(ref_hello_func)
+    result = d(intData, stringData)
+    assert result == (intData + 1, stringData + '!')
+
+    ob = DelegateTest()
+    result = ob.CallRefIntRefStringDelegate(d, intData, stringData)
+    assert result == (intData + 1, stringData + '!')
+
+    def not_a_tuple(intValue, stringValue):
+        return 'a'
+
+    d = RefIntRefStringDelegate(not_a_tuple)
+    with pytest.raises(TypeError):
+        result = d(intData, stringData)
+
+    def short_tuple(intValue, stringValue):
+        return (5,)
+
+    d = RefIntRefStringDelegate(short_tuple)
+    with pytest.raises(TypeError):
+        result = d(intData, stringData)
+
+    def long_tuple(intValue, stringValue):
+        return (5, 'a', 'b')
+
+    d = RefIntRefStringDelegate(long_tuple)
+    with pytest.raises(TypeError):
+        result = d(intData, stringData)
+
+    def wrong_tuple_item(intValue, stringValue):
+        return ('a', 'b')
+
+    d = RefIntRefStringDelegate(wrong_tuple_item)
+    with pytest.raises(TypeError):
+        result = d(intData, stringData)
+
+def test_int_ref_int_ref_string_delegate():
+    """Test delegate with a ref int and ref string parameter."""
+    from Python.Test import IntRefIntRefStringDelegate
+    intData = 7
+    stringData = 'goodbye'
+
+    def ref_hello_func(intValue, stringValue):
+        assert intData == intValue
+        assert stringData == stringValue
+        return (intValue + len(stringValue), intValue + 1, stringValue + '!')
+
+    d = IntRefIntRefStringDelegate(ref_hello_func)
+    result = d(intData, stringData)
+    assert result == (intData + len(stringData), intData + 1, stringData + '!')
+
+    ob = DelegateTest()
+    result = ob.CallIntRefIntRefStringDelegate(d, intData, stringData)
+    assert result == (intData + len(stringData), intData + 1, stringData + '!')
+
+    def not_a_tuple(intValue, stringValue):
+        return 'a'
+
+    d = IntRefIntRefStringDelegate(not_a_tuple)
+    with pytest.raises(TypeError):
+        result = d(intData, stringData)
+
+    def short_tuple(intValue, stringValue):
+        return (5,)
+
+    d = IntRefIntRefStringDelegate(short_tuple)
+    with pytest.raises(TypeError):
+        result = d(intData, stringData)
+
+    def wrong_return_type(intValue, stringValue):
+        return ('a', 7, 'b')
+
+    d = IntRefIntRefStringDelegate(wrong_return_type)
+    with pytest.raises(TypeError):
+        result = d(intData, stringData)
+
     # test async delegates
 
     # test multicast delegates

--- a/src/tests/test_event.py
+++ b/src/tests/test_event.py
@@ -295,6 +295,41 @@ def test_function_handler():
     ob.OnPublicEvent(EventArgsTest(20))
     assert dict_['value'] == 10
 
+def test_out_function_handler():
+    """Test function handlers with Out arguments."""
+    ob = EventTest()
+
+    value = 10
+    def handler(ignored):
+        return value
+
+    ob.OutIntEvent += handler
+    result = ob.OnOutIntEvent(55)
+    assert result == value
+
+    ob.OutStringEvent += handler
+    value = 'This is the event data'
+    result = ob.OnOutStringEvent('Hello')
+    assert result == value
+
+def test_ref_function_handler():
+    """Test function handlers with Ref arguments."""
+    ob = EventTest()
+
+    value = 10
+    def handler(data):
+        return value + data
+
+    ob.RefIntEvent += ob.RefIntHandler
+    ob.RefIntEvent += handler
+    result = ob.OnRefIntEvent(5)
+    assert result == value + 5 + 1
+
+    ob.RefStringEvent += ob.RefStringHandler
+    ob.RefStringEvent += handler
+    value = 'This is the event data'
+    result = ob.OnRefStringEvent('!')
+    assert result == value + '!!'
 
 def test_add_non_callable_handler():
     """Test handling of attempts to add non-callable handlers."""


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When an event handler has a ByRef argument, extra logic is needed in DelegateManager.GetDispatcher or else the program will access invalid memory and crash.

### Does this close any currently open issues?

#1355 

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
