### PR TITLE
Disable implicit conversions that might lose information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   .NET collection types now implement standard Python collection interfaces from `collections.abc`.
 See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   .NET arrays implement Python buffer protocol
+-   Python.NET will correctly resolve .NET methods, that accept `PyList`, `PyInt`,
+and other `PyObject` derived types when called from Python.
 
 
 ### Changed
@@ -51,13 +53,20 @@ One must now either use enum members (e.g. `MyEnum.Option`), or use enum constru
 -   Sign Runtime DLL with a strong name
 -   Implement loading through `clr_loader` instead of the included `ClrModule`, enables
     support for .NET Core
--   .NET and Python exceptions are preserved when crossing Python/.NET boundary
+-   BREAKING: .NET and Python exceptions are preserved when crossing Python/.NET boundary
 -   BREAKING: custom encoders are no longer called for instances of `System.Type`
 -   `PythonException.Restore` no longer clears `PythonException` instance.
 -   Replaced the old `__import__` hook hack with a PEP302-style Meta Path Loader
 -   BREAKING: Names of .NET types (e.g. `str(__class__)`) changed to better support generic types
 -   BREAKING: overload resolution will no longer prefer basic types. Instead, first matching overload will
 be chosen.
+-   BREAKING: .NET collections and arrays are no longer automatically converted to
+Python collections. Instead, they implement standard Python
+collection interfaces from `collections.abc`.
+See [Mixins/collections.py](src/runtime/Mixins/collections.py).
+-   BREAKING: When trying to convert Python `int` to `System.Object`, result will
+be of type `PyInt` instead of `System.Int32` due to possible loss of information.
+Python `float` will continue to be converted to `System.Double`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   .NET arrays implement Python buffer protocol
 -   Python.NET will correctly resolve .NET methods, that accept `PyList`, `PyInt`,
 and other `PyObject` derived types when called from Python.
+-   `PyIterable` type, that wraps any iterable object in Python
 
 
 ### Changed
@@ -67,6 +68,8 @@ See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   BREAKING: When trying to convert Python `int` to `System.Object`, result will
 be of type `PyInt` instead of `System.Int32` due to possible loss of information.
 Python `float` will continue to be converted to `System.Double`.
