### PR TITLE
Added workaround for warning in `threading` module after `TestInterrupt`

### DIFF
--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -570,8 +570,9 @@ namespace Python.Runtime
         /// <returns>The Python thread ID.</returns>
         public static ulong GetPythonThreadID()
         {
-            dynamic threading = Py.Import("threading");
-            return threading.InvokeMethod("get_ident");
+            using PyObject threading = Py.Import("threading");
+            using PyObject id = threading.InvokeMethod("get_ident");
+            return id.As<ulong>();
         }
 
         /// <summary>


### PR DESCRIPTION
Also: avoid using `dynamic` in `GetPythonThreadID`

### What does this implement/fix? Explain your changes.

This should put us to peace in regards to this warning in CI on MacOS X Python 3.7:

```
Exception ignored in: <module 'threading' from '/Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/threading.py'>
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/threading.py", line 1292, in _shutdown
    assert tlock.locked()
AssertionError: 
```

It happens when the main Python thread never imports `threading` module, while secondary threads do.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change