### PR TITLE
Do not call `find_libpython` during `import clr` as Python.Runtime can find it on its own

### DIFF
--- a/pythonnet/__init__.py
+++ b/pythonnet/__init__.py
@@ -29,7 +29,6 @@ def load():
     if _LOADED:
         return
 
-    from .find_libpython import linked_libpython
     from os.path import join, dirname
 
     if _RUNTIME is None:
@@ -38,21 +37,11 @@ def load():
         set_default_runtime()
 
     dll_path = join(dirname(__file__), "runtime", "Python.Runtime.dll")
-    libpython = linked_libpython()
-
-    if libpython and _FFI is None and sys.platform != "win32":
-        # Load and leak libpython handle s.t. the .NET runtime doesn't dlcloses
-        # it
-        import posix
-
-        import cffi
-        _FFI = cffi.FFI()
-        _FFI.dlopen(libpython, posix.RTLD_NODELETE | posix.RTLD_LOCAL)
-
+    
     _LOADER_ASSEMBLY = _RUNTIME.get_assembly(dll_path)
 
     func = _LOADER_ASSEMBLY["Python.Runtime.Loader.Initialize"]
-    if func(f"{libpython or ''}".encode("utf8")) != 0:
+    if func(''.encode("utf8")) != 0:
         raise RuntimeError("Failed to initialize Python.Runtime.dll")
 
     import atexit


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`find_libpython` spectacularly fails to find libpython for debug build of Python on latest Ubuntu (e.g. `apt install python3-dbg; python3-dbg`). It is also not necessary at runtime, since `Python.Runtime` can now find C API functions, since they are already loaded into the process.

### Does this close any currently open issues?

Probably these:
https://github.com/pythonnet/pythonnet/issues/1388
https://github.com/pythonnet/pythonnet/issues/1412 (partially)