+-   BREAKING: `PyObject` no longer implements `IEnumerable<PyObject>`.
+Instead, `PyIterable` does that.
 
 ### Fixed
 

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -45,12 +45,12 @@ namespace Python.EmbeddingTest {
         [Test]
         public void TupleConversionsObject()
         {
-            TupleConversionsObject<ValueTuple<int, string, object>, ValueTuple>();
+            TupleConversionsObject<ValueTuple<double, string, object>, ValueTuple>();
         }
         static void TupleConversionsObject<T, TTuple>()
         {
             TupleCodec<TTuple>.Register();
-            var tuple = Activator.CreateInstance(typeof(T), 42, "42", new object());
+            var tuple = Activator.CreateInstance(typeof(T), 42.0, "42", new object());
             T restored = default;
             using (var scope = Py.CreateScope())
             {
@@ -66,11 +66,11 @@ namespace Python.EmbeddingTest {
         [Test]
         public void TupleRoundtripObject()
         {
-            TupleRoundtripObject<ValueTuple<int, string, object>, ValueTuple>();
+            TupleRoundtripObject<ValueTuple<double, string, object>, ValueTuple>();
         }
         static void TupleRoundtripObject<T, TTuple>()
         {
-            var tuple = Activator.CreateInstance(typeof(T), 42, "42", new object());
+            var tuple = Activator.CreateInstance(typeof(T), 42.0, "42", new object());
             var pyTuple = TupleCodec<TTuple>.Instance.TryEncode(tuple);
             Assert.IsTrue(TupleCodec<TTuple>.Instance.TryDecode(pyTuple, out object restored));
             Assert.AreEqual(expected: tuple, actual: restored);
@@ -231,7 +231,7 @@ namespace Python.EmbeddingTest {
             //ensure a PyList can be converted to a plain IEnumerable
             System.Collections.IEnumerable plainEnumerable1 = null;
             Assert.DoesNotThrow(() => { codec.TryDecode(pyList, out plainEnumerable1); });
-            CollectionAssert.AreEqual(plainEnumerable1, new List<object> { 1, 2, 3 });
+            CollectionAssert.AreEqual(plainEnumerable1.Cast<PyInt>().Select(i => i.ToInt32()), new List<object> { 1, 2, 3 });
 
             //can convert to any generic ienumerable.  If the type is not assignable from the python element
             //it will lead to an empty iterable when decoding.  TODO - should it throw?
@@ -271,7 +271,7 @@ namespace Python.EmbeddingTest {
             var fooType = foo.GetPythonType();
             System.Collections.IEnumerable plainEnumerable2 = null;
             Assert.DoesNotThrow(() => { codec.TryDecode(pyList, out plainEnumerable2); });
-            CollectionAssert.AreEqual(plainEnumerable2, new List<object> { 1, 2, 3 });
+            CollectionAssert.AreEqual(plainEnumerable2.Cast<PyInt>().Select(i => i.ToInt32()), new List<object> { 1, 2, 3 });
 
             //can convert to any generic ienumerable.  If the type is not assignable from the python element
             //it will be an exception during TryDecode

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -117,6 +117,25 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
+        public void ToNullable()
+        {
+            const int Const = 42;
+            var i = new PyInt(Const);
+            var ni = i.As<int?>();
+            Assert.AreEqual(Const, ni);
+        }
+
+        [Test]
+        public void ToPyList()
+        {
+            var list = new PyList();
+            list.Append("hello".ToPython());
+            list.Append("world".ToPython());
+            var back = list.ToPython().As<PyList>();
+            Assert.AreEqual(list.Length(), back.Length());
+        }
+
+        [Test]
         public void RawListProxy()
         {
             var list = new List<string> {"hello", "world"};

--- a/src/runtime/Util.cs
+++ b/src/runtime/Util.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -68,5 +69,7 @@ namespace Python.Runtime
             using var reader = new StreamReader(stream);
             return reader.ReadToEnd();
         }
+
+        public static IEnumerator<T> GetEnumerator<T>(this IEnumerator<T> enumerator) => enumerator;
     }
 }

--- a/src/runtime/classderived.cs
+++ b/src/runtime/classderived.cs
@@ -174,7 +174,7 @@ namespace Python.Runtime
             {
                 Runtime.XIncref(py_dict);
                 using (var dict = new PyDict(py_dict))
-                using (PyObject keys = dict.Keys())
+                using (PyIterable keys = dict.Keys())
                 {
                     foreach (PyObject pyKey in keys)
                     {
@@ -223,7 +223,7 @@ namespace Python.Runtime
             {
                 Runtime.XIncref(py_dict);
                 using (var dict = new PyDict(py_dict))
-                using (PyObject keys = dict.Keys())
+                using (PyIterable keys = dict.Keys())
                 {
                     foreach (PyObject pyKey in keys)
                     {
@@ -439,17 +439,12 @@ namespace Python.Runtime
             }
 
             using (PyObject pyReturnType = func.GetAttr("_clr_return_type_"))
-            using (PyObject pyArgTypes = func.GetAttr("_clr_arg_types_"))
+            using (var pyArgTypes = PyIter.GetIter(func.GetAttr("_clr_arg_types_")))
             {
                 var returnType = pyReturnType.AsManagedObject(typeof(Type)) as Type;
                 if (returnType == null)
                 {
                     returnType = typeof(void);
-                }
-
-                if (!pyArgTypes.IsIterable())
-                {
-                    throw new ArgumentException("_clr_arg_types_ must be a list or tuple of CLR types");
                 }
 
                 var argTypes = new List<Type>();

--- a/src/runtime/pydict.cs
+++ b/src/runtime/pydict.cs
@@ -8,7 +8,7 @@ namespace Python.Runtime
     /// PY3: https://docs.python.org/3/c-api/dict.html
     /// for details.
     /// </summary>
-    public class PyDict : PyObject
+    public class PyDict : PyIterable
     {
         /// <summary>
         /// PyDict Constructor
@@ -102,14 +102,14 @@ namespace Python.Runtime
         /// <remarks>
         /// Returns a sequence containing the keys of the dictionary.
         /// </remarks>
-        public PyObject Keys()
+        public PyIterable Keys()
         {
             using var items = Runtime.PyDict_Keys(Reference);
             if (items.IsNull())
             {
                 throw PythonException.ThrowLastAsClrException();
             }
-            return items.MoveToPyObject();
+            return new PyIterable(items.Steal());
         }
 
 
@@ -119,14 +119,14 @@ namespace Python.Runtime
         /// <remarks>
         /// Returns a sequence containing the values of the dictionary.
         /// </remarks>
-        public PyObject Values()
+        public PyIterable Values()
         {
             IntPtr items = Runtime.PyDict_Values(obj);
             if (items == IntPtr.Zero)
             {
                 throw PythonException.ThrowLastAsClrException();
             }
-            return new PyObject(items);
+            return new PyIterable(items);
         }
 
 
@@ -136,22 +136,14 @@ namespace Python.Runtime
         /// <remarks>
         /// Returns a sequence containing the items of the dictionary.
         /// </remarks>
-        public PyObject Items()
+        public PyIterable Items()
         {
-            var items = Runtime.PyDict_Items(this.Reference);
-            try
+            using var items = Runtime.PyDict_Items(this.Reference);
+            if (items.IsNull())
             {
-                if (items.IsNull())
-                {
-                    throw PythonException.ThrowLastAsClrException();
-                }
-
-                return items.MoveToPyObject();
+                throw PythonException.ThrowLastAsClrException();
             }
-            finally
-            {
-                items.Dispose();
-            }
+            return new PyIterable(items.Steal());
         }
 
 

--- a/src/runtime/pyint.cs
+++ b/src/runtime/pyint.cs
@@ -22,6 +22,11 @@ namespace Python.Runtime
         {
         }
 
+        internal PyInt(BorrowedReference reference): base(reference)
+        {
+            if (!Runtime.PyInt_Check(reference)) throw new ArgumentException("object is not an int");
+        }
+
 
         /// <summary>
         /// PyInt Constructor

--- a/src/runtime/pyiterable.cs
+++ b/src/runtime/pyiterable.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Python.Runtime
+{
+    public class PyIterable : PyObject, IEnumerable<PyObject>
+    {
+        internal PyIterable(IntPtr ptr) : base(ptr)
+        {
+        }
+
+        internal PyIterable(BorrowedReference reference) : base(reference) { }
+        internal PyIterable(in StolenReference reference) : base(reference) { }
+
+        /// <summary>
+        /// Return a new PyIter object for the object. This allows any iterable
+        /// python object to be iterated over in C#. A PythonException will be
+        /// raised if the object is not iterable.
+        /// </summary>
+        public PyIter GetEnumerator()
+        {
+            return PyIter.GetIter(this);
+        }
+        IEnumerator<PyObject> IEnumerable<PyObject>.GetEnumerator() => this.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+    }
+}

--- a/src/runtime/pynumber.cs
+++ b/src/runtime/pynumber.cs
@@ -17,6 +17,8 @@ namespace Python.Runtime
         {
         }
 
+        internal PyNumber(BorrowedReference reference): base(reference) { }
+
         /// <summary>
         /// IsNumberType Method
         /// </summary>

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -17,7 +17,7 @@ namespace Python.Runtime
     /// </summary>
     [Serializable]
     [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
-    public partial class PyObject : DynamicObject, IEnumerable<PyObject>, IDisposable
+    public partial class PyObject : DynamicObject, IDisposable
     {
 #if TRACE_ALLOC
         /// <summary>
@@ -80,7 +80,7 @@ namespace Python.Runtime
 #endif
         }
 
-        internal PyObject(StolenReference reference)
+        internal PyObject(in StolenReference reference)
         {
             if (reference == null) throw new ArgumentNullException(nameof(reference));
 
@@ -702,21 +702,6 @@ namespace Python.Runtime
             }
             return new PyObject(r);
         }
-
-        /// <summary>
-        /// GetEnumerator Method
-        /// </summary>
-        /// <remarks>
-        /// Return a new PyIter object for the object. This allows any iterable
-        /// python object to be iterated over in C#. A PythonException will be
-        /// raised if the object is not iterable.
-        /// </remarks>
-        public IEnumerator<PyObject> GetEnumerator()
-        {
-            return PyIter.GetIter(this);
-        }
-        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-
 
         /// <summary>
         /// Invoke Method

--- a/src/runtime/pysequence.cs
+++ b/src/runtime/pysequence.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 
 namespace Python.Runtime
 {
@@ -10,13 +9,14 @@ namespace Python.Runtime
     /// PY3: https://docs.python.org/3/c-api/sequence.html
     /// for details.
     /// </summary>
-    public class PySequence : PyObject, IEnumerable
+    public class PySequence : PyIterable
     {
-        protected PySequence(IntPtr ptr) : base(ptr)
+        protected internal PySequence(IntPtr ptr) : base(ptr)
         {
         }
 
         internal PySequence(BorrowedReference reference) : base(reference) { }
+        internal PySequence(StolenReference reference) : base(reference) { }
 
 
         /// <summary>
@@ -29,7 +29,6 @@ namespace Python.Runtime
         {
             return Runtime.PySequence_Check(value.obj);
         }
-
 
         /// <summary>
         /// GetSlice Method

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -387,7 +387,7 @@ namespace Python.Runtime
             using var traceback = PyModule.Import("traceback");
             var buffer = new StringBuilder();
             using var values = traceback.InvokeMethod("format_exception", copy.Type, copy.Value, copy.Traceback);
-            foreach (PyObject val in values)
+            foreach (PyObject val in PyIter.GetIter(values))
             {
                 buffer.Append(val);
                 val.Dispose();

--- a/src/runtime/pythonexception.cs
+++ b/src/runtime/pythonexception.cs
@@ -139,9 +139,9 @@ namespace Python.Runtime
 
             try
             {
-                if (Converter.ToManagedValue(pyInfo, typeof(ExceptionDispatchInfo), out object result, setError: false))
+                if (Converter.ToManagedValue(pyInfo, typeof(ExceptionDispatchInfo), out object? result, setError: false))
                 {
-                    return (ExceptionDispatchInfo)result;
+                    return (ExceptionDispatchInfo)result!;
                 }
 
                 return null;

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -8,6 +8,7 @@ import System
 import pytest
 
 from collections import UserList
+from System import Single as float32
 
 
 def test_public_array():
@@ -533,8 +534,8 @@ def test_single_array():
     assert items[0] == 0.0
     assert items[4] == 4.0
 
-    max_ = 3.402823e38
-    min_ = -3.402823e38
+    max_ = float32(3.402823e38)
+    min_ = float32(-3.402823e38)
 
     items[0] = max_
     assert items[0] == max_
@@ -1291,7 +1292,7 @@ def test_special_array_creation():
 
     value = Array[System.Single]([0.0, 3.402823e38])
     assert value[0] == 0.0
-    assert value[1] == 3.402823e38
+    assert value[1] == System.Single(3.402823e38)
     assert value.Length == 2
 
     value = Array[System.Double]([0.0, 1.7976931348623157e308])

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -413,16 +413,10 @@ def test_single_conversion():
     assert ob.SingleField == 0.0
 
     ob.SingleField = 3.402823e38
-    assert ob.SingleField == 3.402823e38
+    assert ob.SingleField == System.Single(3.402823e38)
 
     ob.SingleField = -3.402823e38
-    assert ob.SingleField == -3.402823e38
-
-    ob.SingleField = System.Single(3.402823e38)
-    assert ob.SingleField == 3.402823e38
-
-    ob.SingleField = System.Single(-3.402823e38)
-    assert ob.SingleField == -3.402823e38
+    assert ob.SingleField == System.Single(-3.402823e38)
 
     with pytest.raises(TypeError):
         ConversionTest().SingleField = "spam"

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -300,7 +300,7 @@ def test_single_field():
     assert ob.SingleField == 0.0
 
     ob.SingleField = 1.1
-    assert ob.SingleField == 1.1
+    assert ob.SingleField == System.Single(1.1)
 
 
 def test_double_field():

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -259,7 +259,7 @@ def test_generic_type_binding():
     assert_generic_wrapper_by_type(System.UInt16, 65000)
     assert_generic_wrapper_by_type(System.UInt32, 4294967295)
     assert_generic_wrapper_by_type(System.UInt64, 18446744073709551615)
-    assert_generic_wrapper_by_type(System.Single, 3.402823e38)
+    assert_generic_wrapper_by_type(System.Single, System.Single(3.402823e38))
     assert_generic_wrapper_by_type(System.Double, 1.7976931348623157e308)
     assert_generic_wrapper_by_type(float, 1.7976931348623157e308)
     assert_generic_wrapper_by_type(System.Decimal, System.Decimal.One)
@@ -309,7 +309,7 @@ def test_generic_method_type_handling():
     assert_generic_method_by_type(System.Int32, 2147483647)
     assert_generic_method_by_type(int, 2147483647)
     assert_generic_method_by_type(System.UInt16, 65000)
-    assert_generic_method_by_type(System.Single, 3.402823e38)
+    assert_generic_method_by_type(System.Single, System.Single(3.402823e38))
     assert_generic_method_by_type(System.Double, 1.7976931348623157e308)
     assert_generic_method_by_type(float, 1.7976931348623157e308)
     assert_generic_method_by_type(System.Decimal, System.Decimal.One)
@@ -504,7 +504,7 @@ def test_method_overload_selection_with_generic_types():
     vtype = GenericWrapper[System.Single]
     input_ = vtype(3.402823e38)
     value = MethodTest.Overloaded.__overloads__[vtype](input_)
-    assert value.value == 3.402823e38
+    assert value.value == System.Single(3.402823e38)
 
     vtype = GenericWrapper[System.Double]
     input_ = vtype(1.7976931348623157e308)
@@ -663,7 +663,7 @@ def test_overload_selection_with_arrays_of_generic_types():
     vtype = System.Array[gtype]
     input_ = vtype([gtype(3.402823e38), gtype(3.402823e38)])
     value = MethodTest.Overloaded.__overloads__[vtype](input_)
-    assert value[0].value == 3.402823e38
+    assert value[0].value == System.Single(3.402823e38)
     assert value.Length == 2
 
     gtype = GenericWrapper[System.Double]

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -510,7 +510,7 @@ def test_explicit_overload_selection():
     assert value == 18446744073709551615
 
     value = MethodTest.Overloaded.__overloads__[System.Single](3.402823e38)
-    assert value == 3.402823e38
+    assert value == System.Single(3.402823e38)
 
     value = MethodTest.Overloaded.__overloads__[System.Double](
         1.7976931348623157e308)
@@ -645,7 +645,7 @@ def test_overload_selection_with_array_types():
     input_ = vtype([0.0, 3.402823e38])
     value = MethodTest.Overloaded.__overloads__[vtype](input_)
     assert value[0] == 0.0
-    assert value[1] == 3.402823e38
+    assert value[1] == System.Single(3.402823e38)
 
     vtype = Array[System.Double]
     input_ = vtype([0.0, 1.7976931348623157e308])

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -357,7 +357,7 @@ def test_clr_get_clr_type():
     comparable = GetClrType(IComparable)
     assert comparable.FullName == "System.IComparable"
     assert comparable.IsInterface
-    assert GetClrType(int).FullName == "System.Int32"
+    assert GetClrType(int).FullName == "Python.Runtime.PyInt"
     assert GetClrType(str).FullName == "System.String"
     assert GetClrType(float).FullName == "System.Double"
     dblarr = System.Array[System.Double]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This removes the following conversions:
`PyInt` -> `int32` (when trying to convert to `object` only)
.NET arrays and collections -> Python `list` (due to mutability)

Additionally, `PyObject` no longer implements `IEnumerable<PyObject>`, as not all python objects are iterable. Instead, a new class `PyIterable` is added.

### Checklist

-   [x] Make sure to include one or more tests for your change
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
