### PR TITLE
Raise `BadPythonDllException`  instead of confusing `TypeLoadException` when `PythonDLL` was not configured properly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,10 +45,11 @@ module:
 Embedding Python in .NET
 ------------------------
 
--  You must set `Runtime.PythonDLL` property or `PYTHONNET_PYDLL` environment variable
-   starting with version 3.0, otherwise you will receive `TypeInitializationException`.
-   Typical values are `python38.dll` (Windows), `libpython3.8.dylib` (Mac),
-   `libpython3.8.so` (most other *nix).
+-  You must set ``Runtime.PythonDLL`` property or ``PYTHONNET_PYDLL`` environment variable
+   starting with version 3.0, otherwise you will receive ``BadPythonDllException``
+   (internal, derived from ``MissingMethodException``) upon calling ``Initialize``.
+   Typical values are ``python38.dll`` (Windows), ``libpython3.8.dylib`` (Mac),
+   ``libpython3.8.so`` (most other *nix).
 -  All calls to python should be inside a
    ``using (Py.GIL()) {/* Your code here */}`` block.
 -  Import python modules using ``dynamic mod = Py.Import("mod")``, then

--- a/src/embed_tests/TestPythonEngineProperties.cs
+++ b/src/embed_tests/TestPythonEngineProperties.cs
@@ -81,7 +81,7 @@ namespace Python.EmbeddingTest
         public static void GetProgramNameDefault()
         {
             PythonEngine.Initialize();
-            string s = PythonEngine.PythonHome;
+            string s = PythonEngine.ProgramName;
 
             Assert.NotNull(s);
             PythonEngine.Shutdown();

--- a/src/runtime/platform/LibraryLoader.cs
+++ b/src/runtime/platform/LibraryLoader.cs
@@ -111,7 +111,7 @@ namespace Python.Runtime.Platform
         {
             var res = WindowsLoader.LoadLibrary(dllToLoad);
             if (res == IntPtr.Zero)
-                throw new DllNotFoundException($"Could not load {dllToLoad}", new Win32Exception());
+                throw new DllNotFoundException($"Could not load {dllToLoad}.", new Win32Exception());
             return res;
         }
 
@@ -128,7 +128,7 @@ namespace Python.Runtime.Platform
 
             var res = WindowsLoader.GetProcAddress(hModule, procedureName);
             if (res == IntPtr.Zero)
-                throw new MissingMethodException($"Failed to load symbol {procedureName}", new Win32Exception());
+                throw new MissingMethodException($"Failed to load symbol {procedureName}.", new Win32Exception());
             return res;
         }
 

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -86,13 +86,15 @@ namespace Python.Runtime
         {
             get
             {
-                IntPtr p = Runtime.Py_GetProgramName();
+                IntPtr p = Runtime.TryUsingDll(() => Runtime.Py_GetProgramName());
                 return UcsMarshaler.PtrToPy3UnicodePy2String(p) ?? "";
             }
             set
             {
                 Marshal.FreeHGlobal(_programName);
-                _programName = UcsMarshaler.Py3UnicodePy2StringtoPtr(value);
+                _programName = Runtime.TryUsingDll(
+                    () => UcsMarshaler.Py3UnicodePy2StringtoPtr(value)
+                );
                 Runtime.Py_SetProgramName(_programName);
             }
         }
@@ -101,14 +103,16 @@ namespace Python.Runtime
         {
             get
             {
-                IntPtr p = Runtime.Py_GetPythonHome();
+                IntPtr p = Runtime.TryUsingDll(() => Runtime.Py_GetPythonHome());
                 return UcsMarshaler.PtrToPy3UnicodePy2String(p) ?? "";
             }
             set
             {
                 // this value is null in the beginning
                 Marshal.FreeHGlobal(_pythonHome);
-                _pythonHome = UcsMarshaler.Py3UnicodePy2StringtoPtr(value);
+                _pythonHome = Runtime.TryUsingDll(
+                    () => UcsMarshaler.Py3UnicodePy2StringtoPtr(value)
+                );
                 Runtime.Py_SetPythonHome(_pythonHome);
             }
         }
@@ -117,13 +121,15 @@ namespace Python.Runtime
         {
             get
             {
-                IntPtr p = Runtime.Py_GetPath();
+                IntPtr p = Runtime.TryUsingDll(() => Runtime.Py_GetPath());
                 return UcsMarshaler.PtrToPy3UnicodePy2String(p) ?? "";
             }
             set
             {
                 Marshal.FreeHGlobal(_pythonPath);
-                _pythonPath = UcsMarshaler.Py3UnicodePy2StringtoPtr(value);
+                _pythonPath = Runtime.TryUsingDll(
+                    () => UcsMarshaler.Py3UnicodePy2StringtoPtr(value)
+                );
                 Runtime.Py_SetPath(_pythonPath);
             }
         }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This handles failure to load internal `Delegates` type due to misconfigured `PythonDLL`, which used to raise `TypeLoadException` whose `InnerException` would give users the details. Unfortunately, some users do not bother to go as far as to look into the `InnerException`, and instead go straight to GitHub and report "a bug".

This change handles that `TypeLoadException` and rethrows it as `BadPythonDllException` in major entry points, which makes looking into `InnerException` unnecessary, hopefully reducing the number of "bugs"

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
