### PR TITLE
Fix #1523

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -29,6 +29,8 @@ namespace Python.Runtime
         private static Type int64Type;
         private static Type boolType;
         private static Type typeType;
+        private static Type uint64Type;
+        private static Type uint32Type;
 
         static Converter()
         {
@@ -43,13 +45,15 @@ namespace Python.Runtime
             decimalType = typeof(Decimal);
             boolType = typeof(Boolean);
             typeType = typeof(Type);
+            uint64Type = typeof(UInt64);
+            uint32Type = typeof(UInt32);
         }
 
 
         /// <summary>
         /// Given a builtin Python type, return the corresponding CLR type.
         /// </summary>
-        internal static Type GetTypeByAlias(IntPtr op)
+        internal static Type GetTypeByAlias(IntPtr op, Type preferred=null)
         {
             if (op == Runtime.PyStringType)
                 return stringType;
@@ -57,11 +61,17 @@ namespace Python.Runtime
             if (op == Runtime.PyUnicodeType)
                 return stringType;
 
-            if (op == Runtime.PyIntType)
+            if (op == Runtime.PyIntType && (preferred == null || preferred == int32Type))
                 return int32Type;
 
-            if (op == Runtime.PyLongType)
+            if (op == Runtime.PyIntType && (preferred == null || preferred == uint32Type))
+                return uint32Type;
+
+            if (op == Runtime.PyLongType && (preferred == null || preferred == int64Type))
                 return int64Type;
+
+            if (op == Runtime.PyLongType && (preferred == null || preferred == uint64Type))
+                return uint64Type;
 
             if (op == Runtime.PyFloatType)
                 return doubleType;

--- a/src/runtime/methodbinder.cs
+++ b/src/runtime/methodbinder.cs
@@ -725,7 +725,7 @@ namespace Python.Runtime
                 pyoptype = Runtime.PyObject_Type(argument);
                 if (pyoptype != IntPtr.Zero)
                 {
-                    clrtype = Converter.GetTypeByAlias(pyoptype);
+                    clrtype = Converter.GetTypeByAlias(pyoptype, parameterType);
                 }
                 Runtime.XDecref(pyoptype);
             }

--- a/src/testing/conversiontest.cs
+++ b/src/testing/conversiontest.cs
@@ -42,7 +42,7 @@ namespace Python.Test
 
     }
 
-    
+
 
     public interface ISpam
     {
@@ -63,7 +63,7 @@ namespace Python.Test
             return value;
         }
     }
-    
+
     public class UnicodeString
     {
         public string value = "안녕";
@@ -76,6 +76,19 @@ namespace Python.Test
         public override string ToString()
         {
             return value;
+        }
+    }
+
+    public class MethodResolutionInt
+    {
+        public IEnumerable<byte> MethodA(ulong address, int size)
+        {
+            return new byte[10];
+        }
+
+        public int MethodA(string dummy, ulong address, int size)
+        {
+            return 0;
         }
     }
 }

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -4,7 +4,7 @@ import operator
 import pytest
 
 import System
-from Python.Test import ConversionTest, UnicodeString
+from Python.Test import ConversionTest, UnicodeString, MethodResolutionInt
 from Python.Runtime import PyObjectConversions
 from Python.Runtime.Codecs import RawProxyEncoder
 
@@ -681,3 +681,15 @@ def test_codecs():
     l = ob.ListField
     l.Add(42)
     assert ob.ListField.Count == 1
+
+def test_int_param_resolution_required():
+    """Test resolution of `int` parameters when resolution is needed"""
+
+    mri = MethodResolutionInt()
+    data = list(mri.MethodA(0x1000, 10))
+    assert len(data) == 10
+    assert data[0] == 0
+
+    data = list(mri.MethodA(0x100000000, 10))
+    assert len(data) == 10
+    assert data[0] == 0


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds a preferred type parameter to GetTypeByAlias and then the preferred type gets passed in in methodbinder's TryComputeClrArgumentType. I am not sure if this is the best fix for the issue, I know that the test fails before the fix and passes after.


### Does this close any currently open issues?

#1523

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
