### PR TITLE
Allow substituting base types for CLR types (as seen from Python)

### DIFF
--- a/src/embed_tests/Inheritance.cs
+++ b/src/embed_tests/Inheritance.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class Inheritance
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+            var locals = new PyDict();
+            PythonEngine.Exec(InheritanceTestBaseClassWrapper.ClassSourceCode, locals: locals.Handle);
+            ExtraBaseTypeProvider.ExtraBase = new PyType(locals[InheritanceTestBaseClassWrapper.ClassName]);
+            var baseTypeProviders = PythonEngine.InteropConfiguration.PythonBaseTypeProviders;
+            baseTypeProviders.Add(new ExtraBaseTypeProvider());
+            baseTypeProviders.Add(new NoEffectBaseTypeProvider());
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void ExtraBase_PassesInstanceCheck()
+        {
+            var inherited = new Inherited();
+            bool properlyInherited = PyIsInstance(inherited, ExtraBaseTypeProvider.ExtraBase);
+            Assert.IsTrue(properlyInherited);
+        }
+
+        static dynamic PyIsInstance => PythonEngine.Eval("isinstance");
+
+        [Test]
+        public void InheritingWithExtraBase_CreatesNewClass()
+        {
+            PyObject a = ExtraBaseTypeProvider.ExtraBase;
+            var inherited = new Inherited();
+            PyObject inheritedClass = inherited.ToPython().GetAttr("__class__");
+            Assert.IsFalse(PythonReferenceComparer.Instance.Equals(a, inheritedClass));
+        }
+
+        [Test]
+        public void InheritedFromInheritedClassIsSelf()
+        {
+            using var scope = Py.CreateScope();
+            scope.Exec($"from {typeof(Inherited).Namespace} import {nameof(Inherited)}");
+            scope.Exec($"class B({nameof(Inherited)}): pass");
+            PyObject b = scope.Eval("B");
+            PyObject bInstance = b.Invoke();
+            PyObject bInstanceClass = bInstance.GetAttr("__class__");
+            Assert.IsTrue(PythonReferenceComparer.Instance.Equals(b, bInstanceClass));
+        }
+
+        [Test]
+        public void Grandchild_PassesExtraBaseInstanceCheck()
+        {
+            using var scope = Py.CreateScope();
+            scope.Exec($"from {typeof(Inherited).Namespace} import {nameof(Inherited)}");
+            scope.Exec($"class B({nameof(Inherited)}): pass");
+            PyObject b = scope.Eval("B");
+            PyObject bInst = b.Invoke();
+            bool properlyInherited = PyIsInstance(bInst, ExtraBaseTypeProvider.ExtraBase);
+            Assert.IsTrue(properlyInherited);
+        }
+
+        [Test]
+        public void CallInheritedClrMethod_WithExtraPythonBase()
+        {
+            var instance = new Inherited().ToPython();
+            string result = instance.InvokeMethod(nameof(PythonWrapperBase.WrapperBaseMethod)).As<string>();
+            Assert.AreEqual(result, nameof(PythonWrapperBase.WrapperBaseMethod));
+        }
+
+        [Test]
+        public void CallExtraBaseMethod()
+        {
+            var instance = new Inherited();
+            using var scope = Py.CreateScope();
+            scope.Set(nameof(instance), instance);
+            int actual = instance.ToPython().InvokeMethod("callVirt").As<int>();
+            Assert.AreEqual(expected: Inherited.OverridenVirtValue, actual);
+        }
+
+        [Test]
+        public void SetAdHocAttributes_WhenExtraBasePresent()
+        {
+            var instance = new Inherited();
+            using var scope = Py.CreateScope();
+            scope.Set(nameof(instance), instance);
+            scope.Exec($"super({nameof(instance)}.__class__, {nameof(instance)}).set_x_to_42()");
+            int actual = scope.Eval<int>($"{nameof(instance)}.{nameof(Inherited.XProp)}");
+            Assert.AreEqual(expected: Inherited.X, actual);
+        }
+    }
+
+    class ExtraBaseTypeProvider : IPythonBaseTypeProvider
+    {
+        internal static PyType ExtraBase;
+        public IEnumerable<PyType> GetBaseTypes(Type type, IList<PyType> existingBases)
+        {
+            if (type == typeof(InheritanceTestBaseClassWrapper))
+            {
+                return new[] { PyType.Get(type.BaseType), ExtraBase };
+            }
+            return existingBases;
+        }
+    }
+
+    class NoEffectBaseTypeProvider : IPythonBaseTypeProvider
+    {
+        public IEnumerable<PyType> GetBaseTypes(Type type, IList<PyType> existingBases)
+            => existingBases;
+    }
+
+    public class PythonWrapperBase
+    {
+        public string WrapperBaseMethod() => nameof(WrapperBaseMethod);
+    }
+
+    public class InheritanceTestBaseClassWrapper : PythonWrapperBase
+    {
+        public const string ClassName = "InheritanceTestBaseClass";
+        public const string ClassSourceCode = "class " + ClassName +
+@":
+  def virt(self):
+    return 42
+  def set_x_to_42(self):
+    self.XProp = 42
+  def callVirt(self):
+    return self.virt()
+  def __getattr__(self, name):
+    return '__getattr__:' + name
+  def __setattr__(self, name, value):
+    value[name] = name
+" + ClassName + " = " + ClassName + "\n";
+    }
+
+    public class Inherited : InheritanceTestBaseClassWrapper
+    {
+        public const int OverridenVirtValue = -42;
+        public const int X = 42;
+        readonly Dictionary<string, object> extras = new Dictionary<string, object>();
+        public int virt() => OverridenVirtValue;
+        public int XProp
+        {
+            get
+            {
+                using (var scope = Py.CreateScope())
+                {
+                    scope.Set("this", this);
+                    try
+                    {
+                        return scope.Eval<int>($"super(this.__class__, this).{nameof(XProp)}");
+                    }
+                    catch (PythonException ex) when (ex.Type.Handle == Exceptions.AttributeError)
+                    {
+                        if (this.extras.TryGetValue(nameof(this.XProp), out object value))
+                            return (int)value;
+                        throw;
+                    }
+                }
+            }
+            set => this.extras[nameof(this.XProp)] = value;
+        }
+    }
+}

