### PR TITLE
Simplify PyScope by delegating ownership to PyObject instance

### DIFF
--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -157,6 +157,7 @@ namespace Python.Runtime
             return (T)AsManagedObject(typeof(T));
         }
 
+        internal bool IsDisposed => obj == IntPtr.Zero;
 
         /// <summary>
         /// Dispose Method


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

I noticed `PyScope` ownership implementation is so-so. One of the potential reasons for the crash could be `PyScope` being improperly deallocated.

This is an attempt to fix crash in CI on Ubuntu with Python 3.9.

### Does this close any currently open issues?

No
