### PR TITLE
Do not clean `tpHandle` in `ClassBase.tp_clear` - it might be used in `tp_dealloc`

### DIFF
--- a/src/runtime/classbase.cs
+++ b/src/runtime/classbase.cs
@@ -373,7 +373,6 @@ namespace Python.Runtime
                     return baseClearResult;
                 }
             }
-            if (self is not null) self.tpHandle = IntPtr.Zero;
             return 0;
         }
 

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -28,8 +28,23 @@ namespace Python.Runtime
         internal IntPtr pyHandle; // PyObject *
         internal IntPtr tpHandle; // PyType *
 
-        internal BorrowedReference ObjectReference => new(pyHandle);
-        internal BorrowedReference TypeReference => new(tpHandle);
+        internal BorrowedReference ObjectReference
+        {
+            get
+            {
+                Debug.Assert(pyHandle != IntPtr.Zero);
+                return new(pyHandle);
+            }
+        }
+
+        internal BorrowedReference TypeReference
+        {
+            get
+            {
+                Debug.Assert(tpHandle != IntPtr.Zero);
+                return new(tpHandle);
+            }
+        }
 
         private static readonly Dictionary<ManagedType, TrackTypes> _managedObjs = new Dictionary<ManagedType, TrackTypes>();
 
@@ -310,6 +325,8 @@ namespace Python.Runtime
 
         internal static void SetGCHandle(BorrowedReference reflectedClrObject, BorrowedReference type, GCHandle newHandle)
         {
+            Debug.Assert(type != null);
+            Debug.Assert(reflectedClrObject != null);
             Debug.Assert(Runtime.PyObject_TypeCheck(reflectedClrObject, type));
 
             int offset = Marshal.ReadInt32(type.DangerousGetAddress(), Offsets.tp_clr_inst_offset);

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -2021,7 +2021,11 @@ namespace Python.Runtime
         internal static void PyType_Modified(BorrowedReference type) => Delegates.PyType_Modified(type);
         internal static bool PyType_IsSubtype(BorrowedReference t1, IntPtr ofType)
             => PyType_IsSubtype(t1, new BorrowedReference(ofType));
-        internal static bool PyType_IsSubtype(BorrowedReference t1, BorrowedReference t2) => Delegates.PyType_IsSubtype(t1, t2);
+        internal static bool PyType_IsSubtype(BorrowedReference t1, BorrowedReference t2)
+        {
+            Debug.Assert(t1 != null && t2 != null);
+            return Delegates.PyType_IsSubtype(t1, t2);
+        }
 
         internal static bool PyObject_TypeCheck(IntPtr ob, IntPtr tp)
             => PyObject_TypeCheck(new BorrowedReference(ob), new BorrowedReference(tp));

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -290,3 +290,19 @@ def test_construction_from_clr():
     assert len(calls) == 1
     assert calls[0][0] == 1
     assert calls[0][1] == "foo"
+
+# regression test for https://github.com/pythonnet/pythonnet/issues/1565
+def test_can_be_collected_by_gc():
+    from Python.Test import BaseClass
+
+    class Derived(BaseClass):
+        __namespace__ = 'test_can_be_collected_by_gc'
+
+    inst = Derived()
+    cycle = [inst]
+    del inst
+    cycle.append(cycle)
+    del cycle
+
+    import gc
+    gc.collect()


### PR DESCRIPTION
### Does this close any currently open issues?

#1565

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change