### PR TITLE
Ensure interned strings can not be referenced after InternString.Shutdown

### DIFF
--- a/src/runtime/intern.cs
+++ b/src/runtime/intern.cs
@@ -42,9 +42,10 @@ namespace Python.Runtime
 
         public static void Shutdown()
         {
-            foreach (var ptr in _intern2strings.Keys)
+            foreach (var entry in _intern2strings)
             {
-                Runtime.XDecref(ptr);
+                Runtime.XDecref(entry.Key);
+                typeof(PyIdentifier).GetField(entry.Value).SetValue(null, IntPtr.Zero);
             }
             _string2interns = null;
             _intern2strings = null;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This nulls entries in `PyIdentifier` upon runtime shutdown. If any threads are still executing C# <-> Python interop, they will see NPE instead of generic segfault, which should make it easier to debug.
