### PR TITLE
Fixed recursive dependency in clr module initialization

### DIFF
--- a/src/embed_tests/pyimport.cs
+++ b/src/embed_tests/pyimport.cs
@@ -112,3 +112,14 @@ clr.AddReference('{path}')
         }
     }
 }
+
+// regression for https://github.com/pythonnet/pythonnet/issues/1601
+// initialize fails if a class derived from IEnumerable is in global namespace
+public class PublicEnumerator : System.Collections.IEnumerable
+{
+    public System.Collections.IEnumerator GetEnumerator()
+    {
+        return null;
+    }
+}
+

--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -220,8 +220,7 @@ namespace Python.Runtime
             }
 
             // Load the clr.py resource into the clr module
-            NewReference clr = Python.Runtime.ImportHook.GetCLRModule();
-            BorrowedReference clr_dict = Runtime.PyModule_GetDict(clr);
+            BorrowedReference clr_dict = Runtime.PyModule_GetDict(ImportHook.ClrModuleReference);
 
             var locals = new PyDict();
             try
@@ -236,7 +235,7 @@ namespace Python.Runtime
 
                 LoadSubmodule(module_globals, "clr.interop", "interop.py");
 
-                    LoadMixins(module_globals);
+                LoadMixins(module_globals);
 
                 // add the imported module to the clr module, and copy the API functions
                 // and decorators into the main clr module.
@@ -257,6 +256,8 @@ namespace Python.Runtime
             {
                 locals.Dispose();
             }
+
+            ImportHook.UpdateCLRModuleDict();
         }
 
         static BorrowedReference DefineModule(string name)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

There was a recursive dependency in `clr` module initialization when a public class that implements `IEnumerable` exists in the global namespace.

The fix is to delay updating `clr` module dict with contents of .NET namespaces until after our internal modules are loaded because .NET classes might depend on our internal modules to be initialized. In particular, any class implementing `IEnumerable` needs `IterableMixin` from `collections.py`

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1601

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change