### PR TITLE
Reworked Enum marshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ when .NET expects an integer [#1342][i1342]
 -   BREAKING: to call Python from .NET `Runtime.PythonDLL` property must be set to Python DLL name
 or the DLL must be loaded in advance. This must be done before calling any other Python.NET functions.
 -   BREAKING: `PyObject.Length()` now raises a `PythonException` when object does not support a concept of length.
+-   BREAKING: disabled implicit conversion from C# enums to Python `int` and back.
+One must now either use enum members (e.g. `MyEnum.Option`), or use enum constructor
+(e.g. `MyEnum(42)` or `MyEnum(42, True)` when `MyEnum` does not have a member with value 42).
 -   Sign Runtime DLL with a strong name
 -   Implement loading through `clr_loader` instead of the included `ClrModule`, enables
     support for .NET Core

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -336,6 +336,14 @@ assert c == (a.Num > b.Num)
         }
 
         [Test]
+        public void EnumOperator()
+        {
+            PythonEngine.Exec($@"
+from System.IO import FileAccess
+c = FileAccess.Read | FileAccess.Write");
+        }
+
+        [Test]
         public void OperatorOverloadMissingArgument()
         {
             string name = string.Format("{0}.{1}",

--- a/src/runtime/Codecs/EnumPyLongCodec.cs
+++ b/src/runtime/Codecs/EnumPyLongCodec.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Python.Runtime.Codecs
+{
+    [Obsolete]
+    public sealed class EnumPyLongCodec : IPyObjectEncoder, IPyObjectDecoder
+    {
+        public static EnumPyLongCodec Instance { get; } = new EnumPyLongCodec();
+
+        public bool CanDecode(PyObject objectType, Type targetType)
+        {
+            return targetType.IsEnum
+                && objectType.IsSubclass(new BorrowedReference(Runtime.PyLongType));
+        }
+
+        public bool CanEncode(Type type)
+        {
+            return type == typeof(object) || type == typeof(ValueType) || type.IsEnum;
+        }
+
+        public bool TryDecode<T>(PyObject pyObj, out T value)
+        {
+            value = default;
+            if (!typeof(T).IsEnum) return false;
+
+            Type etype = Enum.GetUnderlyingType(typeof(T));
+
+            if (!PyLong.IsLongType(pyObj)) return false;
+
+            object result;
+            try
+            {
+                result = pyObj.AsManagedObject(etype);
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+
+            if (Enum.IsDefined(typeof(T), result) || typeof(T).IsFlagsEnum())
+            {
+                value = (T)Enum.ToObject(typeof(T), result);
+                return true;
+            }
+
+            return false;
+        }
+
+        public PyObject TryEncode(object value)
+        {
+            if (value is null) return null;
+
+            var enumType = value.GetType();
+            if (!enumType.IsEnum) return null;
+
+            try
+            {
+                return new PyLong((long)value);
+            }
+            catch (InvalidCastException)
+            {
+                return new PyLong((ulong)value);
+            }
+        }
+
+        private EnumPyLongCodec() { }
+    }
+}

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -403,6 +403,17 @@ namespace Python.Runtime
                 }
             }
 
+            // only [Flags] enums support bitwise operations
+            if (type.IsEnum && type.IsFlagsEnum())
+            {
+                var opsImpl = typeof(EnumOps<>).MakeGenericType(type);
+                foreach (var op in opsImpl.GetMethods(OpsHelper.BindingFlags))
+                {
+                    local[op.Name] = 1;
+                }
+                info = info.Concat(opsImpl.GetMethods(OpsHelper.BindingFlags)).ToArray();
+            }
+
             // Now again to filter w/o losing overloaded member info
             for (i = 0; i < info.Length; i++)
             {

--- a/src/runtime/classobject.cs
+++ b/src/runtime/classobject.cs
@@ -50,8 +50,9 @@ namespace Python.Runtime
         /// <summary>
         /// Implements __new__ for reflected classes and value types.
         /// </summary>
-        public static IntPtr tp_new(IntPtr tp, IntPtr args, IntPtr kw)
+        public static IntPtr tp_new(IntPtr tpRaw, IntPtr args, IntPtr kw)
         {
+            var tp = new BorrowedReference(tpRaw);
             var self = GetManagedObject(tp) as ClassObject;
 
             // Sanity check: this ensures a graceful error if someone does
@@ -87,7 +88,7 @@ namespace Python.Runtime
                     return IntPtr.Zero;
                 }
 
-                return CLRObject.GetInstHandle(result, tp);
+                return CLRObject.GetInstHandle(result, tp).DangerousMoveToPointerOrNull();
             }
 
             if (type.IsAbstract)
@@ -98,8 +99,7 @@ namespace Python.Runtime
 
             if (type.IsEnum)
             {
-                Exceptions.SetError(Exceptions.TypeError, "cannot instantiate enumeration");
-                return IntPtr.Zero;
+                return NewEnum(type, new BorrowedReference(args), tp).DangerousMoveToPointerOrNull();
             }
 
             object obj = self.binder.InvokeRaw(IntPtr.Zero, args, kw);
@@ -108,7 +108,44 @@ namespace Python.Runtime
                 return IntPtr.Zero;
             }
 
-            return CLRObject.GetInstHandle(obj, tp);
+            return CLRObject.GetInstHandle(obj, tp).DangerousMoveToPointerOrNull();
+        }
+
+        private static NewReference NewEnum(Type type, BorrowedReference args, BorrowedReference tp)
+        {
+            nint argCount = Runtime.PyTuple_Size(args);
+            bool allowUnchecked = false;
+            if (argCount == 2)
+            {
+                var allow = Runtime.PyTuple_GetItem(args, 1);
+                if (!Converter.ToManaged(allow, typeof(bool), out var allowObj, true) || allowObj is null)
+                {
+                    Exceptions.RaiseTypeError("second argument to enum constructor must be a boolean");
+                    return default;
+                }
+                allowUnchecked |= (bool)allowObj;
+            }
+
+            if (argCount < 1 || argCount > 2)
+            {
+                Exceptions.SetError(Exceptions.TypeError, "no constructors match given arguments");
+                return default;
+            }
+
+            var op = Runtime.PyTuple_GetItem(args, 0);
+            if (!Converter.ToManaged(op, type.GetEnumUnderlyingType(), out object result, true))
+            {
+                return default;
+            }
+
+            if (!allowUnchecked && !Enum.IsDefined(type, result) && !type.IsFlagsEnum())
+            {
+                Exceptions.SetError(Exceptions.ValueError, "Invalid enumeration value. Pass True as the second argument if unchecked conversion is desired");
+                return default;
+            }
+
+            object enumValue = Enum.ToObject(type, result);
+            return CLRObject.GetInstHandle(enumValue, tp);
         }
 
 

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -27,7 +27,6 @@ namespace Python.Runtime
         private static Type int16Type;
         private static Type int32Type;
         private static Type int64Type;
