### PR TITLE
Update NonCopyableAnalyzer to latest version with our changes upstreamed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Lost.NonCopyableAnalyzer" Version="0.7.0-m04">
+    <PackageReference Include="NonCopyableAnalyzer" Version="0.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Should supersede https://github.com/pythonnet/pythonnet/pull/1615
