### PR TITLE
Match generic and private methods upon runtime reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Instead, `PyIterable` does that.
 -   Providing an invalid type parameter to a generic type or method produces a helpful Python error
 -   Empty parameter names (as can be generated from F#) do not cause crashes
 -   Unicode strings with surrogates were truncated when converting from Python
+-   `Reload` mode now supports generic methods (previously Python would stop seeing them after reload)
 
 ### Removed
 

--- a/src/embed_tests/StateSerialization/MethodSerialization.cs
+++ b/src/embed_tests/StateSerialization/MethodSerialization.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using System.Reflection;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest.StateSerialization;
+
+public class MethodSerialization
+{
+    [Test]
+    public void GenericRoundtrip()
+    {
+        var method = typeof(MethodTestHost).GetMethod(nameof(MethodTestHost.Generic));
+        var maybeMethod = new MaybeMethodBase<MethodBase>(method);
+        var restored = SerializationRoundtrip(maybeMethod);
+        Assert.IsTrue(restored.Valid);
+        Assert.AreEqual(method, restored.Value);
+    }
+
+    static T SerializationRoundtrip<T>(T item)
+    {
+        using var buf = new MemoryStream();
+        var formatter = RuntimeData.CreateFormatter();
+        formatter.Serialize(buf, item);
+        buf.Position = 0;
+        return (T)formatter.Deserialize(buf);
+    }
+}
+
+public class MethodTestHost
+{
+    public void Generic<T>(T item, T[] array, ref T @ref) { }
+}

--- a/src/runtime/Reflection/ParameterHelper.cs
+++ b/src/runtime/Reflection/ParameterHelper.cs
@@ -1,18 +1,20 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 
 namespace Python.Runtime.Reflection;
 
 [Serializable]
-struct ParameterHelper : IEquatable<ParameterInfo>
+class ParameterHelper : IEquatable<ParameterInfo>
 {
     public readonly string TypeName;
     public readonly ParameterModifier Modifier;
+    public readonly ParameterHelper[]? GenericArguments;
 
-    public ParameterHelper(ParameterInfo tp)
+    public ParameterHelper(ParameterInfo tp) : this(tp.ParameterType)
     {
-        TypeName = tp.ParameterType.AssemblyQualifiedName;
         Modifier = ParameterModifier.None;
 
         if (tp.IsIn && tp.ParameterType.IsByRef)
@@ -29,12 +31,55 @@ struct ParameterHelper : IEquatable<ParameterInfo>
         }
     }
 
+    public ParameterHelper(Type type)
+    {
+        TypeName = type.AssemblyQualifiedName;
+        if (TypeName is null)
+        {
+            if (type.IsByRef || type.IsArray)
+            {
+                TypeName = type.IsArray ? "[]" : "&";
+                GenericArguments = new[] { new ParameterHelper(type.GetElementType()) };
+            }
+            else
+            {
+                Debug.Assert(type.ContainsGenericParameters);
+                TypeName = $"{type.Assembly}::{type.Namespace}/{type.Name}";
+                GenericArguments = type.GenericTypeArguments.Select(t => new ParameterHelper(t)).ToArray();
+            }
+        }
+    }
+
+    public bool IsSpecialType => TypeName == "&" || TypeName == "[]";
+
     public bool Equals(ParameterInfo other)
     {
         return this.Equals(new ParameterHelper(other));
     }
 
     public bool Matches(ParameterInfo other) => this.Equals(other);
+
+    public bool Equals(ParameterHelper other)
+    {
+        if (other is null) return false;
+
+        if (!(other.TypeName == TypeName && other.Modifier == Modifier))
+            return false;
+
+        if (GenericArguments == other.GenericArguments) return true;
+
+        if (GenericArguments is not null && other.GenericArguments is not null)
+        {
+            if (GenericArguments.Length != other.GenericArguments.Length) return false;
+            for (int arg = 0; arg < GenericArguments.Length; arg++)
+            {
+                if (!GenericArguments[arg].Equals(other.GenericArguments[arg])) return false;
+            }
+            return true;
+        }
+
+        return false;
+    }
 }
 
 enum ParameterModifier

--- a/src/runtime/runtime_data.cs
+++ b/src/runtime/runtime_data.cs
@@ -247,7 +247,7 @@ namespace Python.Runtime
             }
         }
 
-        private static IFormatter CreateFormatter()
+        internal static IFormatter CreateFormatter()
         {
             return FormatterType != null ?
                 (IFormatter)Activator.CreateInstance(FormatterType)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The old method matching code never worked for generic methods because their parameter types did not have assembly qualified names.

The new method explicitly checks generic parameters.

It also allows reloading of private methods, which can be exposed to Python via reflection or delegate binding.

### Any other comments?

This is part of work to remove all shutdown modes (only Reload will remain), that ensures, that internal methods are always successfully reloaded.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
