### PR TITLE
Fixed `__cause__` on overload bind failure and array conversion

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -814,9 +814,14 @@ namespace Python.Runtime
 
         private static void SetConversionError(IntPtr value, Type target)
         {
+            // PyObject_Repr might clear the error
+            Runtime.PyErr_Fetch(out var causeType, out var causeVal, out var causeTrace);
+
             IntPtr ob = Runtime.PyObject_Repr(value);
             string src = Runtime.GetManagedString(ob);
             Runtime.XDecref(ob);
+
+            Runtime.PyErr_Restore(causeType, causeVal, causeTrace);
             Exceptions.RaiseTypeError($"Cannot convert {src} to {target}");
         }
 

--- a/src/runtime/finalizer.cs
+++ b/src/runtime/finalizer.cs
@@ -54,7 +54,7 @@ namespace Python.Runtime
             public IncorrectRefCountException(IntPtr ptr)
             {
                 PyPtr = ptr;
-                IntPtr pyname = Runtime.PyObject_Unicode(PyPtr);
+                IntPtr pyname = Runtime.PyObject_Str(PyPtr);
                 string name = Runtime.GetManagedString(pyname);
                 Runtime.XDecref(pyname);
                 _message = $"<{name}> may has a incorrect ref count";

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -876,7 +876,7 @@ namespace Python.Runtime
                     {
                         try
                         {
-                            var description = Runtime.PyObject_Unicode(type);
+                            var description = Runtime.PyObject_Str(type);
                             if (description != IntPtr.Zero)
                             {
                                 to.Append(Runtime.GetManagedString(description));
@@ -926,7 +926,9 @@ namespace Python.Runtime
                 }
 
                 value.Append(": ");
+                Runtime.PyErr_Fetch(out var errType, out var errVal, out var errTrace);
                 AppendArgumentTypes(to: value, args);
+                Runtime.PyErr_Restore(errType, errVal, errTrace);
                 Exceptions.RaiseTypeError(value.ToString());
                 return IntPtr.Zero;
             }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -1040,7 +1040,7 @@ namespace Python.Runtime
         /// </remarks>
         public override string ToString()
         {
-            IntPtr strval = Runtime.PyObject_Unicode(obj);
+            IntPtr strval = Runtime.PyObject_Str(obj);
             string result = Runtime.GetManagedString(strval);
             Runtime.XDecref(strval);
             return result;

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1,8 +1,7 @@
-using System.Reflection.Emit;
 using System;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Text;
 using System.Threading;
 using System.Collections.Generic;
@@ -1127,13 +1126,18 @@ namespace Python.Runtime
         internal static nint PyObject_Hash(IntPtr op) => Delegates.PyObject_Hash(op);
 
 
-        internal static IntPtr PyObject_Repr(IntPtr pointer) => Delegates.PyObject_Repr(pointer);
+        internal static IntPtr PyObject_Repr(IntPtr pointer)
+        {
+            Debug.Assert(PyErr_Occurred() == IntPtr.Zero);
+            return Delegates.PyObject_Repr(pointer);
+        }
 
 
-        internal static IntPtr PyObject_Str(IntPtr pointer) => Delegates.PyObject_Str(pointer);
-
-
-        internal static IntPtr PyObject_Unicode(IntPtr pointer) => Delegates.PyObject_Unicode(pointer);
+        internal static IntPtr PyObject_Str(IntPtr pointer)
+        {
+            Debug.Assert(PyErr_Occurred() == IntPtr.Zero);
+            return Delegates.PyObject_Str(pointer);
+        }
 
 
         internal static IntPtr PyObject_Dir(IntPtr pointer) => Delegates.PyObject_Dir(pointer);
@@ -2322,7 +2326,6 @@ namespace Python.Runtime
                 PyObject_Hash = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_Hash), GetUnmanagedDll(_PythonDll));
                 PyObject_Repr = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_Repr), GetUnmanagedDll(_PythonDll));
                 PyObject_Str = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_Str), GetUnmanagedDll(_PythonDll));
-                PyObject_Unicode = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName("PyObject_Str", GetUnmanagedDll(_PythonDll));
                 PyObject_Dir = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyObject_Dir), GetUnmanagedDll(_PythonDll));
                 PyObject_GetBuffer = (delegate* unmanaged[Cdecl]<IntPtr, ref Py_buffer, int, int>)GetFunctionByName(nameof(PyObject_GetBuffer), GetUnmanagedDll(_PythonDll));
                 PyBuffer_Release = (delegate* unmanaged[Cdecl]<ref Py_buffer, void>)GetFunctionByName(nameof(PyBuffer_Release), GetUnmanagedDll(_PythonDll));
@@ -2607,7 +2610,6 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Hash { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Repr { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Str { get; }
-            internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Unicode { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyObject_Dir { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, ref Py_buffer, int, int> PyObject_GetBuffer { get; }
             internal static delegate* unmanaged[Cdecl]<ref Py_buffer, void> PyBuffer_Release { get; }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Calls to `PyObject_Str` and `PyObject_Repr` should not be made with error set, as they may clear it. When using debug build of Python, this causes an assertion at runtime, preventing use of Python.NET.

### Does this close any currently open issues?

Partial fix for https://github.com/pythonnet/pythonnet/issues/1412