### PR TITLE
Handle ProcessExit event

### DIFF
--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -192,6 +192,7 @@ namespace Python.Runtime
 
             // Make sure we clean up properly on app domain unload.
             AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
+            AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
 
             // The global scope gets used implicitly quite early on, remember
             // to clear it out when we shut down.
@@ -245,6 +246,11 @@ namespace Python.Runtime
         }
 
         static void OnDomainUnload(object _, EventArgs __)
+        {
+            Shutdown();
+        }
+
+        static void OnProcessExit(object _, EventArgs __)
         {
             Shutdown();
         }
@@ -319,6 +325,7 @@ namespace Python.Runtime
             // If the shutdown handlers trigger a domain unload,
             // don't call shutdown again.
             AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
+            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
 
             PyScopeManager.Global.Clear();
             ExecuteShutdownHandlers();

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -393,6 +393,10 @@ namespace Python.Runtime
                 {
                     Py_Finalize();
                 }
+                else
+                {
+                    PyGILState_Release(state);
+                }
             }
         }
 


### PR DESCRIPTION
This avoids segfault when CLR (in particular Mono) is unloaded before Python stops.

### What does this implement/fix? Explain your changes.

1. Added a handler to `AppDomain.ProcessExit`, that fires in the situations like this instead of `AppDomain.DomainUnload`. This allows Python.NET to remove all slots, that are implemented in C#.
2. When initialized as extension (e.g.  Python hosts CLR), release GIL acquired during shutdown so that Python finalization can resume.

### Does this close any currently open issues?

This is (at least one of) the reason of CI test crashes in https://github.com/pythonnet/pythonnet/pull/1134