### PR TITLE
Simplify `Dispatcher`

### DIFF
--- a/src/runtime/converter.cs
+++ b/src/runtime/converter.cs
@@ -112,6 +112,8 @@ namespace Python.Runtime
 
         internal static NewReference ToPythonReference<T>(T value)
             => NewReference.DangerousFromPointer(ToPython(value, typeof(T)));
+        internal static NewReference ToPythonReference(object value, Type type)
+            => NewReference.DangerousFromPointer(ToPython(value, type));
 
         private static readonly Func<object, bool> IsTransparentProxy = GetIsTransparentProxy();
 

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -120,7 +120,7 @@ class DotNetFinder(importlib.abc.MetaPathFinder):
             var mod_dict = Runtime.PyModule_GetDict(import_hook_module);
             // reference not stolen due to overload incref'ing for us.
             Runtime.PyTuple_SetItem(args, 1, mod_dict);
-            Runtime.PyObject_Call(exec, args, default);
+            Runtime.PyObject_Call(exec, args, default).Dispose();
             // Set as a sub-module of clr.
             if(Runtime.PyModule_AddObject(ClrModuleReference, "loader", import_hook_module.DangerousGetAddress()) != 0)
             {

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -1013,6 +1013,8 @@ namespace Python.Runtime
         internal static NewReference PyObject_Type(BorrowedReference o)
             => Delegates.PyObject_Type(o);
 
+        internal static string PyObject_GetTypeName(BorrowedReference op)
+            => PyObject_GetTypeName(op.DangerousGetAddress());
         internal static string PyObject_GetTypeName(IntPtr op)
         {
             IntPtr pyType = PyObject_TYPE(op);
@@ -1097,8 +1099,8 @@ namespace Python.Runtime
 
 
         internal static IntPtr PyObject_Call(IntPtr pointer, IntPtr args, IntPtr kw) => Delegates.PyObject_Call(pointer, args, kw);
-        internal static IntPtr PyObject_Call(BorrowedReference pointer, BorrowedReference args, BorrowedReference kw) 
-            => Delegates.PyObject_Call(pointer.DangerousGetAddress(), args.DangerousGetAddress(), kw.DangerousGetAddressOrNull());
+        internal static NewReference PyObject_Call(BorrowedReference pointer, BorrowedReference args, BorrowedReference kw) 
+            => NewReference.DangerousFromPointer(Delegates.PyObject_Call(pointer.DangerousGetAddress(), args.DangerousGetAddress(), kw.DangerousGetAddressOrNull()));
 
 
         internal static NewReference PyObject_CallObject(BorrowedReference callable, BorrowedReference args) => Delegates.PyObject_CallObject(callable, args);


### PR DESCRIPTION
Remove risky finalization code from `Dispatcher`, and use reference types