### PR TITLE
When reflecting nested types, ensure their corresponding `PyType` is allocated

### DIFF
--- a/src/embed_tests/ClassManagerTests.cs
+++ b/src/embed_tests/ClassManagerTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class ClassManagerTests
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+
+        [Test]
+        public void NestedClassDerivingFromParent()
+        {
+            var f = new NestedTestContainer().ToPython();
+            f.GetAttr(nameof(NestedTestContainer.Bar));
+        }
+    }
+
+    public class NestedTestParent
+    {
+        public class Nested : NestedTestParent
+        {
+        }
+    }
+
+    public class NestedTestContainer
+    {
+        public NestedTestParent Bar = new NestedTestParent.Nested();
+    }
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Without this fix attempting to use a nested .NET class that derives from its parent would cause a crash due to false mutual dependency.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1414

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
