### PR TITLE
Refactoring of tp_clear and tp_dealloc

### DIFF
--- a/src/runtime/ManagedTypes.cd
+++ b/src/runtime/ManagedTypes.cd
@@ -29,9 +29,9 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.BoundContructor" Collapsed="true">
-    <Position X="40.75" Y="3.25" Width="1.5" />
+    <Position X="29.5" Y="4.5" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAAACAAAAAAABABAAAAACAAAABAJAAAAAAAAAAIAAAQ=</HashCode>
+      <HashCode>AAAACAAAAAAABABAAAAACAAAABAJAEAAAAAAAAIAAAA=</HashCode>
       <FileName>constructorbinding.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -52,7 +52,7 @@
   <Class Name="Python.Runtime.ConstructorBinding" Collapsed="true">
     <Position X="29.5" Y="3.25" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAAACAAAAAAABAAAAAAACAAAABAJAAAAAAAAAAIAEAQ=</HashCode>
+      <HashCode>AAAACAAAAAAABAAAAAAACAAAABAJAEAAAAAAAAIAEAA=</HashCode>
       <FileName>constructorbinding.cs</FileName>
     </TypeIdentifier>
   </Class>
@@ -64,7 +64,15 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.EventBinding" Collapsed="true">
-    <Position X="43" Y="3.25" Width="1.5" />
+    <Position X="22.75" Y="1.75" Width="1.5" />
+    <InheritanceLine Type="Python.Runtime.ExtensionType" FixedFromPoint="true">
+      <Path>
+        <Point X="28.25" Y="2.441" />
+        <Point X="28.25" Y="2.875" />
+        <Point X="23.5" Y="2.875" />
+        <Point X="23.5" Y="2.441" />
+      </Path>
+    </InheritanceLine>
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAADAAAIAAAEABAAAAAAAACAAAAAAIAAAQ=</HashCode>
       <FileName>eventbinding.cs</FileName>
@@ -87,12 +95,12 @@
   <Class Name="Python.Runtime.ExtensionType" Collapsed="true">
     <Position X="27.5" Y="1.75" Width="1.5" />
     <TypeIdentifier>
-      <HashCode>AAAAAAAAAAAAAAAAAAAAAAECAAAAAEEBAAAAAAABAAQ=</HashCode>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAACAAAAAEEBAAAAAAABAAQ=</HashCode>
       <FileName>extensiontype.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.FieldObject" Collapsed="true">
-    <Position X="34" Y="3.25" Width="1.5" />
+    <Position X="31.75" Y="3.25" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAIBEAA=</HashCode>
       <FileName>fieldobject.cs</FileName>
@@ -120,21 +128,29 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.MethodBinding" Collapsed="true">
-    <Position X="31.75" Y="3.25" Width="1.5" />
+    <Position X="33.75" Y="1.75" Width="1.5" />
+    <InheritanceLine Type="Python.Runtime.ExtensionType" FixedFromPoint="true" FixedToPoint="true">
+      <Path>
+        <Point X="28.25" Y="2.441" />
+        <Point X="28.25" Y="2.875" />
+        <Point X="34.5" Y="2.875" />
+        <Point X="34.5" Y="2.441" />
+      </Path>
+    </InheritanceLine>
     <TypeIdentifier>
       <HashCode>EAAAAAAAAIAADABAIAAAAAAAAAgBAAAAUgAAAAIAAAQ=</HashCode>
       <FileName>methodbinding.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.MethodObject" Collapsed="true">
-    <Position X="36.25" Y="3.25" Width="1.5" />
+    <Position X="33.75" Y="3.25" Width="1.5" />
     <TypeIdentifier>
       <HashCode>FIADAAAAAAAIBAAAIAAIAAAIAAgFAAAAUAAgAAIAEAQ=</HashCode>
       <FileName>methodobject.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.ModuleFunctionObject" Collapsed="true">
-    <Position X="36.25" Y="4.75" Width="1.5" />
+    <Position X="33.75" Y="4.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAIAAAA=</HashCode>
       <FileName>modulefunctionobject.cs</FileName>
@@ -148,17 +164,32 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.ModulePropertyObject" Collapsed="true">
-    <Position X="27.25" Y="3.25" Width="1.5" />
+    <Position X="27.25" Y="4.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>modulepropertyobject.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Python.Runtime.PropertyObject" Collapsed="true">
-    <Position X="38.5" Y="3.25" Width="1.5" />
+    <Position X="27.25" Y="3.25" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAIBEAg=</HashCode>
       <FileName>propertyobject.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Python.Runtime.OverloadMapper" Collapsed="true">
