### PR TITLE
Use PyType instances instead of raw pointers

### DIFF
--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -373,7 +373,7 @@ namespace Python.Runtime
         protected override void OnSave(InterDomainContext context)
         {
             base.OnSave(context);
-            if (pyHandle != tpHandle)
+            if (!this.IsClrMetaTypeInstance())
             {
                 IntPtr dict = GetObjectDict(pyHandle);
                 Runtime.XIncref(dict);
@@ -384,7 +384,7 @@ namespace Python.Runtime
         protected override void OnLoad(InterDomainContext context)
         {
             base.OnLoad(context);
-            if (pyHandle != tpHandle)
+            if (!this.IsClrMetaTypeInstance())
             {
                 IntPtr dict = context.Storage.GetValue<IntPtr>("dict");
                 SetObjectDict(pyHandle, dict);

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -122,11 +122,13 @@ namespace Python.Runtime
         /// </summary>
         internal static Type CreateDerivedType(string name,
             Type baseType,
-            IntPtr py_dict,
+            BorrowedReference dictRef,
             string namespaceStr,
             string assemblyName,
             string moduleName = "Python.Runtime.Dynamic.dll")
         {
+            // TODO: clean up
+            IntPtr py_dict = dictRef.DangerousGetAddress();
             if (null != namespaceStr)
             {
                 name = namespaceStr + "." + name;
@@ -824,7 +826,7 @@ namespace Python.Runtime
             try
             {
                 // create the python object
-                IntPtr type = TypeManager.GetTypeHandle(obj.GetType());
+                BorrowedReference type = TypeManager.GetTypeReference(obj.GetType());
                 self = new CLRObject(obj, type);
 
                 // set __pyobj__ to self and deref the python object which will allow this

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -117,7 +117,7 @@ namespace Python.Runtime
                 // Python object's dictionary tool; thus raising an AttributeError
                 // instead of a TypeError.
                 // Classes are re-initialized on in RestoreRuntimeData.
-                var dict = new BorrowedReference(Marshal.ReadIntPtr(cls.Value.tpHandle, TypeOffset.tp_dict));
+                using var dict = Runtime.PyObject_GenericGetDict(cls.Value.TypeReference);
                 foreach (var member in cls.Value.dotNetMembers)
                 {
                     // No need to decref the member, the ClassBase instance does 
@@ -135,7 +135,7 @@ namespace Python.Runtime
                     }
                 }
                 // We modified the Type object, notify it we did.
-                Runtime.PyType_Modified(cls.Value.tpHandle);
+                Runtime.PyType_Modified(cls.Value.TypeReference);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Python.Runtime
                 // re-init the class
                 InitClassBase(pair.Key.Value, pair.Value);
                 // We modified the Type object, notify it we did.
-                Runtime.PyType_Modified(pair.Value.tpHandle);
+                Runtime.PyType_Modified(pair.Value.TypeReference);
                 var context = contexts[pair.Value.pyHandle];
                 pair.Value.Load(context);
                 loadedObjs.Add(pair.Value, context);
@@ -266,10 +266,10 @@ namespace Python.Runtime
             // point to the managed methods providing the implementation.
 
 
-            IntPtr tp = TypeManager.GetTypeHandle(impl, type);
+            var pyType = TypeManager.GetType(impl, type);
 
             // Finally, initialize the class __dict__ and return the object.
-            var dict = new BorrowedReference(Marshal.ReadIntPtr(tp, TypeOffset.tp_dict));
+            using var dict = Runtime.PyObject_GenericGetDict(pyType.Reference);
 
 
             if (impl.dotNetMembers == null)
@@ -312,7 +312,7 @@ namespace Python.Runtime
                     // Implement Overloads on the class object
                     if (!CLRModule._SuppressOverloads)
                     {
-                        var ctors = new ConstructorBinding(type, tp, co.binder);
+                        var ctors = new ConstructorBinding(type, pyType, co.binder);
                         // ExtensionType types are untracked, so don't Incref() them.
                         // TODO: deprecate __overloads__ soon...
                         Runtime.PyDict_SetItem(dict, PyIdentifier.__overloads__, ctors.ObjectReference);
@@ -332,7 +332,7 @@ namespace Python.Runtime
 
             // The type has been modified after PyType_Ready has been called
             // Refresh the type
-            Runtime.PyType_Modified(tp);
+            Runtime.PyType_Modified(pyType.Reference);
         }
 
         internal static bool ShouldBindMethod(MethodBase mb)

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -26,6 +26,8 @@ namespace Python.Runtime
             if (ob is Exception e) Exceptions.SetArgsAndCause(e, py);
         }
 
+        internal CLRObject(object ob, BorrowedReference tp) : this(ob, tp.DangerousGetAddress()) { }
+
         protected CLRObject()
         {
         }

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -206,6 +206,15 @@ namespace Python.Runtime
             }
         }
 
+        internal static IntPtr ErrorCheckIfNull(IntPtr pointer)
+        {
+            if (pointer == IntPtr.Zero && ErrorOccurred())
+            {
+                throw new PythonException();
+            }
+            return pointer;
+        }
+
         /// <summary>
         /// ExceptionMatches Method
         /// </summary>

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -18,7 +18,7 @@ namespace Python.Runtime
             // The Python instance object is related to an instance of a
             // particular concrete subclass with a hidden CLR gchandle.
 
-            IntPtr tp = TypeManager.GetTypeHandle(GetType());
+            BorrowedReference tp = TypeManager.GetTypeReference(GetType());
 
             //int rc = (int)Marshal.ReadIntPtr(tp, TypeOffset.ob_refcnt);
             //if (rc > 1050)
@@ -27,11 +27,11 @@ namespace Python.Runtime
             //    DebugUtil.DumpType(tp);
             //}
 
-            IntPtr py = Runtime.PyType_GenericAlloc(tp, 0);
+            NewReference py = Runtime.PyType_GenericAlloc(tp, 0);
 
-            // Steals a ref to tpHandle.
-            tpHandle = tp;
-            pyHandle = py;
+            // Borrowed reference. Valid as long as pyHandle is valid.
+            tpHandle = tp.DangerousGetAddress();
+            pyHandle = py.DangerousMoveToPointer();
 
 #if DEBUG
             GetGCHandle(ObjectReference, TypeReference, out var existing);

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -27,8 +28,8 @@ namespace Python.Runtime
         internal IntPtr pyHandle; // PyObject *
         internal IntPtr tpHandle; // PyType *
 
-        internal BorrowedReference ObjectReference => new BorrowedReference(pyHandle);
-        internal BorrowedReference TypeReference => new BorrowedReference(tpHandle);
+        internal BorrowedReference ObjectReference => new(pyHandle);
+        internal BorrowedReference TypeReference => new(tpHandle);
 
         private static readonly Dictionary<ManagedType, TrackTypes> _managedObjs = new Dictionary<ManagedType, TrackTypes>();
 
@@ -78,12 +79,12 @@ namespace Python.Runtime
             }
         }
 
-        internal static ManagedType GetManagedObject(BorrowedReference ob)
+        internal static ManagedType? GetManagedObject(BorrowedReference ob)
             => GetManagedObject(ob.DangerousGetAddress());
         /// <summary>
         /// Given a Python object, return the associated managed object or null.
         /// </summary>
-        internal static ManagedType GetManagedObject(IntPtr ob)
+        internal static ManagedType? GetManagedObject(IntPtr ob)
         {
             if (ob != IntPtr.Zero)
             {
@@ -106,7 +107,7 @@ namespace Python.Runtime
         /// <summary>
         /// Given a Python object, return the associated managed object type or null.
         /// </summary>
-        internal static ManagedType GetManagedObjectType(IntPtr ob)
+        internal static ManagedType? GetManagedObjectType(IntPtr ob)
         {
             if (ob != IntPtr.Zero)
             {
@@ -120,18 +121,6 @@ namespace Python.Runtime
             }
             return null;
         }
-
-
-        internal static ManagedType GetManagedObjectErr(IntPtr ob)
-        {
-            ManagedType result = GetManagedObject(ob);
-            if (result == null)
-            {
-                Exceptions.SetError(Exceptions.TypeError, "invalid argument, expected CLR type");
-            }
-            return result;
-        }
-
 
         internal static bool IsInstanceOfManagedType(BorrowedReference ob)
             => IsInstanceOfManagedType(ob.DangerousGetAddressOrNull());
@@ -154,6 +143,13 @@ namespace Python.Runtime
         {
             var flags = (TypeFlags)Util.ReadCLong(type.DangerousGetAddress(), TypeOffset.tp_flags);
             return (flags & TypeFlags.HasClrInstance) != 0;
+        }
+
+        public bool IsClrMetaTypeInstance()
+        {
+            Debug.Assert(Runtime.PyCLRMetaType != IntPtr.Zero);
+            Debug.Assert(pyHandle != IntPtr.Zero);
+            return Runtime.PyObject_TYPE(pyHandle) == Runtime.PyCLRMetaType;
         }
 
         internal static IDictionary<ManagedType, TrackTypes> GetManagedObjects()
@@ -185,7 +181,8 @@ namespace Python.Runtime
             {
                 return;
             }
-            var clearPtr = Marshal.ReadIntPtr(tpHandle, TypeOffset.tp_clear);
+
+            var clearPtr = Runtime.PyType_GetSlot(TypeReference, TypeSlotID.tp_clear);
             if (clearPtr == IntPtr.Zero)
             {
                 return;
@@ -203,7 +200,7 @@ namespace Python.Runtime
             {
                 return;
             }
-            var traversePtr = Marshal.ReadIntPtr(tpHandle, TypeOffset.tp_traverse);
+            var traversePtr = Runtime.PyType_GetSlot(TypeReference, TypeSlotID.tp_traverse);
             if (traversePtr == IntPtr.Zero)
             {
                 return;

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -132,7 +132,7 @@ namespace Python.Runtime
                 {
                     if (clsDict.HasKey("__assembly__") || clsDict.HasKey("__namespace__"))
                     {
-                        return TypeManager.CreateSubType(name, base_type, dict);
+                        return TypeManager.CreateSubType(name, base_type, clsDict.Reference);
                     }
                 }
             }
@@ -266,7 +266,7 @@ namespace Python.Runtime
             }
 
             int res = Runtime.PyObject_GenericSetAttr(tp, name, value);
-            Runtime.PyType_Modified(tp);
+            Runtime.PyType_Modified(new BorrowedReference(tp));
 
             return res;
         }

--- a/src/runtime/pytype.cs
+++ b/src/runtime/pytype.cs
@@ -6,6 +6,7 @@ using Python.Runtime.Native;
 
 namespace Python.Runtime
 {
+    [Serializable]
     public class PyType : PyObject
     {
         /// <summary>Creates heap type object from the <paramref name="spec"/>.</summary>
@@ -13,12 +14,24 @@ namespace Python.Runtime
         /// <summary>Wraps an existing type object.</summary>
         public PyType(PyObject o) : base(FromObject(o)) { }
 
+        internal PyType(BorrowedReference reference) : base(reference)
+        {
+            if (!Runtime.PyType_Check(this.Handle))
+                throw new ArgumentException("object is not a type");
+        }
+
         /// <summary>Checks if specified object is a Python type.</summary>
         public static bool IsType(PyObject value)
         {
             if (value is null) throw new ArgumentNullException(nameof(value));
 
             return Runtime.PyType_Check(value.obj);
+        }
+
+        internal IntPtr GetSlot(TypeSlotID slot)
+        {
+            IntPtr result = Runtime.PyType_GetSlot(this.Reference, slot);
+            return Exceptions.ErrorCheckIfNull(result);
         }
 
         private static BorrowedReference FromObject(PyObject o)

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1991,7 +1991,7 @@ namespace Python.Runtime
         }
 
 
-        internal static void PyType_Modified(IntPtr type) => Delegates.PyType_Modified(type);
+        internal static void PyType_Modified(BorrowedReference type) => Delegates.PyType_Modified(type);
         internal static bool PyType_IsSubtype(BorrowedReference t1, IntPtr ofType)
             => PyType_IsSubtype(t1, new BorrowedReference(ofType));
         internal static bool PyType_IsSubtype(BorrowedReference t1, BorrowedReference t2) => Delegates.PyType_IsSubtype(t1, t2);
@@ -2014,14 +2014,10 @@ namespace Python.Runtime
 
         internal static IntPtr PyType_GenericNew(IntPtr type, IntPtr args, IntPtr kw) => Delegates.PyType_GenericNew(type, args, kw);
 
-        internal static IntPtr PyType_GenericAlloc(IntPtr type, long n)
-        {
-            return PyType_GenericAlloc(type, new IntPtr(n));
-        }
+        internal static IntPtr PyType_GenericAlloc(IntPtr type, nint n) => PyType_GenericAlloc(new BorrowedReference(type), n).DangerousMoveToPointer();
+        internal static NewReference PyType_GenericAlloc(BorrowedReference type, nint n) => Delegates.PyType_GenericAlloc(type, n);
 
-
-        private static IntPtr PyType_GenericAlloc(IntPtr type, IntPtr n) => Delegates.PyType_GenericAlloc(type, n);
-        
+        internal static IntPtr PyType_GetSlot(BorrowedReference type, TypeSlotID slot) => Delegates.PyType_GetSlot(type, slot);
         internal static NewReference PyType_FromSpecWithBases(in NativeTypeSpec spec, BorrowedReference bases) => Delegates.PyType_FromSpecWithBases(in spec, bases);
 
         /// <summary>
@@ -2489,10 +2485,10 @@ namespace Python.Runtime
                 PySys_SetArgvEx = (delegate* unmanaged[Cdecl]<int, IntPtr, int, void>)GetFunctionByName(nameof(PySys_SetArgvEx), GetUnmanagedDll(_PythonDll));
                 PySys_GetObject = (delegate* unmanaged[Cdecl]<StrPtr, BorrowedReference>)GetFunctionByName(nameof(PySys_GetObject), GetUnmanagedDll(_PythonDll));
                 PySys_SetObject = (delegate* unmanaged[Cdecl]<StrPtr, BorrowedReference, int>)GetFunctionByName(nameof(PySys_SetObject), GetUnmanagedDll(_PythonDll));
-                PyType_Modified = (delegate* unmanaged[Cdecl]<IntPtr, void>)GetFunctionByName(nameof(PyType_Modified), GetUnmanagedDll(_PythonDll));
+                PyType_Modified = (delegate* unmanaged[Cdecl]<BorrowedReference, void>)GetFunctionByName(nameof(PyType_Modified), GetUnmanagedDll(_PythonDll));
                 PyType_IsSubtype = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, bool>)GetFunctionByName(nameof(PyType_IsSubtype), GetUnmanagedDll(_PythonDll));
                 PyType_GenericNew = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr>)GetFunctionByName(nameof(PyType_GenericNew), GetUnmanagedDll(_PythonDll));
-                PyType_GenericAlloc = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)GetFunctionByName(nameof(PyType_GenericAlloc), GetUnmanagedDll(_PythonDll));
+                PyType_GenericAlloc = (delegate* unmanaged[Cdecl]<BorrowedReference, nint, NewReference>)GetFunctionByName(nameof(PyType_GenericAlloc), GetUnmanagedDll(_PythonDll));
                 PyType_Ready = (delegate* unmanaged[Cdecl]<IntPtr, int>)GetFunctionByName(nameof(PyType_Ready), GetUnmanagedDll(_PythonDll));
                 _PyType_Lookup = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)GetFunctionByName(nameof(_PyType_Lookup), GetUnmanagedDll(_PythonDll));
                 PyObject_GenericGetAttr = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_GenericGetAttr), GetUnmanagedDll(_PythonDll));
