### PR TITLE
`ClassManager` illegally decrefed `ClassObject`'s refcount on shutdown

### DIFF
--- a/src/embed_tests/pyinitialize.cs
+++ b/src/embed_tests/pyinitialize.cs
@@ -46,6 +46,22 @@ namespace Python.EmbeddingTest
             }
         }
 
+        // regression test for https://github.com/pythonnet/pythonnet/issues/1561
+        [Test]
+        public void ImportClassShutdownRefcount()
+        {
+            PythonEngine.Initialize();
+
+            PyObject ns = Py.Import(typeof(ImportClassShutdownRefcountClass).Namespace);
+            PyObject cls = ns.GetAttr(nameof(ImportClassShutdownRefcountClass));
+            ns.Dispose();
+
+            Assert.Less(cls.Refcount, 256);
+
+            PythonEngine.Shutdown();
+            Assert.Greater(cls.Refcount, 0);
+        }
+
         /// <summary>
         /// Failing test demonstrating current issue with OverflowException (#376)
         /// and ArgumentException issue after that one is fixed.
@@ -182,4 +198,6 @@ namespace Python.EmbeddingTest
             Assert.True(called);
         }
     }
+
+    public class ImportClassShutdownRefcountClass { }
 }

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -67,7 +67,6 @@ namespace Python.Runtime
                     // since others may still referencing it.
                     cls.CallTypeTraverse(TraverseTypeClear, visitedPtr);
                     cls.CallTypeClear();
-                    cls.DecrRefCount();
                 }
             }
             finally


### PR DESCRIPTION
### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1561

### Any other comments?

Long term we should switch `ManagedType` and other classes, that hold long-lived references to Python objects to use `PyObject`. This would make any code, that uses them refcount-balanced automatically.

See #1562

### Checklist
-   [x] Make sure to include one or more tests for your change