### PR TITLE
Refactoring of tp_clear

### DIFF
--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -149,12 +149,6 @@ namespace Python.Runtime
             return self.repr;
         }
 
-        protected override void Dealloc()
-        {
-            Runtime.Py_CLEAR(ref this.repr);
-            base.Dealloc();
-        }
-
         protected override void Clear()
         {
             Runtime.Py_CLEAR(ref this.repr);
@@ -245,12 +239,6 @@ namespace Python.Runtime
             self.repr = Runtime.PyString_FromString(str);
             Runtime.XIncref(self.repr);
             return self.repr;
-        }
-
-        protected override void Dealloc()
-        {
-            Runtime.Py_CLEAR(ref this.repr);
-            base.Dealloc();
         }
 
         protected override void Clear()

--- a/src/runtime/constructorbinding.cs
+++ b/src/runtime/constructorbinding.cs
@@ -155,11 +155,10 @@ namespace Python.Runtime
             base.Dealloc();
         }
 
-        public static int tp_clear(IntPtr ob)
+        protected override void Clear()
         {
-            var self = (ConstructorBinding)GetManagedObject(ob);
-            Runtime.Py_CLEAR(ref self.repr);
-            return 0;
+            Runtime.Py_CLEAR(ref this.repr);
+            base.Clear();
         }
 
         public static int tp_traverse(IntPtr ob, IntPtr visit, IntPtr arg)
@@ -254,11 +253,10 @@ namespace Python.Runtime
             base.Dealloc();
         }
 
-        public static int tp_clear(IntPtr ob)
+        protected override void Clear()
         {
-            var self = (BoundContructor)GetManagedObject(ob);
-            Runtime.Py_CLEAR(ref self.repr);
-            return 0;
+            Runtime.Py_CLEAR(ref this.repr);
+            base.Clear();
         }
 
         public static int tp_traverse(IntPtr ob, IntPtr visit, IntPtr arg)

--- a/src/runtime/eventbinding.cs
+++ b/src/runtime/eventbinding.cs
@@ -109,11 +109,10 @@ namespace Python.Runtime
             base.Dealloc();
         }
 
-        public static int tp_clear(IntPtr ob)
+        protected override void Clear()
         {
-            var self = (EventBinding)GetManagedObject(ob);
-            Runtime.Py_CLEAR(ref self.target);
-            return 0;
+            Runtime.Py_CLEAR(ref this.target);
+            base.Clear();
         }
     }
 }

--- a/src/runtime/eventbinding.cs
+++ b/src/runtime/eventbinding.cs
@@ -103,12 +103,6 @@ namespace Python.Runtime
             return Runtime.PyString_FromString(s);
         }
 
-        protected override void Dealloc()
-        {
-            Runtime.Py_CLEAR(ref this.target);
-            base.Dealloc();
-        }
-
         protected override void Clear()
         {
             Runtime.Py_CLEAR(ref this.target);

--- a/src/runtime/eventobject.cs
+++ b/src/runtime/eventobject.cs
@@ -198,16 +198,6 @@ namespace Python.Runtime
         }
 
 
-        protected override void Dealloc()
-        {
-            if (this.unbound is not null)
-            {
-                Runtime.XDecref(this.unbound.pyHandle);
-                this.unbound = null;
-            }
-            base.Dealloc();
-        }
-
         protected override void Clear()
         {
             if (this.unbound is not null)

--- a/src/runtime/eventobject.cs
+++ b/src/runtime/eventobject.cs
@@ -207,6 +207,16 @@ namespace Python.Runtime
             }
             base.Dealloc();
         }
+
+        protected override void Clear()
+        {
+            if (this.unbound is not null)
+            {
+                Runtime.XDecref(this.unbound.pyHandle);
+                this.unbound = null;
+            }
+            base.Clear();
+        }
     }
 
 

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -62,6 +62,9 @@ namespace Python.Runtime
             this.FreeGCHandle();
         }
 
+        /// <summary>DecRefs and nulls any fields pointing back to Python</summary>
+        protected virtual void Clear() { }
+
         /// <summary>
         /// Type __setattr__ implementation.
         /// </summary>
@@ -88,15 +91,19 @@ namespace Python.Runtime
         }
 
 
-        /// <summary>
-        /// Default dealloc implementation.
-        /// </summary>
         public static void tp_dealloc(IntPtr ob)
         {
             // Clean up a Python instance of this extension type. This
             // frees the allocated Python object and decrefs the type.
             var self = (ExtensionType)GetManagedObject(ob);
             self?.Dealloc();
+        }
+
+        public static int tp_clear(IntPtr ob)
+        {
+            var self = (ExtensionType)GetManagedObject(ob);
+            self?.Clear();
+            return 0;
         }
 
         protected override void OnLoad(InterDomainContext context)

--- a/src/runtime/methodbinding.cs
+++ b/src/runtime/methodbinding.cs
@@ -241,11 +241,10 @@ namespace Python.Runtime
             base.Dealloc();
         }
 
