### PR TITLE
ParameterInfo.Name needs to be checked for null before usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ or the DLL must be loaded in advance. This must be done before calling any other
 -   `import` may now raise errors with more detail than "No module named X"
 -   Exception stacktraces on `PythonException.StackTrace` are now properly formatted
 -   Providing an invalid type parameter to a generic type or method produces a helpful Python error
+-   Empty parameter names (as can be generated from F#) do not cause crashes
 
 ### Removed
 

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -622,7 +622,7 @@ namespace Python.Runtime
             for (int paramIndex = 0; paramIndex < pi.Length; paramIndex++)
             {
                 var parameter = pi[paramIndex];
-                bool hasNamedParam = kwargDict.ContainsKey(parameter.Name);
+                bool hasNamedParam = parameter.Name != null ? kwargDict.ContainsKey(parameter.Name) : false;
                 bool isNewReference = false;
 
                 if (paramIndex >= pyArgCount && !(hasNamedParam || (paramsArray && paramIndex == arrayStart)))


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This occured in trying to use F# code from Python. As the `.Name` property returns `null`, `ContainsKey` fails.

### Does this close any currently open issues?

I don't think so.

### Any other comments?

Related documentation: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.parameterinfo.name

I don't know if there is a way to create a C# method without a parameter name. I'll try to set up a few simple F# test-cases in the future in a separate PR (follow-up ticket: #1374).

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
