### PR TITLE
Fixed `FileLoadException` when trying `clr.AddReference('/full/path.dll')`

### DIFF
--- a/src/embed_tests/pyimport.cs
+++ b/src/embed_tests/pyimport.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
+
 using NUnit.Framework;
 using Python.Runtime;
 
@@ -83,9 +85,17 @@ namespace Python.EmbeddingTest
         public void BadAssembly()
         {
             string path;
-            if (Python.Runtime.Runtime.IsWindows)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 path = @"C:\Windows\System32\kernel32.dll";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                path = "/usr/lib/libc.dylib";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                path = "/usr/lib/locale/locale-archive";
             }
             else
             {
@@ -98,7 +108,7 @@ import clr
 clr.AddReference('{path}')
 ";
 
-            Assert.Throws<FileLoadException>(() => PythonEngine.Exec(code));
+            Assert.Throws<BadImageFormatException>(() => PythonEngine.Exec(code));
         }
     }
 }

--- a/src/runtime/assemblymanager.cs
+++ b/src/runtime/assemblymanager.cs
@@ -121,6 +121,18 @@ namespace Python.Runtime
             return LoadAssemblyPath(name.Name);
         }
 
+        internal static AssemblyName? TryParseAssemblyName(string name)
+        {
+            try
+            {
+                return new AssemblyName(name);
+            }
+            catch (FileLoadException)
+            {
+                return null;
+            }
+        }
+
 
         /// <summary>
         /// We __really__ want to avoid using Python objects or APIs when
@@ -208,18 +220,11 @@ namespace Python.Runtime
 
         /// <summary>
         /// Loads an assembly from the application directory or the GAC
-        /// given a simple assembly name. Returns the assembly if loaded.
+        /// given its name. Returns the assembly if loaded.
         /// </summary>
-        public static Assembly LoadAssembly(string name)
+        public static Assembly LoadAssembly(AssemblyName name)
         {
-            try
-            {
-                return Assembly.Load(name);
-            }
-            catch (FileNotFoundException)
-            {
-                return null;
-            }
+            return Assembly.Load(name);
         }
 
 

--- a/src/runtime/moduleobject.cs
+++ b/src/runtime/moduleobject.cs
@@ -516,9 +516,9 @@ namespace Python.Runtime
             {
                 assembly = AssemblyManager.LoadAssemblyPath(name);
             }
-            if (assembly == null)
+            if (assembly == null && AssemblyManager.TryParseAssemblyName(name) is { } parsedName)
             {
-                assembly = AssemblyManager.LoadAssembly(name);
+                assembly = AssemblyManager.LoadAssembly(parsedName);
             }
             if (assembly == null)
             {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Before trying to load an assembly by its full path we were trying to call `Assembly.Load` on it. `Assembly.Load` interprets its argument as a valid `AssemblyName`. However full paths are not valid assembly names, so that call would throw `FileLoadException`, which we did not handle.

The fix is to separately try to parse input string into an `AssemblyName` and only try `Assembly.Load` when it succeeds.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/commit/9d5f57973bafb9086bb7664547abbd73c9fabc3c#commitcomment-57061082

### Any other comments?

Related: https://github.com/pythonnet/pythonnet/issues/1514