-        private static Type flagsType;
         private static Type boolType;
         private static Type typeType;
 
@@ -42,7 +41,6 @@ namespace Python.Runtime
             singleType = typeof(Single);
             doubleType = typeof(Double);
             decimalType = typeof(Decimal);
-            flagsType = typeof(FlagsAttribute);
             boolType = typeof(Boolean);
             typeType = typeof(Type);
         }
@@ -148,7 +146,8 @@ namespace Python.Runtime
                 return result;
             }
 
-            if (Type.GetTypeCode(type) == TypeCode.Object && value.GetType() != typeof(object)) {
+            if (Type.GetTypeCode(type) == TypeCode.Object && value.GetType() != typeof(object)
+                || type.IsEnum) {
                 var encoded = PyObjectConversions.TryEncode(value, type);
                 if (encoded != null) {
                     result = encoded.Handle;
@@ -202,6 +201,11 @@ namespace Python.Runtime
             // implementing class.
 
             type = value.GetType();
+
+            if (type.IsEnum)
+            {
+                return CLRObject.GetInstHandle(value, type);
+            }
 
             TypeCode tc = Type.GetTypeCode(type);
 
@@ -317,6 +321,18 @@ namespace Python.Runtime
             }
             return Converter.ToManagedValue(value, type, out result, setError);
         }
+        /// <summary>
+        /// Return a managed object for the given Python object, taking funny
+        /// byref types into account.
+        /// </summary>
+        /// <param name="value">A Python object</param>
+        /// <param name="type">The desired managed type</param>
+        /// <param name="result">Receives the managed object</param>
+        /// <param name="setError">If true, call <c>Exceptions.SetError</c> with the reason for failure.</param>
+        /// <returns>True on success</returns>
+        internal static bool ToManaged(BorrowedReference value, Type type,
+            out object result, bool setError)
+            => ToManaged(value.DangerousGetAddress(), type, out result, setError);
 
         internal static bool ToManagedValue(BorrowedReference value, Type obType,
             out object result, bool setError)
@@ -396,11 +412,6 @@ namespace Python.Runtime
             if (obType.IsArray)
             {
                 return ToArray(value, obType, out result, setError);
-            }
-
-            if (obType.IsEnum)
-            {
-                return ToEnum(value, obType, out result, setError);
             }
 
             // Conversion to 'Object' is done based on some reasonable default
@@ -497,7 +508,7 @@ namespace Python.Runtime
             }
 
             TypeCode typeCode = Type.GetTypeCode(obType);
