### PR TITLE
Make .NET objects that have `__call__` method callable from Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   .NET arrays implement Python buffer protocol
 -   Python.NET will correctly resolve .NET methods, that accept `PyList`, `PyInt`,
 and other `PyObject` derived types when called from Python.
+-   .NET classes, that have `__call__` method are callable from Python
 -   `PyIterable` type, that wraps any iterable object in Python
 
 

--- a/src/embed_tests/CallableObject.cs
+++ b/src/embed_tests/CallableObject.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest
+{
+    public class CallableObject
+    {
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            PythonEngine.Initialize();
+            using var locals = new PyDict();
+            PythonEngine.Exec(CallViaInheritance.BaseClassSource, locals: locals.Handle);
+            CustomBaseTypeProvider.BaseClass = new PyType(locals[CallViaInheritance.BaseClassName]);
+            PythonEngine.InteropConfiguration.PythonBaseTypeProviders.Add(new CustomBaseTypeProvider());
+        }
+
+        [OneTimeTearDown]
+        public void Dispose()
+        {
+            PythonEngine.Shutdown();
+        }
+        [Test]
+        public void CallMethodMakesObjectCallable()
+        {
+            var doubler = new DerivedDoubler();
+            dynamic applyObjectTo21 = PythonEngine.Eval("lambda o: o(21)");
+            Assert.AreEqual(doubler.__call__(21), (int)applyObjectTo21(doubler.ToPython()));
+        }
+        [Test]
+        public void CallMethodCanBeInheritedFromPython()
+        {
+            var callViaInheritance = new CallViaInheritance();
+            dynamic applyObjectTo14 = PythonEngine.Eval("lambda o: o(14)");
+            Assert.AreEqual(callViaInheritance.Call(14), (int)applyObjectTo14(callViaInheritance.ToPython()));
+        }
+
+        [Test]
+        public void CanOverwriteCall()
+        {
+            var callViaInheritance = new CallViaInheritance();
+            using var scope = Py.CreateScope();
+            scope.Set("o", callViaInheritance);
+            scope.Exec("orig_call = o.Call");
+            scope.Exec("o.Call = lambda a: orig_call(a*7)");
+            int result = scope.Eval<int>("o.Call(5)");
+            Assert.AreEqual(105, result);
+        }
+
+        class Doubler
+        {
+            public int __call__(int arg) => 2 * arg;
+        }
+
+        class DerivedDoubler : Doubler { }
+
+        class CallViaInheritance
+        {
+            public const string BaseClassName = "Forwarder";
+            public static readonly string BaseClassSource = $@"
+class MyCallableBase:
+  def __call__(self, val):
+    return self.Call(val)
+
+class {BaseClassName}(MyCallableBase): pass
+";
+            public int Call(int arg) => 3 * arg;
+        }
+
+        class CustomBaseTypeProvider : IPythonBaseTypeProvider
+        {
+            internal static PyType BaseClass;
+
+            public IEnumerable<PyType> GetBaseTypes(Type type, IList<PyType> existingBases)
+            {
+                Assert.Greater(BaseClass.Refcount, 0);
+                return type != typeof(CallViaInheritance)
+                    ? existingBases
+                    : new[] { BaseClass };
+            }
+        }
+    }
+}

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -162,6 +162,9 @@ namespace Python.Runtime
                 Runtime.PyType_Modified(pair.Value.TypeReference);
                 var context = contexts[pair.Value.pyHandle];
                 pair.Value.Load(context);
+                var slotsHolder = TypeManager.GetSlotsHolder(pyType);
+                pair.Value.InitializeSlots(slotsHolder);
+                Runtime.PyType_Modified(pair.Value.TypeReference);
                 loadedObjs.Add(pair.Value, context);
             }
             

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -242,8 +242,13 @@ namespace Python.Runtime
                 return ThunkInfo.Empty;
             }
             Delegate d = Delegate.CreateDelegate(dt, method);
-            var info = new ThunkInfo(d);
-            allocatedThunks[info.Address] = d;
+            return GetThunk(d);
+        }
+
+        internal static ThunkInfo GetThunk(Delegate @delegate)
+        {
+            var info = new ThunkInfo(@delegate);
+            allocatedThunks[info.Address] = @delegate;
             return info;
         }
 

--- a/src/runtime/pytype.cs
+++ b/src/runtime/pytype.cs
@@ -121,6 +121,20 @@ namespace Python.Runtime
             return new BorrowedReference(basePtr);
         }
 
+        internal static BorrowedReference GetBases(BorrowedReference type)
+        {
+            Debug.Assert(IsType(type));
+            IntPtr basesPtr = Marshal.ReadIntPtr(type.DangerousGetAddress(), TypeOffset.tp_bases);
+            return new BorrowedReference(basesPtr);
+        }
+
+        internal static BorrowedReference GetMRO(BorrowedReference type)
+        {
+            Debug.Assert(IsType(type));
+            IntPtr basesPtr = Marshal.ReadIntPtr(type.DangerousGetAddress(), TypeOffset.tp_mro);
+            return new BorrowedReference(basesPtr);
+        }
+
         private static IntPtr EnsureIsType(in StolenReference reference)
         {
             IntPtr address = reference.DangerousGetAddressOrNull();


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Implemented by adding `tp_call` to `ClassBase`, that uses reflection to find `__call__` methods in .NET, and falls back to invoking `__call__` method from Python base classes.

### Does this close any currently open issues?

Implements https://github.com/pythonnet/pythonnet/issues/890

### Any other comments?

This is an amalgamation of d46878c7,  5bb10073, and 960457f5 from https://github.com/losttech/pythonnet

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
