### PR TITLE
Changed signature of `IPyObjectDecoder.CanDecode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Python `float` will continue to be converted to `System.Double`.
 -   BREAKING: `PyObject.GetAttr(name, default)` now only ignores `AttributeError` (previously ignored all exceptions).
 -   BREAKING: `PyObject` no longer implements `IEnumerable<PyObject>`.
 Instead, `PyIterable` does that.
+-   BREAKING: `IPyObjectDecoder.CanDecode` `objectType` parameter type changed from `PyObject` to `PyType`
 
 ### Fixed
 

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -141,16 +141,17 @@ namespace Python.EmbeddingTest {
 
             //SequenceConverter can only convert to any ICollection
             var pyList = new PyList(items.ToArray());
+            var listType = pyList.GetPythonType();
             //it can convert a PyList, since PyList satisfies the python sequence protocol
 
-            Assert.IsFalse(codec.CanDecode(pyList, typeof(bool)));
-            Assert.IsFalse(codec.CanDecode(pyList, typeof(IList<int>)));
-            Assert.IsFalse(codec.CanDecode(pyList, typeof(System.Collections.IEnumerable)));
-            Assert.IsFalse(codec.CanDecode(pyList, typeof(IEnumerable<int>)));
+            Assert.IsFalse(codec.CanDecode(listType, typeof(bool)));
+            Assert.IsFalse(codec.CanDecode(listType, typeof(IList<int>)));
+            Assert.IsFalse(codec.CanDecode(listType, typeof(System.Collections.IEnumerable)));
+            Assert.IsFalse(codec.CanDecode(listType, typeof(IEnumerable<int>)));
 
-            Assert.IsTrue(codec.CanDecode(pyList, typeof(ICollection<float>)));
-            Assert.IsTrue(codec.CanDecode(pyList, typeof(ICollection<string>)));
-            Assert.IsTrue(codec.CanDecode(pyList, typeof(ICollection<int>)));
+            Assert.IsTrue(codec.CanDecode(listType, typeof(ICollection<float>)));
+            Assert.IsTrue(codec.CanDecode(listType, typeof(ICollection<string>)));
+            Assert.IsTrue(codec.CanDecode(listType, typeof(ICollection<int>)));
 
             //convert to collection of int
             ICollection<int> intCollection = null;
@@ -380,7 +381,7 @@ DateTimeDecoder.Setup()
 
         public class EverythingElseToSelfDecoder : IPyObjectDecoder
         {
-            public bool CanDecode(PyObject objectType, Type targetType)
+            public bool CanDecode(PyType objectType, Type targetType)
             {
                 return targetType.IsAssignableFrom(typeof(EverythingElseToSelfDecoder));
             }
@@ -399,7 +400,7 @@ DateTimeDecoder.Setup()
 
         class ValueErrorCodec : IPyObjectEncoder, IPyObjectDecoder
         {
-            public bool CanDecode(PyObject objectType, Type targetType)
+            public bool CanDecode(PyType objectType, Type targetType)
                 => this.CanEncode(targetType)
                    && PythonReferenceComparer.Instance.Equals(objectType, PythonEngine.Eval("ValueError"));
 
@@ -424,7 +425,7 @@ DateTimeDecoder.Setup()
         {
             readonly PyObject PyErr = Py.Import("clr.interop").GetAttr("PyErr");
 
-            public bool CanDecode(PyObject objectType, Type targetType)
+            public bool CanDecode(PyType objectType, Type targetType)
                 => PythonReferenceComparer.Instance.Equals(PyErr, objectType);
 
             public bool TryDecode<T>(PyObject pyObj, out T value)
@@ -466,7 +467,7 @@ DateTimeDecoder.Setup()
             this.DecodeResult = decodeResult;
         }
 
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
             => objectType.Handle == TheOnlySupportedSourceType.Handle
                && targetType == typeof(TTarget);
         public bool TryDecode<T>(PyObject pyObj, out T value)
@@ -485,7 +486,7 @@ DateTimeDecoder.Setup()
             PyObjectConversions.RegisterDecoder(new DateTimeDecoder());
         }
 
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
         {
             return targetType == typeof(DateTime);
         }

--- a/src/runtime/Codecs/DecoderGroup.cs
+++ b/src/runtime/Codecs/DecoderGroup.cs
@@ -27,7 +27,7 @@ namespace Python.Runtime.Codecs
         public void Clear() => this.decoders.Clear();
 
         /// <inheritdoc />
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
             => this.decoders.Any(decoder => decoder.CanDecode(objectType, targetType));
         /// <inheritdoc />
         public bool TryDecode<T>(PyObject pyObj, out T value)
@@ -58,7 +58,7 @@ namespace Python.Runtime.Codecs
         /// </summary>
         public static IPyObjectDecoder GetDecoder(
             this IPyObjectDecoder decoder,
-            PyObject objectType, Type targetType)
+            PyType objectType, Type targetType)
         {
             if (decoder is null) throw new ArgumentNullException(nameof(decoder));
 

--- a/src/runtime/Codecs/EnumPyIntCodec.cs
+++ b/src/runtime/Codecs/EnumPyIntCodec.cs
@@ -7,7 +7,7 @@ namespace Python.Runtime.Codecs
     {
         public static EnumPyIntCodec Instance { get; } = new EnumPyIntCodec();
 
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
         {
             return targetType.IsEnum
                 && objectType.IsSubclass(new BorrowedReference(Runtime.PyLongType));

--- a/src/runtime/Codecs/IterableDecoder.cs
+++ b/src/runtime/Codecs/IterableDecoder.cs
@@ -17,12 +17,12 @@ namespace Python.Runtime.Codecs
             return targetType.GetGenericTypeDefinition() == typeof(IEnumerable<>);
         }
 
-        internal static bool IsIterable(PyObject objectType)
+        internal static bool IsIterable(PyType objectType)
         {
             return objectType.HasAttr("__iter__");
         }
 
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
         {
             return IsIterable(objectType) && IsIterable(targetType);
         }

--- a/src/runtime/Codecs/ListDecoder.cs
+++ b/src/runtime/Codecs/ListDecoder.cs
@@ -13,7 +13,7 @@ namespace Python.Runtime.Codecs
             return targetType.GetGenericTypeDefinition() == typeof(IList<>);
         }
 
-        private static bool IsList(PyObject objectType)
+        private static bool IsList(PyType objectType)
         {
             //TODO accept any python object that implements the sequence and list protocols
             //must implement sequence protocol to fully implement list protocol
@@ -23,7 +23,7 @@ namespace Python.Runtime.Codecs
             return objectType.Handle == Runtime.PyListType;
         }
 
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
         {
             return IsList(objectType) && IsList(targetType);
         }

--- a/src/runtime/Codecs/SequenceDecoder.cs
+++ b/src/runtime/Codecs/SequenceDecoder.cs
@@ -13,7 +13,7 @@ namespace Python.Runtime.Codecs
             return targetType.GetGenericTypeDefinition() == typeof(ICollection<>);
         }
 
-        internal static bool IsSequence(PyObject objectType)
+        internal static bool IsSequence(PyType objectType)
         {
             //must implement iterable protocol to fully implement sequence protocol
             if (!IterableDecoder.IsIterable(objectType)) return false;
@@ -25,7 +25,7 @@ namespace Python.Runtime.Codecs
             return objectType.HasAttr("__getitem__");
         }
 
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
         {
             return IsSequence(objectType) && IsSequence(targetType);
         }

--- a/src/runtime/Codecs/TupleCodecs.cs
+++ b/src/runtime/Codecs/TupleCodecs.cs
@@ -41,7 +41,7 @@ namespace Python.Runtime.Codecs
             return new PyTuple(StolenReference.DangerousFromPointer(tuple));
         }
 
-        public bool CanDecode(PyObject objectType, Type targetType)
+        public bool CanDecode(PyType objectType, Type targetType)
             => objectType.Handle == Runtime.PyTupleType && this.CanEncode(targetType);
 
         public bool TryDecode<T>(PyObject pyObj, out T value)

--- a/src/runtime/converterextensions.cs
+++ b/src/runtime/converterextensions.cs
@@ -3,6 +3,7 @@ namespace Python.Runtime
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Reflection;
     using Python.Runtime.Codecs;
@@ -15,7 +16,7 @@ namespace Python.Runtime
         /// <summary>
         /// Checks if this decoder can decode from <paramref name="objectType"/> to <paramref name="targetType"/>
         /// </summary>
-        bool CanDecode(PyObject objectType, Type targetType);
+        bool CanDecode(PyType objectType, Type targetType);
         /// <summary>
         /// Attempts do decode <paramref name="pyObj"/> into a variable of specified type
         /// </summary>
@@ -124,7 +125,9 @@ namespace Python.Runtime
         static Converter.TryConvertFromPythonDelegate GetDecoder(IntPtr sourceType, Type targetType)
         {
             IPyObjectDecoder decoder;
-            using (var pyType = new PyObject(Runtime.SelfIncRef(sourceType)))
+            var sourceTypeRef = new BorrowedReference(sourceType);
+            Debug.Assert(PyType.IsType(sourceTypeRef));
+            using (var pyType = new PyType(sourceTypeRef, prevalidated: true))
             {
                 lock (decoders)
                 {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`IPyObjectDecoder.CanDecode` first parameter (objectType) type changed from `PyObject` to `PyType`

### Does this close any currently open issues?

Related: https://github.com/pythonnet/pythonnet/issues/1539

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