--- a/src/runtime/DefaultBaseTypeProvider.cs
+++ b/src/runtime/DefaultBaseTypeProvider.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace Python.Runtime
+{
+    /// <summary>Minimal Python base type provider</summary>
+    public sealed class DefaultBaseTypeProvider : IPythonBaseTypeProvider
+    {
+        public IEnumerable<PyType> GetBaseTypes(Type type, IList<PyType> existingBases)
+        {
+            if (type is null)
+                throw new ArgumentNullException(nameof(type));
+            if (existingBases is null)
+                throw new ArgumentNullException(nameof(existingBases));
+            if (existingBases.Count > 0)
+                throw new ArgumentException("To avoid confusion, this type provider requires the initial set of base types to be empty");
+
+            return new[] { new PyType(GetBaseType(type)) };
+        }
+
+        static BorrowedReference GetBaseType(Type type)
+        {
+            if (type == typeof(Exception))
+                return new BorrowedReference(Exceptions.Exception);
+
+            return type.BaseType is not null
+                ? ClassManager.GetClass(type.BaseType).ObjectReference
+                : new BorrowedReference(Runtime.PyBaseObjectType);
+        }
+
+        DefaultBaseTypeProvider(){}
+        public static DefaultBaseTypeProvider Instance { get; } = new DefaultBaseTypeProvider();
+    }
+}

--- a/src/runtime/IPythonBaseTypeProvider.cs
+++ b/src/runtime/IPythonBaseTypeProvider.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace Python.Runtime
+{
+    public interface IPythonBaseTypeProvider
+    {
+        /// <summary>
+        /// Get Python types, that should be presented to Python as the base types
+        /// for the specified .NET type.
+        /// </summary>
+        IEnumerable<PyType> GetBaseTypes(Type type, IList<PyType> existingBases);
+    }
+}

--- a/src/runtime/InteropConfiguration.cs
+++ b/src/runtime/InteropConfiguration.cs
@@ -1,0 +1,25 @@
+namespace Python.Runtime
+{
+    using System;
+    using System.Collections.Generic;
+
+    public sealed class InteropConfiguration
+    {
+        internal readonly PythonBaseTypeProviderGroup pythonBaseTypeProviders
+            = new PythonBaseTypeProviderGroup();
+
+        /// <summary>Enables replacing base types of CLR types as seen from Python</summary>
+        public IList<IPythonBaseTypeProvider> PythonBaseTypeProviders => this.pythonBaseTypeProviders;
+
+        public static InteropConfiguration MakeDefault()
+        {
+            return new InteropConfiguration
+            {
+                PythonBaseTypeProviders =
+                {
+                    DefaultBaseTypeProvider.Instance,
+                },
+            };
+        }
+    }
+}

--- a/src/runtime/PythonBaseTypeProviderGroup.cs
+++ b/src/runtime/PythonBaseTypeProviderGroup.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Python.Runtime
+{
+    class PythonBaseTypeProviderGroup : List<IPythonBaseTypeProvider>, IPythonBaseTypeProvider
+    {
+        public IEnumerable<PyType> GetBaseTypes(Type type, IList<PyType> existingBases)
+        {
+            if (type is null)
+                throw new ArgumentNullException(nameof(type));
+            if (existingBases is null)
+                throw new ArgumentNullException(nameof(existingBases));
+
+            foreach (var provider in this)
+            {
+                existingBases = provider.GetBaseTypes(type, existingBases).ToList();
+            }
+
+            return existingBases;
+        }
+    }
+}