@@ -2534,6 +2530,7 @@ namespace Python.Runtime
                 PyException_SetCause = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, void>)GetFunctionByName(nameof(PyException_SetCause), GetUnmanagedDll(_PythonDll));
                 PyThreadState_SetAsyncExcLLP64 = (delegate* unmanaged[Cdecl]<uint, IntPtr, int>)GetFunctionByName("PyThreadState_SetAsyncExc", GetUnmanagedDll(_PythonDll));
                 PyThreadState_SetAsyncExcLP64 = (delegate* unmanaged[Cdecl]<ulong, IntPtr, int>)GetFunctionByName("PyThreadState_SetAsyncExc", GetUnmanagedDll(_PythonDll));
+                PyType_GetSlot = (delegate* unmanaged[Cdecl]<BorrowedReference, TypeSlotID, IntPtr>)GetFunctionByName(nameof(PyType_GetSlot), GetUnmanagedDll(_PythonDll));
                 PyType_FromSpecWithBases = (delegate* unmanaged[Cdecl]<in NativeTypeSpec, BorrowedReference, NewReference>)GetFunctionByName(nameof(PyType_FromSpecWithBases), GetUnmanagedDll(PythonDLL));
 
                 try
@@ -2774,10 +2771,10 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<int, IntPtr, int, void> PySys_SetArgvEx { get; }
             internal static delegate* unmanaged[Cdecl]<StrPtr, BorrowedReference> PySys_GetObject { get; }
             internal static delegate* unmanaged[Cdecl]<StrPtr, BorrowedReference, int> PySys_SetObject { get; }