+    <Position X="35.5" Y="1.75" Width="1.5" />
+    <InheritanceLine Type="Python.Runtime.ExtensionType" ManuallyRouted="true" FixedFromPoint="true" FixedToPoint="true">
+      <Path>
+        <Point X="28.25" Y="2.441" />
+        <Point X="28.25" Y="2.875" />
+        <Point X="36.188" Y="2.875" />
+        <Point X="36.188" Y="2.441" />
+      </Path>
+    </InheritanceLine>
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAIAAAAAAAAAABAAAAAgAAAAIAAAQ=</HashCode>
+      <FileName>overload.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Font Name="Segoe UI" Size="9" />

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -149,14 +149,10 @@ namespace Python.Runtime
             return self.repr;
         }
 
-        /// <summary>
-        /// ConstructorBinding dealloc implementation.
-        /// </summary>
-        public new static void tp_dealloc(IntPtr ob)
+        protected override void Dealloc()
         {
-            var self = (ConstructorBinding)GetManagedObject(ob);
-            Runtime.XDecref(self.repr);
-            self.Dealloc();
+            Runtime.Py_CLEAR(ref this.repr);
+            base.Dealloc();
         }
 
         public static int tp_clear(IntPtr ob)
@@ -252,14 +248,10 @@ namespace Python.Runtime
             return self.repr;
         }
 
-        /// <summary>
-        /// ConstructorBinding dealloc implementation.
-        /// </summary>
-        public new static void tp_dealloc(IntPtr ob)
+        protected override void Dealloc()
         {
-            var self = (BoundContructor)GetManagedObject(ob);
-            Runtime.XDecref(self.repr);
-            self.Dealloc();
+            Runtime.Py_CLEAR(ref this.repr);
+            base.Dealloc();
         }
 
         public static int tp_clear(IntPtr ob)

--- a/src/runtime/eventbinding.cs
+++ b/src/runtime/eventbinding.cs
@@ -103,15 +103,10 @@ namespace Python.Runtime
             return Runtime.PyString_FromString(s);
         }
 
-
-        /// <summary>
-        /// EventBinding dealloc implementation.
-        /// </summary>
-        public new static void tp_dealloc(IntPtr ob)
+        protected override void Dealloc()
         {
-            var self = (EventBinding)GetManagedObject(ob);
-            Runtime.XDecref(self.target);
-            self.Dealloc();
+            Runtime.Py_CLEAR(ref this.target);
+            base.Dealloc();
         }
 
         public static int tp_clear(IntPtr ob)

--- a/src/runtime/eventobject.cs
+++ b/src/runtime/eventobject.cs
@@ -198,17 +198,14 @@ namespace Python.Runtime
         }
 
 
-        /// <summary>
-        /// Descriptor dealloc implementation.
-        /// </summary>
-        public new static void tp_dealloc(IntPtr ob)
+        protected override void Dealloc()
         {
-            var self = (EventObject)GetManagedObject(ob);
-            if (self.unbound != null)
+            if (this.unbound is not null)
             {
-                Runtime.XDecref(self.unbound.pyHandle);
+                Runtime.XDecref(this.unbound.pyHandle);
+                this.unbound = null;
             }
-            self.Dealloc();
+            base.Dealloc();
         }
     }
 

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -54,20 +54,12 @@ namespace Python.Runtime
         }
 
 
-        /// <summary>
-        /// Common finalization code to support custom tp_deallocs.
-        /// </summary>
-        public static void FinalizeObject(ManagedType self)
+        protected virtual void Dealloc()
         {
-            ClearObjectDict(self.pyHandle);
-            Runtime.PyObject_GC_Del(self.pyHandle);
+            ClearObjectDict(this.pyHandle);
+            Runtime.PyObject_GC_Del(this.pyHandle);
             // Not necessary for decref of `tpHandle`.
-            self.FreeGCHandle();
-        }
-
-        protected void Dealloc()
-        {
-            FinalizeObject(this);
+            this.FreeGCHandle();
         }
 
         /// <summary>
@@ -104,7 +96,7 @@ namespace Python.Runtime
             // Clean up a Python instance of this extension type. This
             // frees the allocated Python object and decrefs the type.
             var self = (ExtensionType)GetManagedObject(ob);
-            self.Dealloc();
+            self?.Dealloc();
         }
 
         protected override void OnLoad(InterDomainContext context)

--- a/src/runtime/methodbinding.cs
+++ b/src/runtime/methodbinding.cs
@@ -31,7 +31,7 @@ namespace Python.Runtime
             {
                 Runtime.XIncref(targetType);
             }
-            
+
             this.targetType = targetType;
 
             this.info = null;
@@ -40,12 +40,6 @@ namespace Python.Runtime
 
         public MethodBinding(MethodObject m, IntPtr target) : this(m, target, IntPtr.Zero)
         {
-        }
-
-        private void ClearMembers()
-        {
-            Runtime.Py_CLEAR(ref target);
-            Runtime.Py_CLEAR(ref targetType);
         }
 
         /// <summary>
