### PR TITLE
Replaced Space in CLR Metatype to Underscore

### DIFF
--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -21,7 +21,7 @@ namespace Python.Runtime
         };
 
         /// <summary>
-        /// Metatype initialization. This bootstraps the CLR metatype to life.
+        /// Metatype initialization. This bootstraps the CLR_metatype to life.
         /// </summary>
         public static IntPtr Initialize()
         {
@@ -81,7 +81,7 @@ namespace Python.Runtime
             // We do not support multiple inheritance, so the bases argument
             // should be a 1-item tuple containing the type we are subtyping.
             // That type must itself have a managed implementation. We check
-            // that by making sure its metatype is the CLR metatype.
+            // that by making sure its metatype is the CLR_metatype.
 
             if (Runtime.PyTuple_Size(bases) != 1)
             {
@@ -312,7 +312,7 @@ namespace Python.Runtime
             // Delegate the rest of finalization the Python metatype. Note
             // that the PyType_Type implementation of tp_dealloc will call
             // tp_free on the type of the type being deallocated - in this
-            // case our CLR metatype. That is why we implement tp_free.
+            // case our CLR_metatype. That is why we implement tp_free.
 
             op = Marshal.ReadIntPtr(Runtime.PyTypeType, TypeOffset.tp_dealloc);
             NativeCall.Void_Call_1(op, tp);

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -573,7 +573,7 @@ namespace Python.Runtime
             // the standard type slots, and has to subclass PyType_Type for
             // certain functions in the C runtime to work correctly with it.
 
-            IntPtr type = AllocateTypeObject("CLR Metatype", metatype: Runtime.PyTypeType);
+            IntPtr type = AllocateTypeObject("CLR_Metatype", metatype: Runtime.PyTypeType);
 
             IntPtr py_type = Runtime.PyTypeType;
             Marshal.WriteIntPtr(type, TypeOffset.tp_base, py_type);

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,7 @@ def is_clr_root_module(ob):
 
 
 def is_clr_class(ob):
-    return type(ob).__name__ == 'CLR Metatype'  # for now
+    return type(ob).__name__ == 'CLR_Metatype'  # for now
 
 
 class ClassicClass:


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Space in clrmetatype. Having a space in between them looks confusing just thought to change it.
...

### Does this close any currently open issues?
[#436](https://github.com/pythonnet/pythonnet/issues/436) 
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
