### PR TITLE
Allow to specify a full path in clr.AddReference

### DIFF
--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -206,6 +206,10 @@ namespace Python.Runtime
             {
                 return null;
             }
+            catch(FileLoadException)
+            {
+                return null;
+            }
         }
 
 

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -206,10 +206,8 @@ namespace Python.Runtime
             {
                 return null;
             }
-            catch(FileLoadException)
-            {
-                return null;
-            }
+            
+
         }
 
 

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -205,9 +205,7 @@ namespace Python.Runtime
             catch (FileNotFoundException)
             {
                 return null;
-            }
-            
-
+            }          
         }
 
 

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -205,7 +205,7 @@ namespace Python.Runtime
             catch (FileNotFoundException)
             {
                 return null;
-            }          
+            }
         }
 
 

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -518,7 +518,15 @@ namespace Python.Runtime
             }
             if (assembly == null)
             {
-                assembly = AssemblyManager.LoadAssembly(name);
+                try
+                {
+                    assembly = AssemblyManager.LoadAssembly(name);
+                }
+                // The Assembly.Load fail with FileLoadException in case name contains a path
+                catch(FileLoadException)
+                {
+                    assembly=null;
+                }
             }
             if (assembly == null)
             {

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -518,20 +518,13 @@ namespace Python.Runtime
             }
             if (assembly == null)
             {
-                try
-                {
-                    assembly = AssemblyManager.LoadAssembly(name);
-                }
-                // The Assembly.Load fail with FileLoadException in case name contains a path
-                catch(FileLoadException)
-                {
-                    assembly=null;
-                }
+                assembly = AssemblyManager.LoadAssemblyFullPath(name);
             }
             if (assembly == null)
             {
-                assembly = AssemblyManager.LoadAssemblyFullPath(name);
+                    assembly = AssemblyManager.LoadAssembly(name);
             }
+
             if (assembly == null)
             {
                 throw new FileNotFoundException($"Unable to find assembly '{name}'.");


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Allow to specify a full path in clr.AddReference.

The changes consist in first trying to load the assembly directly if the name specified
is a valid root path and the file exists otherwise try to load it from GAC or other valid search locations
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