@@ -235,14 +229,16 @@ namespace Python.Runtime
             return Runtime.PyString_FromString($"<{type} method '{name}'>");
         }
 
-        /// <summary>
-        /// MethodBinding dealloc implementation.
-        /// </summary>
-        public new static void tp_dealloc(IntPtr ob)
+        private void ClearMembers()
         {
-            var self = (MethodBinding)GetManagedObject(ob);
-            self.ClearMembers();
-            self.Dealloc();
+            Runtime.Py_CLEAR(ref target);
+            Runtime.Py_CLEAR(ref targetType);
+        }
+
+        protected override void Dealloc()
+        {
+            this.ClearMembers();
+            base.Dealloc();
         }
 
         public static int tp_clear(IntPtr ob)

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -120,16 +120,6 @@ namespace Python.Runtime
             return is_static;
         }
 
-        private void ClearMembers()
-        {
-            Runtime.Py_CLEAR(ref doc);
-            if (unbound != null)
-            {
-                Runtime.XDecref(unbound.pyHandle);
-                unbound = null;
-            }
-        }
-
         /// <summary>
         /// Descriptor __getattribute__ implementation.
         /// </summary>
@@ -210,15 +200,21 @@ namespace Python.Runtime
             return Runtime.PyString_FromString($"<method '{self.name}'>");
         }
 
-        /// <summary>
-        /// Descriptor dealloc implementation.
-        /// </summary>
-        public new static void tp_dealloc(IntPtr ob)
+        private void ClearMembers()
         {
-            var self = (MethodObject)GetManagedObject(ob);
-            self.ClearMembers();
-            ClearObjectDict(ob);
-            self.Dealloc();
+            Runtime.Py_CLEAR(ref doc);
+            if (unbound != null)
+            {
+                Runtime.XDecref(unbound.pyHandle);
+                unbound = null;
+            }
+        }
+
+        protected override void Dealloc()
+        {
+            this.ClearMembers();
+            ClearObjectDict(this.pyHandle);
+            base.Dealloc();
         }
 
         public static int tp_clear(IntPtr ob)

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -274,7 +274,7 @@ namespace Python.Runtime
                 Exceptions.SetError(e);
                 return IntPtr.Zero;
             }
-            
+
 
             if (attr == null)
             {
@@ -295,11 +295,10 @@ namespace Python.Runtime
             return Runtime.PyString_FromString($"<module '{self.moduleName}'>");
         }
 
-        public new static void tp_dealloc(IntPtr ob)
+        protected override void Dealloc()
         {
-            var self = (ModuleObject)GetManagedObject(ob);
-            tp_clear(ob);
-            self.Dealloc();
+            tp_clear(this.pyHandle);
+            base.Dealloc();
         }
 
         public static int tp_traverse(IntPtr ob, IntPtr visit, IntPtr arg)
@@ -345,7 +344,7 @@ namespace Python.Runtime
                 if ((Runtime.PyDict_DelItemString(DictRef, pair.Key) == -1) &&
                     (Exceptions.ExceptionMatches(Exceptions.KeyError)))
                 {
-                    // Trying to remove a key that's not in the dictionary 
+                    // Trying to remove a key that's not in the dictionary
                     // raises an error. We don't care about it.
                     Runtime.PyErr_Clear();
                 }
@@ -496,7 +495,7 @@ namespace Python.Runtime
         /// clr.GetClrType(IComparable) gives you the Type for IComparable,
         /// that you can e.g. perform reflection on. Similar to typeof(IComparable) in C#
         /// or clr.GetClrType(IComparable) in IronPython.
-        /// 
+        ///
         /// </summary>
         /// <param name="type"></param>
         /// <returns>The Type object</returns>

--- a/src/runtime/native/TypeOffset.cs
+++ b/src/runtime/native/TypeOffset.cs
@@ -153,7 +153,6 @@ namespace Python.Runtime
                 "__instancecheck__",
                 "__subclasscheck__",
                 "AddReference",
-                "FinalizeObject",
                 "FindAssembly",
                 "get_SuppressDocs",
                 "get_SuppressOverloads",

--- a/src/runtime/overload.cs
+++ b/src/runtime/overload.cs
@@ -58,14 +58,10 @@ namespace Python.Runtime
             return doc;
         }
 
-        /// <summary>
-        /// OverloadMapper dealloc implementation.
-        /// </summary>
-        public new static void tp_dealloc(IntPtr ob)
+        protected override void Dealloc()
         {
-            var self = (OverloadMapper)GetManagedObject(ob);
-            Runtime.XDecref(self.target);
-            self.Dealloc();
+            Runtime.Py_CLEAR(ref this.target);
+            base.Dealloc();
         }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This replaces inheritance of `tp_dealloc` and `tp_clear` functions using slots with regular virtual functions on C# side that makes it easier to reason about.