### PR TITLE
Disabled `float` and `bool` implicit conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   BREAKING: When trying to convert Python `int` to `System.Object`, result will
 be of type `PyInt` instead of `System.Int32` due to possible loss of information.
 Python `float` will continue to be converted to `System.Double`.
+-   BREAKING: Python.NET will no longer implicitly convert types like `numpy.float64`, that implement `__float__` to
+`System.Single` and `System.Double`. An explicit conversion is required on Python or .NET side.
+-   BREAKING: Python.NET will no longer implicitly convert any Python object to `System.Boolean`.
 -   BREAKING: `PyObject.GetAttr(name, default)` now only ignores `AttributeError` (previously ignored all exceptions).
 -   BREAKING: `PyObject` no longer implements `IEnumerable<PyObject>`.
 Instead, `PyIterable` does that.

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Example
            dynamic sin = np.sin;
            Console.WriteLine(sin(5));
 
-           double c = np.cos(5) + sin(5);
+           double c = (double)(np.cos(5) + sin(5));
            Console.WriteLine(c);
 
            dynamic a = np.array(new List<float> { 1, 2, 3 });

--- a/src/embed_tests/NumPyTests.cs
+++ b/src/embed_tests/NumPyTests.cs
@@ -40,7 +40,7 @@ namespace Python.EmbeddingTest
             dynamic sin = np.sin;
             StringAssert.StartsWith("-0.95892", sin(5).ToString());
 
-            double c = np.cos(5) + sin(5);
+            double c = (double)(np.cos(5) + sin(5));
             Assert.AreEqual(-0.675262, c, 0.01);
 
             dynamic a = np.array(new List<float> { 1, 2, 3 });

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -117,6 +117,13 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
+        public void NoImplicitConversionToBool()
+        {
+            var pyObj = new PyList(items: new[] { 1.ToPython(), 2.ToPython() }).ToPython();
+            Assert.Throws<InvalidCastException>(() => pyObj.As<bool>());
+        }
+
+        [Test]
         public void ToNullable()
         {
             const int Const = 42;

--- a/src/python_tests_runner/PythonTestRunner.cs
+++ b/src/python_tests_runner/PythonTestRunner.cs
@@ -33,8 +33,8 @@ namespace Python.PythonTestsRunner
         static IEnumerable<string[]> PythonTestCases()
         {
             // Add the test that you want to debug here.
-            yield return new[] { "test_enum", "test_enum_standard_attrs" };
-            yield return new[] { "test_generic", "test_missing_generic_type" };
+            yield return new[] { "test_indexer", "test_boolean_indexer" };
+            yield return new[] { "test_delegate", "test_bool_delegate" };
         }
 
         /// <summary>

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -13,53 +13,36 @@ def test_bool_conversion():
     """Test bool conversion."""
     ob = ConversionTest()
     assert ob.BooleanField is False
-    assert ob.BooleanField is False
     assert ob.BooleanField == 0
 
     ob.BooleanField = True
-    assert ob.BooleanField is True
     assert ob.BooleanField is True
     assert ob.BooleanField == 1
 
     ob.BooleanField = False
     assert ob.BooleanField is False
-    assert ob.BooleanField is False
     assert ob.BooleanField == 0
 
-    ob.BooleanField = 1
-    assert ob.BooleanField is True
-    assert ob.BooleanField is True
-    assert ob.BooleanField == 1
+    with pytest.raises(TypeError):
+        ob.BooleanField = 1
+    
+    with pytest.raises(TypeError):
+        ob.BooleanField = 0
 
-    ob.BooleanField = 0
-    assert ob.BooleanField is False
-    assert ob.BooleanField is False
-    assert ob.BooleanField == 0
+    with pytest.raises(TypeError):
+        ob.BooleanField = None
 
-    ob.BooleanField = System.Boolean(None)
-    assert ob.BooleanField is False
-    assert ob.BooleanField is False
-    assert ob.BooleanField == 0
+    with pytest.raises(TypeError):
+        ob.BooleanField = ''
 
-    ob.BooleanField = System.Boolean('')
-    assert ob.BooleanField is False
-    assert ob.BooleanField is False
-    assert ob.BooleanField == 0
+    with pytest.raises(TypeError):
+        ob.BooleanField = System.Boolean(0)
 
-    ob.BooleanField = System.Boolean(0)
-    assert ob.BooleanField is False
-    assert ob.BooleanField is False
-    assert ob.BooleanField == 0
+    with pytest.raises(TypeError):
+        ob.BooleanField = System.Boolean(1)
 
-    ob.BooleanField = System.Boolean(1)
-    assert ob.BooleanField is True
-    assert ob.BooleanField is True
-    assert ob.BooleanField == 1
-
-    ob.BooleanField = System.Boolean('a')
-    assert ob.BooleanField is True
-    assert ob.BooleanField is True
-    assert ob.BooleanField == 1
+    with pytest.raises(TypeError):
+        ob.BooleanField = System.Boolean('a')
 
 
 def test_sbyte_conversion():

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -247,7 +247,7 @@ def test_bool_delegate():
     from Python.Test import BoolDelegate
 
     def always_so_negative():
-        return 0
+        return False
 
     d = BoolDelegate(always_so_negative)
     ob = DelegateTest()
@@ -255,6 +255,12 @@ def test_bool_delegate():
 
     assert not d()
     assert not ob.CallBoolDelegate(d)
+
+    def always_so_positive():
+        return 1
+    bad = BoolDelegate(always_so_positive)
+    with pytest.raises(TypeError):
+        ob.CallBoolDelegate(bad)
 
 def test_object_delegate():
     """Test object delegate."""

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -200,11 +200,11 @@ def test_boolean_field():
     ob.BooleanField = False
     assert ob.BooleanField is False
 
-    ob.BooleanField = 1
-    assert ob.BooleanField is True
+    with pytest.raises(TypeError):
+        ob.BooleanField = 1
 
-    ob.BooleanField = 0
-    assert ob.BooleanField is False
+    with pytest.raises(TypeError):
+        ob.BooleanField = 0
 
 
 def test_sbyte_field():

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -65,13 +65,15 @@ def test_boolean_indexer():
     ob = Test.BooleanIndexerTest()
 
     assert ob[True] is None
-    assert ob[1] is None
 
-    ob[0] = "false"
-    assert ob[0] == "false"
-
-    ob[1] = "true"
-    assert ob[1] == "true"
+    with pytest.raises(TypeError):
+        ob[1]
+    with pytest.raises(TypeError):
+        ob[0]
+    with pytest.raises(TypeError):
+        ob[1] = "true"
+    with pytest.raises(TypeError):
+        ob[0] = "false"
 
     ob[False] = "false"
     assert ob[False] == "false"

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -41,10 +41,6 @@ def test_preload_var():
     try:
         clr.setPreload(True)
         assert clr.getPreload() is True, clr.getPreload()
-        clr.setPreload(0)
-        assert clr.getPreload() is False, clr.getPreload()
-        clr.setPreload(1)
-        assert clr.getPreload() is True, clr.getPreload()
 
         import System.Configuration
         content = dir(System.Configuration)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Disabled using `__float__` during implicit conversions to .NET floating-point types. Explicit conversion is possible in Python with `float(val)` and .NET with `(double)dynamicPyObj`.

Arbitrary Python objects are no longer implicitly converted to .NET `bool` type.

### Does this close any currently open issues?

this is a continuation of https://github.com/pythonnet/pythonnet/pull/1568

related to https://github.com/pythonnet/pythonnet/issues/1539

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