-            internal static delegate* unmanaged[Cdecl]<IntPtr, void> PyType_Modified { get; }
+            internal static delegate* unmanaged[Cdecl]<BorrowedReference, void> PyType_Modified { get; }
             internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, bool> PyType_IsSubtype { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, IntPtr> PyType_GenericNew { get; }
-            internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr> PyType_GenericAlloc { get; }
+            internal static delegate* unmanaged[Cdecl]<BorrowedReference, nint, NewReference> PyType_GenericAlloc { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, int> PyType_Ready { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr> _PyType_Lookup { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr> PyObject_GenericGetAttr { get; }
@@ -2819,6 +2816,7 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<uint, IntPtr, int> PyThreadState_SetAsyncExcLLP64 { get; }
             internal static delegate* unmanaged[Cdecl]<ulong, IntPtr, int> PyThreadState_SetAsyncExcLP64 { get; }
             internal static delegate* unmanaged[Cdecl]<BorrowedReference, IntPtr, NewReference> PyObject_GenericGetDict { get; }
+            internal static delegate* unmanaged[Cdecl]<BorrowedReference, TypeSlotID, IntPtr> PyType_GetSlot { get; }
             internal static delegate* unmanaged[Cdecl]<in NativeTypeSpec, BorrowedReference, NewReference> PyType_FromSpecWithBases { get; }
             internal static delegate* unmanaged[Cdecl]<BorrowedReference, void> _Py_NewReference { get; }
         }

--- a/src/runtime/runtime_data.cs
+++ b/src/runtime/runtime_data.cs
@@ -119,12 +119,13 @@ namespace Python.Runtime
             var formatter = CreateFormatter();
             var storage = (RuntimeDataStorage)formatter.Deserialize(ms);
 
+            PyCLRMetaType = MetaType.RestoreRuntimeData(storage.GetStorage("meta"));
+
             var objs = RestoreRuntimeDataObjects(storage.GetStorage("objs"));
             RestoreRuntimeDataModules(storage.GetStorage("modules"));
             TypeManager.RestoreRuntimeData(storage.GetStorage("types"));
             var clsObjs = ClassManager.RestoreRuntimeData(storage.GetStorage("classes"));
             ImportHook.RestoreRuntimeData(storage.GetStorage("import"));
-            PyCLRMetaType = MetaType.RestoreRuntimeData(storage.GetStorage("meta"));
 
             foreach (var item in objs)
             {


### PR DESCRIPTION
Use `PyType` instances instead of raw pointers in `TypeManager` type cache and `ConstructorBinding` instances

### What does this implement/fix? Explain your changes.

This is part of an effort to clear up reference ownership story for various implementations of CLR metaclass.

### Does this close any currently open issues?

No