### PR TITLE
Allow to specificy full path in AddReference

### DIFF
--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -206,6 +206,10 @@ namespace Python.Runtime
             {
                 return null;
             }
+            catch(FileLoadException)
+            {
+                return null;
+            }
         }
 
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
If you specify a full path to an assembly in the *clr.AddReference* it fails with a FileLoadException
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
