### PR TITLE
ImportHook cleanup + PyObject.Length exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ when .NET expects an integer [#1342][i1342]
 -   BREAKING: Methods with `ref` or `out` parameters and void return type return a tuple of only the `ref` and `out` parameters.
 -   BREAKING: to call Python from .NET `Runtime.PythonDLL` property must be set to Python DLL name
 or the DLL must be loaded in advance. This must be done before calling any other Python.NET functions.
+-   BREAKING: `PyObject.Length()` now raises a `PythonException` when object does not support a concept of length.
 -   Sign Runtime DLL with a strong name
 -   Implement loading through `clr_loader` instead of the included `ClrModule`, enables
     support for .NET Core

--- a/src/embed_tests/pyimport.cs
+++ b/src/embed_tests/pyimport.cs
@@ -34,7 +34,9 @@ namespace Python.EmbeddingTest
             TestContext.Out.WriteLine(testPath);
 
             IntPtr str = Runtime.Runtime.PyString_FromString(testPath);
+            Assert.IsFalse(str == IntPtr.Zero);
             BorrowedReference path = Runtime.Runtime.PySys_GetObject("path");
+            Assert.IsFalse(path.IsNull);
             Runtime.Runtime.PyList_Append(path, str);
             Runtime.Runtime.XDecref(str);
         }

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -61,6 +61,13 @@ namespace Python.Runtime
         {
             IntPtr builtins = Runtime.GetBuiltins();
 
+            IntPtr existing = Runtime.PyObject_GetAttr(builtins, PyIdentifier.__import__);
+            Runtime.XDecref(existing);
+            if (existing != hook.ptr)
+            {
+                throw new NotSupportedException("Unable to restore original __import__.");
+            }
+
             int res = Runtime.PyObject_SetAttr(builtins, PyIdentifier.__import__, py_import);
             PythonException.ThrowIfIsNotZero(res);
             Runtime.XDecref(py_import);
@@ -374,6 +381,8 @@ namespace Python.Runtime
 
         private static bool IsLoadAll(BorrowedReference fromList)
         {
+            if (fromList == null) throw new ArgumentNullException(nameof(fromList));
+
             if (CLRModule.preload)
             {
                 return false;

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -95,7 +95,7 @@ namespace Python.Runtime
 
             // both dicts are borrowed references
             BorrowedReference mod_dict = Runtime.PyModule_GetDict(ClrModuleReference);
-            BorrowedReference clr_dict = *Runtime._PyObject_GetDictPtr(root.ObjectReference);
+            using var clr_dict = Runtime.PyObject_GenericGetDict(root.ObjectReference);
 
             Runtime.PyDict_Update(mod_dict, clr_dict);
             BorrowedReference dict = Runtime.PyImport_GetModuleDict();
@@ -157,8 +157,10 @@ namespace Python.Runtime
             // update the module dictionary with the contents of the root dictionary
             root.LoadNames();
             BorrowedReference py_mod_dict = Runtime.PyModule_GetDict(ClrModuleReference);
-            BorrowedReference clr_dict = *Runtime._PyObject_GetDictPtr(root.ObjectReference);
-            Runtime.PyDict_Update(py_mod_dict, clr_dict);
+            using (var clr_dict = Runtime.PyObject_GenericGetDict(root.ObjectReference))
+            {
+                Runtime.PyDict_Update(py_mod_dict, clr_dict);
+            }
 
             // find any items from the from list and get them from the root if they're not
             // already in the module dictionary

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -259,7 +259,6 @@ namespace Python.Runtime
             }
 
             string realname = mod_name;
-            string clr_prefix = null;
 
             // 2010-08-15: Always seemed smart to let python try first...
             // This shaves off a few tenths of a second on test_module.py
@@ -317,10 +316,7 @@ namespace Python.Runtime
                     }
                     return new NewReference(module).DangerousMoveToPointer();
                 }
-                if (clr_prefix != null)
-                {
-                    return GetCLRModule(fromList).DangerousMoveToPointerOrNull();
-                }
+
                 module = Runtime.PyDict_GetItemString(modules, names[0]);
                 return new NewReference(module, canBeNull: true).DangerousMoveToPointer();
             }
@@ -360,12 +356,6 @@ namespace Python.Runtime
 
                 // Add the module to sys.modules
                 Runtime.PyDict_SetItemString(modules, tail.moduleName, tail.ObjectReference);
