### PR TITLE
Allow Python to overwrite .NET methods

### DIFF
--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -87,18 +87,6 @@ namespace Python.Runtime
             return -1;
         }
 
-
-        /// <summary>
-        /// Default __set__ implementation - this prevents descriptor instances
-        /// being silently replaced in a type __dict__ by default __setattr__.
-        /// </summary>
-        public static int tp_descr_set(IntPtr ds, IntPtr ob, IntPtr val)
-        {
-            Exceptions.SetError(Exceptions.AttributeError, "attribute is read-only");
-            return -1;
-        }
-
-
         public static void tp_dealloc(IntPtr ob)
         {
             // Clean up a Python instance of this extension type. This

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -14,6 +14,8 @@ namespace Python.Test
         {
         }
 
+        public string OverwritableMethod() => "overwritable";
+
         public string PublicMethod()
         {
             return "public";

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -6,37 +6,12 @@ import System
 import pytest
 from Python.Test import MethodTest
 
+def test_instance_method_overwritable():
+    """Test instance method overwriting."""
 
-def test_instance_method_descriptor():
-    """Test instance method descriptor behavior."""
-
-    with pytest.raises(AttributeError):
-        MethodTest().PublicMethod = 0
-
-    with pytest.raises(AttributeError):
-        MethodTest.PublicMethod = 0
-
-    with pytest.raises(AttributeError):
-        del MethodTest().PublicMethod
-
-    with pytest.raises(AttributeError):
-        del MethodTest.PublicMethod
-
-
-def test_static_method_descriptor():
-    """Test static method descriptor behavior."""
-
-    with pytest.raises(AttributeError):
-        MethodTest().PublicStaticMethod = 0
-
-    with pytest.raises(AttributeError):
-        MethodTest.PublicStaticMethod = 0
-
-    with pytest.raises(AttributeError):
-        del MethodTest().PublicStaticMethod
-
-    with pytest.raises(AttributeError):
-        del MethodTest.PublicStaticMethod
+    ob = MethodTest()
+    ob.OverwritableMethod = lambda: "overwritten"
+    assert ob.OverwritableMethod() == "overwritten"
 
 
 def test_public_instance_method():


### PR DESCRIPTION
This allows Python to hook implementations of .NET methods in-place. Some Python libraries do that (in particular TensorFlow) for validation/tracking purposes.
