### PR TITLE
Adjust static libpython detection

### DIFF
--- a/pythonnet/find_libpython/__init__.py
+++ b/pythonnet/find_libpython/__init__.py
@@ -91,6 +91,11 @@ def _linked_libpython_unix():
     if retcode == 0:  # means error
         return None
     path = os.path.realpath(dlinfo.dli_fname.decode())
+
+    # Compare basenames only, this should always be enough except for very
+    # pathological cases
+    if os.path.basename(path) == os.path.basename(os.path.realpath(sys.executable)):
+        return None
     return path
 
 


### PR DESCRIPTION
`dladdr` may only return the basename of the executable image, so we have to adjust the lookup accordingly.

### What does this implement/fix? Explain your changes.

Second attempt (first was #1396), but just checking `Py_ENABLE_SHARED` is not enough.

### Does this close any currently open issues?

#1388

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
