### PR TITLE
Use .NET 6.0 LTS and C# 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2

--- a/.github/workflows/nuget-preview.yml
+++ b/.github/workflows/nuget-preview.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,15 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <AssemblyCopyright>Copyright (c) 2006-2020 The Contributors of the Python.NET Project</AssemblyCopyright>
+    <AssemblyCopyright>Copyright (c) 2006-2021 The Contributors of the Python.NET Project</AssemblyCopyright>
     <AssemblyCompany>pythonnet</AssemblyCompany>
     <AssemblyProduct>Python.NET</AssemblyProduct>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.9.0-3.final">
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/pythonnet.sln
+++ b/pythonnet.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30717.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Python.Runtime", "src\runtime\Python.Runtime.csproj", "{4E8C8FE2-0FB8-4517-B2D9-5FB2D5FC849B}"
 EndProject
@@ -80,18 +80,6 @@ Global
 		{E6B01706-00BA-4144-9029-186AC42FBE9A}.Release|x64.Build.0 = Release|x64
 		{E6B01706-00BA-4144-9029-186AC42FBE9A}.Release|x86.ActiveCfg = Release|x86
 		{E6B01706-00BA-4144-9029-186AC42FBE9A}.Release|x86.Build.0 = Release|x86
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Debug|x64.Build.0 = Debug|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Debug|x86.Build.0 = Debug|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Release|x64.ActiveCfg = Release|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Release|x64.Build.0 = Release|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Release|x86.ActiveCfg = Release|Any CPU
-		{F9F5FA13-BC52-4C0B-BC1C-FE3C0B8FCCDD}.Release|x86.Build.0 = Release|Any CPU
 		{819E089B-4770-400E-93C6-4F7A35F0EA12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{819E089B-4770-400E-93C6-4F7A35F0EA12}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{819E089B-4770-400E-93C6-4F7A35F0EA12}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/src/console/Console.csproj
+++ b/src/console/Console.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <OutputType>Exe</OutputType>
     <AssemblyName>nPython</AssemblyName>

--- a/src/embed_tests/Python.EmbeddingTest.csproj
+++ b/src/embed_tests/Python.EmbeddingTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\pythonnet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/src/python_tests_runner/Python.PythonTestsRunner.csproj
+++ b/src/python_tests_runner/Python.PythonTestsRunner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/runtime/Python.Runtime.csproj
+++ b/src/runtime/Python.Runtime.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <RootNamespace>Python.Runtime</RootNamespace>
     <AssemblyName>Python.Runtime</AssemblyName>
 

--- a/src/testing/Python.Test.csproj
+++ b/src/testing/Python.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def pytest_configure(config):
 
     # tmpdir_factory.mktemp(f"pythonnet-{runtime_opt}")
 
-    fw = "net5.0" if runtime_opt == "netcore" else "netstandard2.0"
+    fw = "net6.0" if runtime_opt == "netcore" else "netstandard2.0"
 
     check_call(["dotnet", "publish", "-f", fw, "-o", bin_path, test_proj_path])
 


### PR DESCRIPTION
.NET 5 that we use expires in May 2022. For the new version we should use LTS if possible.

Also, new goodies in C#!