-            if (typeCode == TypeCode.Object)
+            if (typeCode == TypeCode.Object || obType.IsEnum)
             {
                 IntPtr pyType = Runtime.PyObject_TYPE(value);
                 if (PyObjectConversions.TryDecode(value, pyType, obType, out result))
@@ -516,8 +527,17 @@ namespace Python.Runtime
         /// </summary>
         private static bool ToPrimitive(IntPtr value, Type obType, out object result, bool setError)
         {
-            TypeCode tc = Type.GetTypeCode(obType);
             result = null;
+            if (obType.IsEnum)
+            {
+                if (setError)
+                {
+                    Exceptions.SetError(Exceptions.TypeError, "since Python.NET 3.0 int can not be converted to Enum implicitly. Use Enum(int_value)");
+                }
+                return false;
+            }
+
+            TypeCode tc = Type.GetTypeCode(obType);
             IntPtr op = IntPtr.Zero;
 
             switch (tc)
@@ -875,40 +895,6 @@ namespace Python.Runtime
 
             result = items;
             return true;
-        }
-
-
-        /// <summary>
-        /// Convert a Python value to a correctly typed managed enum instance.
-        /// </summary>
-        private static bool ToEnum(IntPtr value, Type obType, out object result, bool setError)
-        {
-            Type etype = Enum.GetUnderlyingType(obType);
-            result = null;
-
-            if (!ToPrimitive(value, etype, out result, setError))
-            {
-                return false;
-            }
-
-            if (Enum.IsDefined(obType, result))
-            {
-                result = Enum.ToObject(obType, result);
-                return true;
-            }
-
-            if (obType.GetCustomAttributes(flagsType, true).Length > 0)
-            {
-                result = Enum.ToObject(obType, result);
-                return true;
-            }
-
-            if (setError)
-            {
-                Exceptions.SetError(Exceptions.ValueError, "invalid enumeration value");
-            }
-
-            return false;
         }
     }
 

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -340,7 +340,7 @@ namespace Python.Runtime
         public static void warn(string message, IntPtr exception, int stacklevel)
         {
             if (exception == IntPtr.Zero ||
-                (Runtime.PyObject_IsSubclass(exception, Exceptions.Warning) != 1))
+                (Runtime.PyObject_IsSubclass(new BorrowedReference(exception), new BorrowedReference(Exceptions.Warning)) != 1))
             {
                 Exceptions.RaiseTypeError("Invalid exception");
             }

