### PR TITLE
Dynamic arithmetic ops raise correct Python exception on failure

### DIFF
--- a/src/embed_tests/TestPyObject.cs
+++ b/src/embed_tests/TestPyObject.cs
@@ -71,5 +71,13 @@ a = MemberNamesTest()
             var list = PythonEngine.Eval("list");
             Assert.Throws<InvalidCastException>(() => list.AsManagedObject(typeof(int)));
         }
+
+        [Test]
+        public void UnaryMinus_ThrowsOnBadType()
+        {
+            dynamic list = new PyList();
+            var error = Assert.Throws<PythonException>(() => list = -list);
+            Assert.AreEqual("TypeError", error.Type.Name);
+        }
     }
 }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -1398,6 +1398,7 @@ namespace Python.Runtime
                     result = null;
                     return false;
             }
+            Exceptions.ErrorCheck(res);
             result = CheckNone(new PyObject(res));
             return true;
         }
@@ -1450,6 +1451,7 @@ namespace Python.Runtime
                     result = null;
                     return false;
             }
+            Exceptions.ErrorCheck(res);
             result = CheckNone(new PyObject(res));
             return true;
         }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Instead, they crashed with `ArgumentNullException` due to null pointer passed to `PyObject` constructor. Fixed by adding a check for `None`.

### Does this close any currently open issues?

N/A

### Any other comments?

N/A

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
