### PR TITLE
Allow decoding instanceless exceptions

### DIFF
--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -43,6 +43,9 @@
     <EmbeddedResource Include="resources\clr.py">
       <LogicalName>clr.py</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="resources\interop.py">
+      <LogicalName>interop.py</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/runtime/Util.cs
+++ b/src/runtime/Util.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Python.Runtime
@@ -41,5 +43,27 @@ namespace Python.Runtime
         /// </summary>
         internal static IntPtr Coalesce(this IntPtr primary, IntPtr fallback)
             => primary == IntPtr.Zero ? fallback : primary;
+
+        /// <summary>
+        /// Gets substring after last occurrence of <paramref name="symbol"/>
+        /// </summary>
+        internal static string? AfterLast(this string str, char symbol)
+        {
+            if (str is null)
+                throw new ArgumentNullException(nameof(str));
+
+            int last = str.LastIndexOf(symbol);
+            return last >= 0 ? str.Substring(last + 1) : null;
+        }
+
+        internal static string ReadStringResource(this System.Reflection.Assembly assembly, string resourceName)
+        {
+            if (assembly is null) throw new ArgumentNullException(nameof(assembly));
+            if (string.IsNullOrEmpty(resourceName)) throw new ArgumentNullException(nameof(resourceName));
+
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
     }
 }

--- a/src/runtime/resources/interop.py
+++ b/src/runtime/resources/interop.py
@@ -1,0 +1,10 @@
+_UNSET = object()
+
+class PyErr:
+    def __init__(self, type=_UNSET, value=_UNSET, traceback=_UNSET):
+        if not(type is _UNSET):
+            self.type = type
+        if not(value is _UNSET):
+            self.value = value
+        if not(traceback is _UNSET):
+            self.traceback = traceback

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -178,6 +178,8 @@ namespace Python.Runtime
             }
             XDecref(item);
             AssemblyManager.UpdatePath();
+
+            clrInterop = GetModuleLazy("clr.interop");
         }
 
         private static void InitPyMembers()
@@ -406,6 +408,11 @@ namespace Python.Runtime
             Shutdown(mode);
         }
 
+        private static Lazy<PyObject> GetModuleLazy(string moduleName)
+            => moduleName is null
+                ? throw new ArgumentNullException(nameof(moduleName))
+                : new Lazy<PyObject>(() => PyModule.Import(moduleName), isThreadSafe: false);
+
         internal static ShutdownMode GetDefaultShutdownMode()
         {
             string modeEvn = Environment.GetEnvironmentVariable("PYTHONNET_SHUTDOWN_MODE");
@@ -573,6 +580,9 @@ namespace Python.Runtime
         internal static IntPtr PyFalse;
         internal static IntPtr PyNone;
         internal static IntPtr Error;
+
+        private static Lazy<PyObject> clrInterop;
+        internal static PyObject InteropModule => clrInterop.Value;
 
         internal static BorrowedReference CLRMetaType => new BorrowedReference(PyCLRMetaType);
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Added new Python class `clr.interop.PyErr` with optional `type`, `value`, and `traceback` attributes. User can register decoders for it, that would let them decode instanceless (and even typeless) Python exceptions.

These decoders will be invoked before the regular exception instance decoders.

This allows decoding exceptions before they are normalized (which is not always possible).

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