--- a/src/runtime/opshelper.cs
+++ b/src/runtime/opshelper.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using static Python.Runtime.OpsHelper;
+
+namespace Python.Runtime
+{
+    static class OpsHelper
+    {
+        public static BindingFlags BindingFlags => BindingFlags.Public | BindingFlags.Static;
+
+        public static Func<T, T, T> Binary<T>(Func<Expression, Expression, Expression> func)
+        {
+            var a = Expression.Parameter(typeof(T), "a");
+            var b = Expression.Parameter(typeof(T), "b");
+            var body = func(a, b);
+            var lambda = Expression.Lambda<Func<T, T, T>>(body, a, b);
+            return lambda.Compile();
+        }
+
+        public static Func<T, T> Unary<T>(Func<Expression, Expression> func)
+        {
+            var value = Expression.Parameter(typeof(T), "value");
+            var body = func(value);
+            var lambda = Expression.Lambda<Func<T, T>>(body, value);
+            return lambda.Compile();
+        }
+
+        public static bool IsOpsHelper(this MethodBase method)
+            => method.DeclaringType.GetCustomAttribute<OpsAttribute>() is not null;
+
+        public static Expression EnumUnderlyingValue(Expression enumValue)
+            => Expression.Convert(enumValue, enumValue.Type.GetEnumUnderlyingType());
+    }
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    internal class OpsAttribute: Attribute { }
+
+    [Ops]
+    internal static class EnumOps<T> where T : Enum
+    {
+        static readonly Func<T, T, T> and = BinaryOp(Expression.And);
+        static readonly Func<T, T, T> or = BinaryOp(Expression.Or);
+        static readonly Func<T, T, T> xor = BinaryOp(Expression.ExclusiveOr);
+
+        static readonly Func<T, T> invert = UnaryOp(Expression.OnesComplement);
+
+        public static T op_BitwiseAnd(T a, T b) => and(a, b);
+        public static T op_BitwiseOr(T a, T b) => or(a, b);
+        public static T op_ExclusiveOr(T a, T b) => xor(a, b);
+        public static T op_OnesComplement(T value) => invert(value);
+
+        static Expression FromNumber(Expression number)
+            => Expression.Convert(number, typeof(T));
+
+        static Func<T, T, T> BinaryOp(Func<Expression, Expression, BinaryExpression> op)
+        {
+            return Binary<T>((a, b) =>
+            {
+                var numericA = EnumUnderlyingValue(a);
+                var numericB = EnumUnderlyingValue(b);
+                var numericResult = op(numericA, numericB);
+                return FromNumber(numericResult);
+            });
+        }
+        static Func<T, T> UnaryOp(Func<Expression, UnaryExpression> op)
+        {
+            return Unary<T>(value =>
+            {
+                var numeric = EnumUnderlyingValue(value);
+                var numericResult = op(numeric);
+                return FromNumber(numericResult);
+            });
+        }
+    }
+}

--- a/src/runtime/polyfill/ReflectionPolyfills.cs
+++ b/src/runtime/polyfill/ReflectionPolyfills.cs
@@ -30,5 +30,8 @@ namespace Python.Runtime
                 .Cast<T>()
                 .SingleOrDefault();
         }
+
+        public static bool IsFlagsEnum(this Type type)
+            => type.GetCustomAttribute<FlagsAttribute>() is not null;
     }
 }

--- a/src/runtime/pylong.cs
+++ b/src/runtime/pylong.cs
@@ -188,11 +188,8 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// IsLongType Method
-        /// </summary>
-        /// <remarks>
         /// Returns true if the given object is a Python long.
