### PR TITLE
Prevent crash during debugging when attempting to inspect PyObject

### DIFF
--- a/src/runtime/Util.cs
+++ b/src/runtime/Util.cs
@@ -7,6 +7,8 @@ namespace Python.Runtime
     {
         internal const string UnstableApiMessage =
             "This API is unstable, and might be changed or removed in the next minor release";
+        internal const string MinimalPythonVersionRequired =
+            "Only Python 3.5 or newer is supported";
 
         internal static Int64 ReadCLong(IntPtr tp, int offset)
         {

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 namespace Python.Runtime
 {
     [Serializable]
+    [DebuggerDisplay("clrO: {inst}")]
     internal class CLRObject : ManagedType
     {
         internal object inst;

--- a/src/runtime/debughelper.cs
+++ b/src/runtime/debughelper.cs
@@ -144,5 +144,13 @@ namespace Python.Runtime
             long refcount = Runtime.Refcount(obj);
             Debug.Assert(refcount > 0, "Object refcount is 0 or less");
         }
+
+        [Conditional("DEBUG")]
+        public static void EnsureGIL()
+        {
+            Debug.Assert(HaveInterpreterLock(), "GIL must be acquired");
+        }
+
+        public static bool HaveInterpreterLock() => Runtime.PyGILState_Check() == 1;
     }
 }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -16,6 +16,7 @@ namespace Python.Runtime
     /// for details.
     /// </summary>
     [Serializable]
+    [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
     public partial class PyObject : DynamicObject, IEnumerable<PyObject>, IDisposable
     {
 #if TRACE_ALLOC
@@ -1068,6 +1069,10 @@ namespace Python.Runtime
             Runtime.XDecref(strval);
             return result;
         }
+
+        string DebuggerDisplay => DebugUtil.HaveInterpreterLock()
+            ? this.ToString()
+            : $"pyobj at 0x{this.obj:X} (get Py.GIL to see more info)";
 
 
         /// <summary>

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -832,7 +832,7 @@ namespace Python.Runtime
 
         internal static IntPtr PyThreadState_Swap(IntPtr key) => Delegates.PyThreadState_Swap(key);
 
-
+        internal static int PyGILState_Check() => Delegates.PyGILState_Check();
         internal static IntPtr PyGILState_Ensure() => Delegates.PyGILState_Ensure();
 
 
@@ -2302,6 +2302,14 @@ namespace Python.Runtime
                 PyThread_get_thread_ident = (delegate* unmanaged[Cdecl]<int>)GetFunctionByName(nameof(PyThread_get_thread_ident), GetUnmanagedDll(_PythonDll));
                 PyThread_set_key_value = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int>)GetFunctionByName(nameof(PyThread_set_key_value), GetUnmanagedDll(_PythonDll));
                 PyThreadState_Swap = (delegate* unmanaged[Cdecl]<IntPtr, IntPtr>)GetFunctionByName(nameof(PyThreadState_Swap), GetUnmanagedDll(_PythonDll));
+                try
+                {
+                    PyGILState_Check = (delegate* unmanaged[Cdecl]<int>)GetFunctionByName(nameof(PyGILState_Check), GetUnmanagedDll(_PythonDll));
+                }
+                catch (MissingMethodException e)
+                {
+                    throw new NotSupportedException(Util.MinimalPythonVersionRequired, innerException: e);
+                }
                 PyGILState_Ensure = (delegate* unmanaged[Cdecl]<IntPtr>)GetFunctionByName(nameof(PyGILState_Ensure), GetUnmanagedDll(_PythonDll));
                 PyGILState_Release = (delegate* unmanaged[Cdecl]<IntPtr, void>)GetFunctionByName(nameof(PyGILState_Release), GetUnmanagedDll(_PythonDll));
                 PyGILState_GetThisThreadState = (delegate* unmanaged[Cdecl]<IntPtr>)GetFunctionByName(nameof(PyGILState_GetThisThreadState), GetUnmanagedDll(_PythonDll));
@@ -2605,6 +2613,7 @@ namespace Python.Runtime
             internal static delegate* unmanaged[Cdecl]<int> PyThread_get_thread_ident { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr, int> PyThread_set_key_value { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, IntPtr> PyThreadState_Swap { get; }
+            internal static delegate* unmanaged[Cdecl]<int> PyGILState_Check { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr> PyGILState_Ensure { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr, void> PyGILState_Release { get; }
             internal static delegate* unmanaged[Cdecl]<IntPtr> PyGILState_GetThisThreadState { get; }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When debugging code, that uses `PyObject` instances, debugger would try to execute `PyObject.ToString` to show `PyObject` values in watches window. That call causes `AccessViolationException` when the current thread does not hold global interpreter lock.

This change adds `DebuggerDisplay` attribute to `PyObject`, that makes debugger first check if GIL is held by the current thread, and only use `ToString` when it does. Otherwise, a message with object handle and a suggestion to acquire GIL is displayed.
