### PR TITLE
Safer `GetAttr(name, default)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   BREAKING: When trying to convert Python `int` to `System.Object`, result will
 be of type `PyInt` instead of `System.Int32` due to possible loss of information.
 Python `float` will continue to be converted to `System.Double`.
+-   BREAKING: `PyObject.GetAttr(name, default)` now only ignores `AttributeError` (previously ignored all exceptions).
 -   BREAKING: `PyObject` no longer implements `IEnumerable<PyObject>`.
 Instead, `PyIterable` does that.
 

--- a/src/embed_tests/TestPyObject.cs
+++ b/src/embed_tests/TestPyObject.cs
@@ -79,5 +79,26 @@ a = MemberNamesTest()
             var error = Assert.Throws<PythonException>(() => list = -list);
             Assert.AreEqual("TypeError", error.Type.Name);
         }
+
+        [Test]
+        [Obsolete]
+        public void GetAttrDefault_IgnoresAttributeErrorOnly()
+        {
+            var ob = new PyObjectTestMethods().ToPython();
+            using var fallback = new PyList();
+            var attrErrResult = ob.GetAttr(nameof(PyObjectTestMethods.RaisesAttributeError), fallback);
+            Assert.IsTrue(PythonReferenceComparer.Instance.Equals(fallback, attrErrResult));
+
+            var typeErrResult = Assert.Throws<PythonException>(
+                () => ob.GetAttr(nameof(PyObjectTestMethods.RaisesTypeError), fallback)
+            );
+            Assert.AreEqual(Exceptions.TypeError, typeErrResult.Type.Handle);
+        }
+    }
+
+    public class PyObjectTestMethods
+    {
+        public string RaisesAttributeError => throw new PythonException(new PyType(new BorrowedReference(Exceptions.AttributeError)), value: null, traceback: null);
+        public string RaisesTypeError => throw new PythonException(new PyType(new BorrowedReference(Exceptions.TypeError)), value: null, traceback: null);
     }
 }

--- a/src/runtime/pyobject.cs
+++ b/src/runtime/pyobject.cs
@@ -309,12 +309,20 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// GetAttr Method. Returns fallback value if getting attribute fails for any reason.
+        /// Returns the named attribute of the Python object, or the given
+        /// default object if the attribute access throws AttributeError.
         /// </summary>
         /// <remarks>
-        /// Returns the named attribute of the Python object, or the given
-        /// default object if the attribute access fails.
+        /// This method ignores any AttrubiteError(s), even ones
+        /// not raised due to missing requested attribute.
+        ///
+        /// For example, if attribute getter calls other Python code, and
+        /// that code happens to cause AttributeError elsewhere, it will be ignored
+        /// and <paramref name="_default"/> value will be returned instead.
         /// </remarks>
+        /// <param name="name">Name of the attribute.</param>
+        /// <param name="_default">The object to return on AttributeError.</param>
+        [Obsolete("See remarks")]
         public PyObject GetAttr(string name, PyObject _default)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
@@ -322,8 +330,15 @@ namespace Python.Runtime
             IntPtr op = Runtime.PyObject_GetAttrString(obj, name);
             if (op == IntPtr.Zero)
             {
-                Runtime.PyErr_Clear();
-                return _default;
+                if (Exceptions.ExceptionMatches(Exceptions.AttributeError))
+                {
+                    Runtime.PyErr_Clear();
+                    return _default;
+                }
+                else
+                {
+                    throw PythonException.ThrowLastAsClrException();
+                }
             }
             return new PyObject(op);
         }
@@ -351,13 +366,20 @@ namespace Python.Runtime
 
 
         /// <summary>
-        /// GetAttr Method
+        /// Returns the named attribute of the Python object, or the given
+        /// default object if the attribute access throws AttributeError.
         /// </summary>
         /// <remarks>
-        /// Returns the named attribute of the Python object, or the given
-        /// default object if the attribute access fails. The name argument
-        /// is a PyObject wrapping a Python string or unicode object.
+        /// This method ignores any AttrubiteError(s), even ones
+        /// not raised due to missing requested attribute.
+        ///
+        /// For example, if attribute getter calls other Python code, and
+        /// that code happens to cause AttributeError elsewhere, it will be ignored
+        /// and <paramref name="_default"/> value will be returned instead.
         /// </remarks>
+        /// <param name="name">Name of the attribute. Must be of Python type 'str'.</param>
+        /// <param name="_default">The object to return on AttributeError.</param>
+        [Obsolete("See remarks")]
         public PyObject GetAttr(PyObject name, PyObject _default)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
@@ -365,8 +387,15 @@ namespace Python.Runtime
             IntPtr op = Runtime.PyObject_GetAttr(obj, name.obj);
             if (op == IntPtr.Zero)
             {
-                Runtime.PyErr_Clear();
-                return _default;
+                if (Exceptions.ExceptionMatches(Exceptions.AttributeError))
+                {
+                    Runtime.PyErr_Clear();
+                    return _default;
+                }
+                else
+                {
+                    throw PythonException.ThrowLastAsClrException();
+                }
             }
             return new PyObject(op);
         }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Prior to this change `PyObject.GetAttr(name, default)` would ignore any exceptions, including ones unrelated to missing attribute. For example (hypothetically) `PyObject` is a file, and you call `file.GetAttr("len", 0)`, it would return `0` on I/O error even though `file` object actually has `len` attribute.

### Remarks

I marked the method obsolete, as even now when we restrict ignored errors to `AttributeError` and derived types, the behavior of this method still going to be misleading in some scenarios. For example,

```python
class RaisesAttrErr:
  @property
  def prop(self): raise AttributeError

class OK:
  def __init__(self, impl):
    self._impl = impl

  @property
  def existing_prop(self): return self._impl.prop
```

```csharp
PythonEngine.Eval("OK(RaisesAttrErr())").GetAttr("existing_prop", 0)
// returns 0 despite existing_prop actually existing -^ in OK
```

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1036

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