-        /// </remarks>
+        /// </summary>
         public static bool IsLongType(PyObject value)
         {
             return Runtime.PyLong_Check(value.obj);

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -930,17 +930,21 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// IsSubclass Method
-        /// </summary>
-        /// <remarks>
-        /// Return true if the object is identical to or derived from the
+        /// Return <c>true</c> if the object is identical to or derived from the
         /// given Python type or class. This method always succeeds.
-        /// </remarks>
+        /// </summary>
         public bool IsSubclass(PyObject typeOrClass)
         {
             if (typeOrClass == null) throw new ArgumentNullException(nameof(typeOrClass));
 
-            int r = Runtime.PyObject_IsSubclass(obj, typeOrClass.obj);
+            return IsSubclass(typeOrClass.Reference);
+        }
+
+        internal bool IsSubclass(BorrowedReference typeOrClass)
+        {
+            if (typeOrClass.IsNull) throw new ArgumentNullException(nameof(typeOrClass));
+
+            int r = Runtime.PyObject_IsSubclass(Reference, typeOrClass);
             if (r < 0)
             {
                 Runtime.PyErr_Clear();

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1109,7 +1109,7 @@ namespace Python.Runtime
         internal static int PyObject_IsInstance(IntPtr ob, IntPtr type) => Delegates.PyObject_IsInstance(ob, type);
 
 
-        internal static int PyObject_IsSubclass(IntPtr ob, IntPtr type) => Delegates.PyObject_IsSubclass(ob, type);
+        internal static int PyObject_IsSubclass(BorrowedReference ob, BorrowedReference type) => Delegates.PyObject_IsSubclass(ob, type);
 
 
         internal static int PyCallable_Check(IntPtr pointer) => Delegates.PyCallable_Check(pointer);
@@ -2314,7 +2314,7 @@ namespace Python.Runtime
                 PyObject_CallObject = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_CallObject), GetUnmanagedDll(_PythonDll));
                 PyObject_RichCompareBool = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int, int>)GetFunctionByName(nameof(PyObject_RichCompareBool), GetUnmanagedDll(_PythonDll));
                 PyObject_IsInstance = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int>)GetFunctionByName(nameof(PyObject_IsInstance), GetUnmanagedDll(_PythonDll));
-                PyObject_IsSubclass = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int>)GetFunctionByName(nameof(PyObject_IsSubclass), GetUnmanagedDll(_PythonDll));
+                PyObject_IsSubclass = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int>)GetFunctionByName(nameof(PyObject_IsSubclass), GetUnmanagedDll(_PythonDll));
                 PyCallable_Check = (delegate* unmanaged[Cdecl]<IntPtr, int>)GetFunctionByName(nameof(PyCallable_Check), GetUnmanagedDll(_PythonDll));
                 PyObject_IsTrue = (delegate* unmanaged[Cdecl]<BorrowedReference, int>)GetFunctionByName(nameof(PyObject_IsTrue), GetUnmanagedDll(_PythonDll));
                 PyObject_Not = (delegate* unmanaged[Cdecl]<IntPtr, int>)GetFunctionByName(nameof(PyObject_Not), GetUnmanagedDll(_PythonDll));
