### PR TITLE
Property descriptor made visible on the reflected class

### DIFF
--- a/src/embed_tests/Inspect.cs
+++ b/src/embed_tests/Inspect.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class Inspect
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void InstancePropertiesVisibleOnClass()
+        {
+            var uri = new Uri("http://example.org").ToPython();
+            var uriClass = uri.GetPythonType();
+            var property = uriClass.GetAttr(nameof(Uri.AbsoluteUri));
+            var pyProp = (PropertyObject)ManagedType.GetManagedObject(property.Reference);
+            Assert.AreEqual(nameof(Uri.AbsoluteUri), pyProp.info.Value.Name);
+        }
+    }
+}

--- a/src/runtime/propertyobject.cs
+++ b/src/runtime/propertyobject.cs
@@ -11,7 +11,7 @@ namespace Python.Runtime
     [Serializable]
     internal class PropertyObject : ExtensionType
     {
-        private MaybeMemberInfo<PropertyInfo> info;
+        internal MaybeMemberInfo<PropertyInfo> info;
         private MaybeMethodInfo getter;
         private MaybeMethodInfo setter;
 
@@ -50,9 +50,9 @@ namespace Python.Runtime
             {
                 if (!getter.IsStatic)
                 {
-                    Exceptions.SetError(Exceptions.TypeError,
-                        "instance property must be accessed through a class instance");
-                    return IntPtr.Zero;
+                    Runtime.XIncref(ds);
+                    // unbound property
+                    return ds;
                 }
 
                 try


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Assuming
```csharp
class C
{
  public int Prop { get; set; }
}
```

and Python code using it:
```python
inst = C()
print(inst.Prop)
print(C.Prop)
```

The second print call would fail prior to this change, because accessing `C.Prop` was explicitly denied.

After this change `C.Prop` will return a Python property descriptor for `Prop` property, and `inst.Prop` will behave as before.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
