### PR TITLE
Adjust static libpython detection

### DIFF
--- a/pythonnet/find_libpython/__init__.py
+++ b/pythonnet/find_libpython/__init__.py
@@ -87,8 +87,11 @@ def _linked_libpython_unix():
         ctypes.pointer(dlinfo))
     if retcode == 0:  # means error
         return None
-    path = os.path.realpath(dlinfo.dli_fname.decode())
-    if path == os.path.realpath(sys.executable):
+    path = dlinfo.dli_fname.decode()
+
+    # Compare basenames only, this should always be enough except for very
+    # pathological cases
+    if os.path.basename(path) == os.path.basename(os.path.realpath(sys.executable)):
         return None
     return path
 

--- a/pythonnet/find_libpython/__init__.py
+++ b/pythonnet/find_libpython/__init__.py
@@ -77,6 +77,9 @@ class Dl_info(ctypes.Structure):
 
 
 def _linked_libpython_unix():
+    if not sysconfig.get_config_var("Py_ENABLE_SHARED"):
+        return None
+
     libdl = ctypes.CDLL(ctypes.util.find_library("dl"))
     libdl.dladdr.argtypes = [ctypes.c_void_p, ctypes.POINTER(Dl_info)]
     libdl.dladdr.restype = ctypes.c_int
@@ -87,12 +90,7 @@ def _linked_libpython_unix():
         ctypes.pointer(dlinfo))
     if retcode == 0:  # means error
         return None
-    path = dlinfo.dli_fname.decode()
-
-    # Compare basenames only, this should always be enough except for very
-    # pathological cases
-    if os.path.basename(path) == os.path.basename(os.path.realpath(sys.executable)):
-        return None
+    path = os.path.realpath(dlinfo.dli_fname.decode())
     return path
 
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Skips checking for a linked libpython.so on Unix unless `Py_ENABLE_SHARED` is set. If it's not set, all symbols are in the base image.

### Does this close any currently open issues?

#1388

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
