### PR TITLE
Remove a deprecated attribute in PropertyObject

### DIFF
--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -51,7 +51,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Permissions" Version="4.4.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/runtime/propertyobject.cs
+++ b/src/runtime/propertyobject.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using System.Security.Permissions;
 
 namespace Python.Runtime
 {
@@ -15,7 +14,6 @@ namespace Python.Runtime
         private MaybeMethodInfo getter;
         private MaybeMethodInfo setter;
 
-        [StrongNameIdentityPermission(SecurityAction.Assert)]
         public PropertyObject(PropertyInfo md)
         {
             getter = md.GetGetMethod(true);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR removes an obsolete attribute in PropertyObejct

### Does this close any currently open issues?

No

### Any other comments?

The attribute is obsolete, not honored by the runtime, and causes problems with Unity.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