--- a/src/runtime/PythonReferenceComparer.cs
+++ b/src/runtime/PythonReferenceComparer.cs
@@ -1,0 +1,22 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace Python.Runtime
+{
+    /// <summary>
+    /// Compares Python object wrappers by Python object references.
+    /// <para>Similar to <see cref="object.ReferenceEquals"/> but for Python objects</para>
+    /// </summary>
+    public sealed class PythonReferenceComparer : IEqualityComparer<PyObject>
+    {
+        public static PythonReferenceComparer Instance { get; } = new PythonReferenceComparer();
+        public bool Equals(PyObject? x, PyObject? y)
+        {
+            return x?.Handle == y?.Handle;
+        }
+
+        public int GetHashCode(PyObject obj) => obj.Handle.GetHashCode();
+
+        private PythonReferenceComparer() { }
+    }
+}

--- a/src/runtime/StolenReference.cs
+++ b/src/runtime/StolenReference.cs
@@ -35,6 +35,13 @@ namespace Python.Runtime
 
         [Pure]
         public override int GetHashCode() => Pointer.GetHashCode();
+
+        [Pure]
+        public static StolenReference DangerousFromPointer(IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero) throw new ArgumentNullException(nameof(ptr));
+            return new StolenReference(ptr);
+        }
     }
 
     static class StolenReferenceExtensions

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -26,6 +26,7 @@ namespace Python.Runtime
         private static IntPtr _pythonHome = IntPtr.Zero;
         private static IntPtr _programName = IntPtr.Zero;
         private static IntPtr _pythonPath = IntPtr.Zero;
+        private static InteropConfiguration interopConfiguration = InteropConfiguration.MakeDefault();
 
         public PythonEngine()
         {
@@ -65,6 +66,18 @@ namespace Python.Runtime
                         "DelegateManager has not yet been initialized using Python.Runtime.PythonEngine.Initialize().");
                 }
                 return delegateManager;
+            }
+        }
+
+        public static InteropConfiguration InteropConfiguration
+        {
+            get => interopConfiguration;
+            set
+            {
+                if (IsInitialized)
+                    throw new NotSupportedException("Changing interop configuration when engine is running is not supported");
+
+                interopConfiguration = value ?? throw new ArgumentNullException(nameof(InteropConfiguration));
             }
         }
 
@@ -334,6 +347,8 @@ namespace Python.Runtime
             PyObjectConversions.Reset();
 
             initialized = false;
+
+            InteropConfiguration = InteropConfiguration.MakeDefault();
         }
 
         /// <summary>
@@ -563,7 +578,7 @@ namespace Python.Runtime
         /// Interrupts the execution of a thread.
         /// </summary>
         /// <param name="pythonThreadID">The Python thread ID.</param>
-        /// <returns>The number of thread states modified; this is normally one, but will be zero if the thread id isn’t found.</returns>
+        /// <returns>The number of thread states modified; this is normally one, but will be zero if the thread id is not found.</returns>
         public static int Interrupt(ulong pythonThreadID)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/runtime/pytype.cs
+++ b/src/runtime/pytype.cs
@@ -44,12 +44,54 @@ namespace Python.Runtime
             }
         }
 
+        /// <summary>Returns <c>true</c> when type is fully initialized</summary>
+        public bool IsReady => Flags.HasFlag(TypeFlags.Ready);
+
+        internal TypeFlags Flags
+        {
+            get => (TypeFlags)Util.ReadCLong(Handle, TypeOffset.tp_flags);
+            set => Util.WriteCLong(Handle, TypeOffset.tp_flags, (long)value);
+        }
+
         /// <summary>Checks if specified object is a Python type.</summary>
         public static bool IsType(PyObject value)
         {
             if (value is null) throw new ArgumentNullException(nameof(value));
 
             return Runtime.PyType_Check(value.obj);
+        }
+
+        /// <summary>
+        /// Gets <see cref="PyType"/>, which represents the specified CLR type.
+        /// Must be called after the CLR type was mapped to its Python type.
+        /// </summary>
+        internal static PyType Get(Type clrType)
+        {
+            if (clrType == null)
+            {
+                throw new ArgumentNullException(nameof(clrType));
+            }
+
+            ClassBase pyClass = ClassManager.GetClass(clrType);
+            return new PyType(pyClass.ObjectReference);
+        }
+
+        internal BorrowedReference BaseReference
+        {
+            get
+            {
+                return new(Marshal.ReadIntPtr(Handle, TypeOffset.tp_base));
+            }
+            set
+            {
+                var old = BaseReference.DangerousGetAddressOrNull();
+                IntPtr @new = value.DangerousGetAddress();
+
+                Runtime.XIncref(@new);
+                Marshal.WriteIntPtr(Handle, TypeOffset.tp_base, @new);
+
+                Runtime.XDecref(old);
+            }
         }
 
         internal IntPtr GetSlot(TypeSlotID slot)


### PR DESCRIPTION
When embedding Python, host can now provide custom implementations of
`IPythonBaseTypeProvider` via `PythonEngine.InteropConfiguration.PythonBaseTypeProviders`.

When .NET type is reflected to Python, this type provider will be
able to specify which bases the resulting Python class will have.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/862

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