-        public static int tp_clear(IntPtr ob)
+        protected override void Clear()
         {
-            var self = (MethodBinding)GetManagedObject(ob);
-            self.ClearMembers();
-            return 0;
+            this.ClearMembers();
+            base.Clear();
         }
 
         protected override void OnSave(InterDomainContext context)

--- a/src/runtime/methodbinding.cs
+++ b/src/runtime/methodbinding.cs
@@ -229,21 +229,10 @@ namespace Python.Runtime
             return Runtime.PyString_FromString($"<{type} method '{name}'>");
         }
 
-        private void ClearMembers()
-        {
-            Runtime.Py_CLEAR(ref target);
-            Runtime.Py_CLEAR(ref targetType);
-        }
-
-        protected override void Dealloc()
-        {
-            this.ClearMembers();
-            base.Dealloc();
-        }
-
         protected override void Clear()
         {
-            this.ClearMembers();
+            Runtime.Py_CLEAR(ref this.target);
+            Runtime.Py_CLEAR(ref this.targetType);
             base.Clear();
         }
 

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -217,12 +217,11 @@ namespace Python.Runtime
             base.Dealloc();
         }
 
-        public static int tp_clear(IntPtr ob)
+        protected override void Clear()
         {
-            var self = (MethodObject)GetManagedObject(ob);
-            self.ClearMembers();
-            ClearObjectDict(ob);
-            return 0;
+            this.ClearMembers();
+            ClearObjectDict(this.pyHandle);
+            base.Clear();
         }
 
         protected override void OnSave(InterDomainContext context)

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -200,26 +200,15 @@ namespace Python.Runtime
             return Runtime.PyString_FromString($"<method '{self.name}'>");
         }
 
-        private void ClearMembers()
-        {
-            Runtime.Py_CLEAR(ref doc);
-            if (unbound != null)
-            {
-                Runtime.XDecref(unbound.pyHandle);
-                unbound = null;
-            }
-        }
-
-        protected override void Dealloc()
-        {
-            this.ClearMembers();
-            ClearObjectDict(this.pyHandle);
-            base.Dealloc();
-        }
-
         protected override void Clear()
         {
-            this.ClearMembers();
+            Runtime.Py_CLEAR(ref this.doc);
+            if (this.unbound != null)
+            {
+                Runtime.XDecref(this.unbound.pyHandle);
+                this.unbound = null;
+            }
+
             ClearObjectDict(this.pyHandle);
             base.Clear();
         }

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -308,12 +308,6 @@ namespace Python.Runtime
             return 0;
         }
 
-        protected override void Dealloc()
-        {
-            tp_clear(this.pyHandle);
-            base.Dealloc();
-        }
-
         protected override void Clear()
         {
             Runtime.Py_CLEAR(ref this.dict);

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -295,12 +295,6 @@ namespace Python.Runtime
             return Runtime.PyString_FromString($"<module '{self.moduleName}'>");
         }
 
-        protected override void Dealloc()
-        {
-            tp_clear(this.pyHandle);
-            base.Dealloc();
-        }
-
         public static int tp_traverse(IntPtr ob, IntPtr visit, IntPtr arg)
         {
             var self = (ModuleObject)GetManagedObject(ob);
@@ -314,17 +308,22 @@ namespace Python.Runtime
             return 0;
         }
 
-        public static int tp_clear(IntPtr ob)
+        protected override void Dealloc()
         {
-            var self = (ModuleObject)GetManagedObject(ob);
-            Runtime.Py_CLEAR(ref self.dict);
-            ClearObjectDict(ob);
-            foreach (var attr in self.cache.Values)
+            tp_clear(this.pyHandle);
+            base.Dealloc();
+        }
+
+        protected override void Clear()
+        {
+            Runtime.Py_CLEAR(ref this.dict);
+            ClearObjectDict(this.pyHandle);
+            foreach (var attr in this.cache.Values)
             {
                 Runtime.XDecref(attr.pyHandle);
             }
-            self.cache.Clear();
-            return 0;
+            this.cache.Clear();
+            base.Clear();
         }
 
         protected override void OnSave(InterDomainContext context)

--- a/src/runtime/overload.cs
+++ b/src/runtime/overload.cs
@@ -58,12 +58,6 @@ namespace Python.Runtime
             return doc;
         }
 
-        protected override void Dealloc()
-        {
-            Runtime.Py_CLEAR(ref this.target);
-            base.Dealloc();
-        }
-
         protected override void Clear()
         {
             Runtime.Py_CLEAR(ref this.target);

--- a/src/runtime/overload.cs
+++ b/src/runtime/overload.cs
@@ -63,5 +63,11 @@ namespace Python.Runtime
             Runtime.Py_CLEAR(ref this.target);
             base.Dealloc();
         }
+
+        protected override void Clear()
+        {
+            Runtime.Py_CLEAR(ref this.target);
+            base.Clear();
+        }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This replaces inheritance of `tp_clear` function using slot with regular virtual function `Clear` on C# side that makes it easier to reason about.