### PR TITLE
Suggest to set Runtime.PythonDLL when embedding in .NET

### DIFF
--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -2518,7 +2518,19 @@ namespace Python.Runtime
             }
 
             static global::System.IntPtr GetFunctionByName(string functionName, global::System.IntPtr libraryHandle)
-                => libraryLoader.GetFunction(libraryHandle, functionName);
+            {
+                try
+                {
+                    return libraryLoader.GetFunction(libraryHandle, functionName);
+                }
+                catch (MissingMethodException e) when (libraryHandle == IntPtr.Zero)
+                {
+                    throw new MissingMethodException(
+                        "Did you forget to set Runtime.PythonDLL?" +
+                        " See https://github.com/pythonnet/pythonnet#embedding-python-in-net",
+                        e);
+                }
+            }
 
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyDictProxy_New { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, void> Py_IncRef { get; }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When `Runtime.PythonDLL` is not set, which causes `Runtime.Delegates` class to fail initialization, suggest setting `Runtime.PythonDLL` in the error message.

### Does this close any currently open issues?

Hopefully, https://github.com/pythonnet/pythonnet/issues/1410 and the likes
