### PR TITLE
Allow decoders affect `PyObject.As<object>()`

### DIFF
--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -373,6 +373,31 @@ DateTimeDecoder.Setup()
 
         public static void AcceptsDateTime(DateTime v) {}
 
+        [Test]
+        public void As_Object_AffectedByDecoders()
+        {
+            var everythingElseToSelf = new EverythingElseToSelfDecoder();
+            PyObjectConversions.RegisterDecoder(everythingElseToSelf);
+
+            var pyObj = PythonEngine.Eval("iter");
+            var decoded = pyObj.As<object>();
+            Assert.AreSame(everythingElseToSelf, decoded);
+        }
+
+        public class EverythingElseToSelfDecoder : IPyObjectDecoder
+        {
+            public bool CanDecode(PyObject objectType, Type targetType)
+            {
+                return targetType.IsAssignableFrom(typeof(EverythingElseToSelfDecoder));
+            }
+
+            public bool TryDecode<T>(PyObject pyObj, out T value)
+            {
+                value = (T)(object)this;
+                return true;
+            }
+        }
+
         class ValueErrorWrapper : Exception
         {
             public ValueErrorWrapper(string message) : base(message) { }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -163,20 +163,10 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// As Method
-        /// </summary>
-        /// <remarks>
         /// Return a managed object of the given type, based on the
         /// value of the Python object.
-        /// </remarks>
-        public T As<T>()
-        {
-            if (typeof(T) == typeof(PyObject) || typeof(T) == typeof(object))
-            {
-                return (T)(this as object);
-            }
-            return (T)AsManagedObject(typeof(T));
-        }
+        /// </summary>
+        public T As<T>() => (T)this.AsManagedObject(typeof(T));
 
         internal bool IsDisposed => obj == IntPtr.Zero;
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Prior to this change there was a discrepancy between `.As<object>()` and `.AsManagedObject(typeof(object))`: the former would bypass all registered custom decoders.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change