### PR TITLE
`Py.Import` and `PyModule.Import` return `PyObject` instead of `PyModule`

### DIFF
--- a/src/embed_tests/TestFinalizer.cs
+++ b/src/embed_tests/TestFinalizer.cs
@@ -183,7 +183,7 @@ namespace Python.EmbeddingTest
             bool oldState = Finalizer.Instance.Enable;
             try
             {
-                using (PyModule gcModule = PyModule.Import("gc"))
+                using (PyObject gcModule = PyModule.Import("gc"))
                 using (PyObject pyCollect = gcModule.GetAttr("collect"))
                 {
                     long span1 = CompareWithFinalizerOn(pyCollect, false);

--- a/src/embed_tests/TestPyModule.cs
+++ b/src/embed_tests/TestPyModule.cs
@@ -1,6 +1,3 @@
-
-using System;
-
 using NUnit.Framework;
 
 using Python.Runtime;
@@ -42,6 +39,12 @@ namespace Python.EmbeddingTest
 
             Assert.IsTrue(scope.TryGet("x", out dynamic x));
             Assert.AreEqual("True", x.ToString());
+        }
+
+        [Test]
+        public void ImportClrNamespace()
+        {
+            Py.Import(typeof(TestPyModule).Namespace);
         }
     }
 }

--- a/src/runtime/exceptions.cs
+++ b/src/runtime/exceptions.cs
@@ -87,8 +87,8 @@ namespace Python.Runtime
     /// </remarks>
     internal static class Exceptions
     {
-        internal static PyModule warnings_module;
-        internal static PyModule exceptions_module;
+        internal static PyObject warnings_module;
+        internal static PyObject exceptions_module;
 
         /// <summary>
         /// Initialization performed on startup of the Python runtime.

--- a/src/runtime/pymodule.cs
+++ b/src/runtime/pymodule.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Text;
-
-using Python.Runtime.Native;
 
 namespace Python.Runtime
 {
@@ -12,15 +9,14 @@ namespace Python.Runtime
         public PyModule(string name, string filename = null) : this(Create(name, filename)) { }
 
         /// <summary>
-        /// Given a module or package name, import the
-        /// module and return the resulting module object as a <see cref="PyModule"/>.
+        /// Given a module or package name, import the module and return the resulting object.
         /// </summary>
         /// <param name="name">Fully-qualified module or package name</param>
-        public static PyModule Import(string name)
+        public static PyObject Import(string name)
         {
             NewReference op = Runtime.PyImport_ImportModule(name);
             PythonException.ThrowIfIsNull(op);
-            return new PyModule(ref op);
+            return IsModule(op) ? new PyModule(ref op) : op.MoveToPyObject();
         }
 
         /// <summary>
@@ -84,6 +80,13 @@ namespace Python.Runtime
                 PythonException.ThrowIfIsNull(sysModulesRef);
                 return new PyDict(sysModulesRef);
             }
+        }
+
+        internal static bool IsModule(BorrowedReference reference)
+        {
+            if (reference == null) return false;
+            BorrowedReference type = Runtime.PyObject_TYPE(reference);
+            return Runtime.PyType_IsSubtype(type, Runtime.PyModuleType);
         }
     }
 }

--- a/src/runtime/pyscope.cs
+++ b/src/runtime/pyscope.cs
@@ -56,7 +56,7 @@ namespace Python.Runtime
         /// <summary>Create a scope based on a Python Module.</summary>
         private PyScope(IntPtr ptr, PyScopeManager manager) : base(ptr)
         {
-            if (!Runtime.PyType_IsSubtype(Runtime.PyObject_TYPE(Reference), Runtime.PyModuleType))
+            if (!PyModule.IsModule(Reference))
             {
                 throw new PyScopeException("object is not a module");
             }

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -750,11 +750,10 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// Given a module or package name, import the
-        /// module and return the resulting module object as a <see cref="PyModule"/>.
+        /// Given a module or package name, import the module and return the resulting object.
         /// </summary>
         /// <param name="name">Fully-qualified module or package name</param>
-        public static PyModule Import(string name) => PyModule.Import(name);
+        public static PyObject Import(string name) => PyModule.Import(name);
 
         public static void SetArgv()
         {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Not everything that can be imported is `PyModule`

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1489

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change