@@ -2599,7 +2599,7 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr> PyObject_CallObject { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int, int> PyObject_RichCompareBool { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int> PyObject_IsInstance { get; }
-            internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int> PyObject_IsSubclass { get; }
+            internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int> PyObject_IsSubclass { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, int> PyCallable_Check { get; }
             internal static delegate* unmanaged[Cdecl]<BorrowedReference, int> PyObject_IsTrue { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, int> PyObject_Not { get; }

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -680,7 +680,7 @@ def test_enum_array():
     items[-1] = ShortEnum.Zero
     assert items[-1] == ShortEnum.Zero
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ob = Test.EnumArrayTest()
         ob.items[0] = 99
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -601,41 +601,6 @@ def test_object_conversion():
     assert ob.ObjectField == Foo
 
 
-def test_enum_conversion():
-    """Test enum conversion."""
-    from Python.Test import ShortEnum
-
-    ob = ConversionTest()
-    assert ob.EnumField == ShortEnum.Zero
-
-    ob.EnumField = ShortEnum.One
-    assert ob.EnumField == ShortEnum.One
-
-    ob.EnumField = 0
-    assert ob.EnumField == ShortEnum.Zero
-    assert ob.EnumField == 0
-
-    ob.EnumField = 1
-    assert ob.EnumField == ShortEnum.One
-    assert ob.EnumField == 1
-
-    with pytest.raises(ValueError):
-        ob = ConversionTest()
-        ob.EnumField = 10
-
-    with pytest.raises(ValueError):
-        ob = ConversionTest()
-        ob.EnumField = 255
-
-    with pytest.raises(OverflowError):
-        ob = ConversionTest()
-        ob.EnumField = 1000000
-
-    with pytest.raises(TypeError):
-        ob = ConversionTest()
-        ob.EnumField = "spam"
-
-
 def test_null_conversion():
     """Test null conversion."""
     import System

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -22,69 +22,69 @@ def test_enum_get_member():
     """Test access to enum members."""
     from System import DayOfWeek
 
-    assert DayOfWeek.Sunday == 0
-    assert DayOfWeek.Monday == 1
-    assert DayOfWeek.Tuesday == 2
-    assert DayOfWeek.Wednesday == 3
-    assert DayOfWeek.Thursday == 4
-    assert DayOfWeek.Friday == 5
-    assert DayOfWeek.Saturday == 6
+    assert DayOfWeek.Sunday == DayOfWeek(0)
+    assert DayOfWeek.Monday == DayOfWeek(1)
+    assert DayOfWeek.Tuesday == DayOfWeek(2)
+    assert DayOfWeek.Wednesday == DayOfWeek(3)
+    assert DayOfWeek.Thursday == DayOfWeek(4)
+    assert DayOfWeek.Friday == DayOfWeek(5)
+    assert DayOfWeek.Saturday == DayOfWeek(6)
 
 
 def test_byte_enum():
     """Test byte enum."""
-    assert Test.ByteEnum.Zero == 0
-    assert Test.ByteEnum.One == 1
-    assert Test.ByteEnum.Two == 2
+    assert Test.ByteEnum.Zero == Test.ByteEnum(0)
+    assert Test.ByteEnum.One == Test.ByteEnum(1)
+    assert Test.ByteEnum.Two == Test.ByteEnum(2)
 
 
 def test_sbyte_enum():
     """Test sbyte enum."""
-    assert Test.SByteEnum.Zero == 0
-    assert Test.SByteEnum.One == 1
-    assert Test.SByteEnum.Two == 2
+    assert Test.SByteEnum.Zero == Test.SByteEnum(0)
+    assert Test.SByteEnum.One == Test.SByteEnum(1)
+    assert Test.SByteEnum.Two == Test.SByteEnum(2)
 
 
 def test_short_enum():
     """Test short enum."""
-    assert Test.ShortEnum.Zero == 0
-    assert Test.ShortEnum.One == 1
-    assert Test.ShortEnum.Two == 2
+    assert Test.ShortEnum.Zero == Test.ShortEnum(0)
+    assert Test.ShortEnum.One == Test.ShortEnum(1)
+    assert Test.ShortEnum.Two == Test.ShortEnum(2)
 
 
 def test_ushort_enum():
     """Test ushort enum."""
-    assert Test.UShortEnum.Zero == 0
-    assert Test.UShortEnum.One == 1
-    assert Test.UShortEnum.Two == 2
+    assert Test.UShortEnum.Zero == Test.UShortEnum(0)
+    assert Test.UShortEnum.One == Test.UShortEnum(1)
+    assert Test.UShortEnum.Two == Test.UShortEnum(2)
 
 
 def test_int_enum():
     """Test int enum."""
-    assert Test.IntEnum.Zero == 0
-    assert Test.IntEnum.One == 1
-    assert Test.IntEnum.Two == 2
+    assert Test.IntEnum.Zero == Test.IntEnum(0)
+    assert Test.IntEnum.One == Test.IntEnum(1)
+    assert Test.IntEnum.Two == Test.IntEnum(2)
 
 
 def test_uint_enum():
     """Test uint enum."""
-    assert Test.UIntEnum.Zero == 0
-    assert Test.UIntEnum.One == 1
-    assert Test.UIntEnum.Two == 2
+    assert Test.UIntEnum.Zero == Test.UIntEnum(0)
+    assert Test.UIntEnum.One == Test.UIntEnum(1)
+    assert Test.UIntEnum.Two == Test.UIntEnum(2)
 
 
 def test_long_enum():
     """Test long enum."""
-    assert Test.LongEnum.Zero == 0
-    assert Test.LongEnum.One == 1
-    assert Test.LongEnum.Two == 2
+    assert Test.LongEnum.Zero == Test.LongEnum(0)
+    assert Test.LongEnum.One == Test.LongEnum(1)
+    assert Test.LongEnum.Two == Test.LongEnum(2)
 
 
 def test_ulong_enum():
     """Test ulong enum."""
-    assert Test.ULongEnum.Zero == 0
-    assert Test.ULongEnum.One == 1
-    assert Test.ULongEnum.Two == 2
+    assert Test.ULongEnum.Zero == Test.ULongEnum(0)
+    assert Test.ULongEnum.One == Test.ULongEnum(1)
+    assert Test.ULongEnum.Two == Test.ULongEnum(2)
 
 
 def test_instantiate_enum_fails():
@@ -117,29 +117,31 @@ def test_enum_set_member_fails():
         del DayOfWeek.Sunday
 
 
-def test_enum_with_flags_attr_conversion():
+def test_enum_undefined_value():
     """Test enumeration conversion with FlagsAttribute set."""
     # This works because the FlagsField enum has FlagsAttribute.
-    Test.FieldTest().FlagsField = 99
+    Test.FieldTest().FlagsField = Test.FlagsEnum(99)
 
     # This should fail because our test enum doesn't have it.
     with pytest.raises(ValueError):
-        Test.FieldTest().EnumField = 99
-
+        Test.FieldTest().EnumField = Test.ShortEnum(20)
+    
+    # explicitly permit undefined values
+    Test.FieldTest().EnumField = Test.ShortEnum(20, True)
 
 def test_enum_conversion():
     """Test enumeration conversion."""
     ob = Test.FieldTest()
-    assert ob.EnumField == 0
+    assert ob.EnumField == Test.ShortEnum(0)
 
     ob.EnumField = Test.ShortEnum.One
-    assert ob.EnumField == 1
-
-    with pytest.raises(ValueError):
-        Test.FieldTest().EnumField = 20
+    assert ob.EnumField == Test.ShortEnum(1)
 
     with pytest.raises(OverflowError):
-        Test.FieldTest().EnumField = 100000
+        Test.FieldTest().EnumField = Test.ShortEnum(100000)
 
     with pytest.raises(TypeError):
         Test.FieldTest().EnumField = "str"
+    
+    with pytest.raises(TypeError):
+        Test.FieldTest().EnumField = 1

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -400,8 +400,10 @@ def test_enum_indexer():
     ob[key] = "eggs"
     assert ob[key] == "eggs"
 
-    ob[1] = "spam"
-    assert ob[1] == "spam"
+    with pytest.raises(TypeError):
+        ob[1] = "spam"
+    with pytest.raises(TypeError):
+        ob[1]
 
     with pytest.raises(TypeError):
         ob = Test.EnumIndexerTest()


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- enums are no longer converted to and from `PyLong` automatically https://github.com/pythonnet/pythonnet/issues/1220
- one can construct an instance of `MyEnum` from Python using `MyEnum(numeric_val)`, e.g. `MyEnum(10)`
- in the above, if `MyEnum` does not have `[Flags]` and does not have member with value `10` defined, to create `MyEnum` with value `10` one must call `MyEnum(10, True)`. Here `True` is an unnamed parameter, that allows unchecked conversion
- legacy behavior has been moved to a codec: `EnumPyLongCodec`; enums can now be encoded by codecs
- added `EnumOps` class, that implements bitwise operations on `[Flags]` enums.

### Does this close any currently open issues?

#1220

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
