### PR TITLE
Call tp_clear of base unmanaged type

### DIFF
--- a/src/embed_tests/Inheritance.cs
+++ b/src/embed_tests/Inheritance.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 using NUnit.Framework;
 
@@ -99,6 +97,18 @@ namespace Python.EmbeddingTest
             scope.Exec($"super({nameof(instance)}.__class__, {nameof(instance)}).set_x_to_42()");
             int actual = scope.Eval<int>($"{nameof(instance)}.{nameof(Inherited.XProp)}");
             Assert.AreEqual(expected: Inherited.X, actual);
+        }
+
+        // https://github.com/pythonnet/pythonnet/issues/1476
+        [Test]
+        public void BaseClearIsCalled()
+        {
+            using var scope = Py.CreateScope();
+            scope.Set("exn", new Exception("42"));
+            var msg = scope.Eval("exn.args[0]");
+            Assert.AreEqual(2, msg.Refcount);
+            scope.Set("exn", null);
+            Assert.AreEqual(1, msg.Refcount);
         }
     }
 

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -149,6 +149,16 @@ namespace Python.Runtime
             return (flags & TypeFlags.HasClrInstance) != 0;
         }
 
+        internal static BorrowedReference GetUnmanagedBaseType(BorrowedReference managedType)
+        {
+            Debug.Assert(managedType != null && IsManagedType(managedType));
+            do
+            {
+                managedType = PyType.GetBase(managedType);
+            } while (IsManagedType(managedType));
+            return managedType;
+        }
+
         public bool IsClrMetaTypeInstance()
         {
             Debug.Assert(Runtime.PyCLRMetaType != IntPtr.Zero);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Calls `tp_clear` (if any) of base unmanaged type when a reflected CLR object instance is cleared.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1476

### Any other comments?

C# exceptions inherit from Python `BaseException` class, which has `tp_clear`. Prior to this change it was not called when Python deallocated them leaving dangling references to `BaseException.args` and `BaseException.__cause__`.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change