### PR TITLE
Names of .NET types changed to better support generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ One must now either use enum members (e.g. `MyEnum.Option`), or use enum constru
 -   BREAKING: custom encoders are no longer called for instances of `System.Type`
 -   `PythonException.Restore` no longer clears `PythonException` instance.
 -   Replaced the old `__import__` hook hack with a PEP302-style Meta Path Loader
+-   BREAKING: Names of .NET types (e.g. `str(__class__)`) changed to better support generic types
 
 ### Fixed
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Previously, Python.NET would produce confusing type names in certain scenarios (generic and/or nesting types).

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
