### PR TITLE
Fix exception refcnt

### DIFF
--- a/src/domain_tests/test_domain_reload.py
+++ b/src/domain_tests/test_domain_reload.py
@@ -56,7 +56,6 @@ def test_property_visibility_change():
 def test_class_visibility_change():
     _run_test("class_visibility_change")
 
-@pytest.mark.skip(reason='FIXME: Domain reload fails when Python points to a .NET object which points back to Python objects')
 def test_method_parameters_change():
     _run_test("method_parameters_change")
 

--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -517,5 +517,11 @@ namespace Python.Runtime
 
             return 0;
         }
+
+        public override string ToString()
+        {
+            return $"<ClassBase of {type}>";
+        }
+
     }
 }

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -106,7 +106,7 @@ namespace Python.Runtime
 
         public override string ToString()
         {
-            return $"<CLRObject wrapping {inst}>";
+            return $"<CLRObject: {inst}>";
         }
     }
 }

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -103,5 +103,10 @@ namespace Python.Runtime
             GCHandle gc = AllocGCHandle(TrackTypes.Wrapper);
             Marshal.WriteIntPtr(pyHandle, ObjectOffset.magic(tpHandle), (IntPtr)gc);
         }
+
+        public override string ToString()
+        {
+            return $"<CLRObject wrapping {inst}>";
+        }
     }
 }

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -89,8 +89,11 @@ namespace Python.Runtime
         static void ClearOffsetHelper(IntPtr ob, int offset)
         {
             var field = Marshal.ReadIntPtr(ob, offset);
-            Runtime.XDecref(field);
-            Marshal.WriteIntPtr(ob, offset, IntPtr.Zero);
+            if (field != IntPtr.Zero)
+            {
+                Marshal.WriteIntPtr(ob, offset, IntPtr.Zero);
+                Runtime.XDecref(field);
+            }
         }
 
         // As seen in exceptions.c, every derived type must also clean the base.

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -368,6 +368,7 @@ namespace Python.Runtime
                 }
 
                 Runtime.XIncref(mod.pyHandle);
+                originalException.Dispose();
                 return mod.pyHandle;
             }
         }

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -166,7 +166,16 @@ namespace Python.Runtime
             {
                 if (Exceptions.ErrorOccurred()) throw new InvalidOperationException("Cannot normalize when an error is set");
                 // If an error is set and this PythonException is unnormalized, the error will be cleared and the PythonException will be replaced by a different error.
+                IntPtr oldValue = _pyValue;
                 Runtime.PyErr_NormalizeException(ref _pyType, ref _pyValue, ref _pyTB);
+
+                if (_pyValue != oldValue) 
+                {
+                    // we own the reference to _pyValue, so make adjustments if it changed.
+                    // Disown old, own new
+                    Runtime.XDecref(oldValue);
+                    Runtime.XIncref(_pyValue);
+                }
             }
             finally
             {

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -166,16 +166,7 @@ namespace Python.Runtime
             {
                 if (Exceptions.ErrorOccurred()) throw new InvalidOperationException("Cannot normalize when an error is set");
                 // If an error is set and this PythonException is unnormalized, the error will be cleared and the PythonException will be replaced by a different error.
-                IntPtr oldValue = _pyValue;
                 Runtime.PyErr_NormalizeException(ref _pyType, ref _pyValue, ref _pyTB);
-
-                if (_pyValue != oldValue) 
-                {
-                    // we own the reference to _pyValue, so make adjustments if it changed.
-                    // Disown old, own new
-                    Runtime.XDecref(oldValue);
-                    Runtime.XIncref(_pyValue);
-                }
             }
             finally
             {

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -429,7 +429,8 @@ def leak_test(func):
         orig_exc = {x for x in get_all_objects() if isinstance(x, Exception)}
         func()
         exc = {x for x in get_all_objects() if isinstance(x, Exception)}
-        assert not exc - orig_exc
+        possibly_leaked = exc - orig_exc
+        assert not possibly_leaked
     
     return do_test_leak
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds a tp_dealloc function to ExceptionClassObject, so we clean the BaseException members the same way as other the derived exceptions in the cpython code does.

### Does this close any currently open issues?

Fixes issue #1371.

### Any other comments?

Fixes a bug where C# Exceptions set as the Inner of another C# Exception, then converted into a Python exception object (and thus having `__cause__` set to a valid object) would leak the `Inner`/`__cause__` objects.

Simplified diagram :
```
AggregateException.Inner        -> ArgumentException(...)
      ^                                    ^
      |                                    |
PyAggregateException.__cause__  -> PyArgumentException
```
In this case, where the AggregateException would be thrown from C# and caught in Python, the AggregateException and PyAggregateException would be freed, but not the ArgumentException set as the cause.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