-
-                // If imported from CLR add clr.<modulename> to sys.modules as well
-                if (clr_prefix != null)
-                {
-                    Runtime.PyDict_SetItemString(modules, clr_prefix + tail.moduleName, tail.ObjectReference);
-                }
             }
 
             {

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -615,19 +615,15 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// Length Method
-        /// </summary>
-        /// <remarks>
         /// Returns the length for objects that support the Python sequence
-        /// protocol, or 0 if the object does not support the protocol.
-        /// </remarks>
+        /// protocol.
+        /// </summary>
         public virtual long Length()
         {
-            var s = Runtime.PyObject_Size(obj);
+            var s = Runtime.PyObject_Size(Reference);
             if (s < 0)
             {
-                Runtime.PyErr_Clear();
-                return 0;
+                throw new PythonException();
             }
             return s;
         }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1115,13 +1115,7 @@ namespace Python.Runtime
 
         internal static int PyObject_Not(IntPtr pointer) => Delegates.PyObject_Not(pointer);
 
-        internal static long PyObject_Size(IntPtr pointer)
-        {
-            return (long)_PyObject_Size(pointer);
-        }
-
-
-        private static IntPtr _PyObject_Size(IntPtr pointer) => Delegates._PyObject_Size(pointer);
+        internal static nint PyObject_Size(BorrowedReference pointer) => Delegates.PyObject_Size(pointer);
 
 
         internal static nint PyObject_Hash(IntPtr op) => Delegates.PyObject_Hash(op);
@@ -2317,7 +2311,7 @@ namespace Python.Runtime
                 PyCallable_Check = (delegate* unmanaged[Cdecl]<IntPtr, int>)GetFunctionByName(nameof(PyCallable_Check), GetUnmanagedDll(_PythonDll));
                 PyObject_IsTrue = (delegate* unmanaged[Cdecl]<BorrowedReference, int>)GetFunctionByName(nameof(PyObject_IsTrue), GetUnmanagedDll(_PythonDll));
                 PyObject_Not = (delegate* unmanaged[Cdecl]<IntPtr, int>)GetFunctionByName(nameof(PyObject_Not), GetUnmanagedDll(_PythonDll));
-                _PyObject_Size = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName("PyObject_Size", GetUnmanagedDll(_PythonDll));
+                PyObject_Size = (delegate* unmanaged[Cdecl]<BorrowedReference, nint>)GetFunctionByName("PyObject_Size", GetUnmanagedDll(_PythonDll));
                 PyObject_Hash = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_Hash), GetUnmanagedDll(_PythonDll));
                 PyObject_Repr = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_Repr), GetUnmanagedDll(_PythonDll));
                 PyObject_Str = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_Str), GetUnmanagedDll(_PythonDll));
@@ -2589,7 +2583,7 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<IntPtr, int> PyCallable_Check { get; }
             internal static delegate* unmanaged[Cdecl]<BorrowedReference, int> PyObject_IsTrue { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, int> PyObject_Not { get; }
-            internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> _PyObject_Size { get; }
+            internal static delegate* unmanaged[Cdecl]<BorrowedReference, nint> PyObject_Size { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Hash { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Repr { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Str { get; }

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -2016,9 +2016,8 @@ namespace Python.Runtime
 
         internal static int PyObject_GenericSetAttr(IntPtr obj, IntPtr name, IntPtr value) => Delegates.PyObject_GenericSetAttr(obj, name, value);
 
-
-        internal static BorrowedReference* _PyObject_GetDictPtr(BorrowedReference obj) => Delegates._PyObject_GetDictPtr(obj);
-
+        internal static NewReference PyObject_GenericGetDict(BorrowedReference o) => PyObject_GenericGetDict(o, IntPtr.Zero);
+        internal static NewReference PyObject_GenericGetDict(BorrowedReference o, IntPtr context) => Delegates.PyObject_GenericGetDict(o, context);
 
         internal static void PyObject_GC_Del(IntPtr tp) => Delegates.PyObject_GC_Del(tp);
 
@@ -2466,8 +2465,8 @@ namespace Python.Runtime
                 PyType_Ready = (delegate* unmanaged[Cdecl]<IntPtr, int>)GetFunctionByName(nameof(PyType_Ready), GetUnmanagedDll(_PythonDll));
                 _PyType_Lookup = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)GetFunctionByName(nameof(_PyType_Lookup), GetUnmanagedDll(_PythonDll));
                 PyObject_GenericGetAttr = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_GenericGetAttr), GetUnmanagedDll(_PythonDll));
+                PyObject_GenericGetDict = (delegate* unmanaged[Cdecl]<BorrowedReference, IntPtr, NewReference>)GetFunctionByName(nameof(PyObject_GenericGetDict), GetUnmanagedDll(PythonDLL));
                 PyObject_GenericSetAttr = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, int>)GetFunctionByName(nameof(PyObject_GenericSetAttr), GetUnmanagedDll(_PythonDll));
-                _PyObject_GetDictPtr = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference*>)GetFunctionByName(nameof(_PyObject_GetDictPtr), GetUnmanagedDll(_PythonDll));
                 PyObject_GC_Del = (delegate* unmanaged[Cdecl]<IntPtr, void>)GetFunctionByName(nameof(PyObject_GC_Del), GetUnmanagedDll(_PythonDll));
                 PyObject_GC_Track = (delegate* unmanaged[Cdecl]<IntPtr, void>)GetFunctionByName(nameof(PyObject_GC_Track), GetUnmanagedDll(_PythonDll));
                 PyObject_GC_UnTrack = (delegate* unmanaged[Cdecl]<IntPtr, void>)GetFunctionByName(nameof(PyObject_GC_UnTrack), GetUnmanagedDll(_PythonDll));
@@ -2732,7 +2731,6 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr> _PyType_Lookup { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr> PyObject_GenericGetAttr { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, int> PyObject_GenericSetAttr { get; }
-            internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference*> _PyObject_GetDictPtr { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, void> PyObject_GC_Del { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, void> PyObject_GC_Track { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, void> PyObject_GC_UnTrack { get; }
@@ -2769,6 +2767,7 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, void> PyException_SetCause { get; }
             internal static delegate* unmanaged[Cdecl]<uint, IntPtr, int> PyThreadState_SetAsyncExcLLP64 { get; }
             internal static delegate* unmanaged[Cdecl]<ulong, IntPtr, int> PyThreadState_SetAsyncExcLP64 { get; }
+            internal static delegate* unmanaged[Cdecl]<BorrowedReference, IntPtr, NewReference> PyObject_GenericGetDict { get; }
         }
     }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

#### Import
- adds validation to `PyImportTest`
- before restoring original `__import__`, validates, that `__import__` was not replaced by a third party (only in `DEBUG` build)
- drops unsupported `_PyObject_GetDictPtr` in favor of `PyObject_GenericGetDict`

#### PyObject
- `Length()` method now raises an exception when object does not support concept of length (was returning 0).