### PR TITLE
Prevent stack overflow when an encoder is registered from Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ One must now either use enum members (e.g. `MyEnum.Option`), or use enum constru
 -   Sign Runtime DLL with a strong name
 -   Implement loading through `clr_loader` instead of the included `ClrModule`, enables
     support for .NET Core
+-   BREAKING: custom encoders are no longer called for instances of `System.Type`
 
 ### Fixed
 

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -298,6 +298,7 @@ namespace Python.EmbeddingTest {
         }
 
         // regression for https://github.com/pythonnet/pythonnet/issues/1427
+        [Ignore("https://github.com/pythonnet/pythonnet/issues/1256")]
         [Test]
         public void PythonRegisteredDecoder_NoStackOverflowOnSystemType()
         {

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -296,6 +296,31 @@ namespace Python.EmbeddingTest {
             Assert.DoesNotThrow(() => { codec.TryDecode(pyList, out intEnumerable); });
             CollectionAssert.AreEqual(intEnumerable, new List<object> { 1, 2, 3 });
         }
+
+        // regression for https://github.com/pythonnet/pythonnet/issues/1427
+        [Test]
+        public void PythonRegisteredDecoder_NoStackOverflowOnSystemType()
+        {
+            const string PyCode = @"
+import clr
+import System
+from Python.Runtime import PyObjectConversions
+from Python.Runtime.Codecs import RawProxyEncoder
+
+
+class ListAsRawEncoder(RawProxyEncoder):
+    __namespace__ = 'Dummy'
+    def CanEncode(self, clr_type):
+        return clr_type.Name == 'IList`1' and clr_type.Namespace == 'System.Collections.Generic'
+
+
+list_encoder = ListAsRawEncoder()
+PyObjectConversions.RegisterEncoder(list_encoder)
+
+system_type = list_encoder.GetType()";
+
+            PythonEngine.Exec(PyCode);
+        }
     }
 
     /// <summary>

--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -146,8 +146,11 @@ namespace Python.Runtime
                 return result;
             }
 
-            if (Type.GetTypeCode(type) == TypeCode.Object && value.GetType() != typeof(object)
-                || type.IsEnum) {
+            if (Type.GetTypeCode(type) == TypeCode.Object
+                && value.GetType() != typeof(object)
+                && value is not Type
+                || type.IsEnum
+            ) {
                 var encoded = PyObjectConversions.TryEncode(value, type);
                 if (encoded != null) {
                     result = encoded.Handle;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This disables ability to register encoders for `System.Type`.

Without this restriction encoders created in Python cause stack overflow due to repeated attempts to pass `System.Type` instance to `CanDecode`, which requires encoding the instance of `System.Type`.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1427

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
