### PR TITLE
Removed `ShutdownMode`. Now always behaves like original `Reload`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,6 @@ jobs:
         os: [windows, ubuntu, macos]
         python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         platform: [x64]
-        shutdown_mode: [Normal, Soft]
-
-    env:
-      PYTHONNET_SHUTDOWN_MODE: ${{ matrix.SHUTDOWN_MODE }}
 
     steps:
       - name: Set Environment on macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ Instead, `PyIterable` does that.
 
 ### Removed
 
+-   `ShutdownMode` has been removed. The only shutdown mode supported now is an equivalent of `ShutdownMode.Reload`.
+There is no need to specify it.
 -   implicit assembly loading (you have to explicitly `clr.AddReference` before doing import)
 -   messages in `PythonException` no longer start with exception type
 -   `PyScopeManager`, `PyScopeException`, `PyScope` (use `PyModule` instead)

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -34,7 +34,7 @@ namespace Python.EmbeddingTest {
             using (var scope = Py.CreateScope())
             {
                 void Accept(T value) => restored = value;
-                var accept = new Action<T>(Accept).ToPython();
+                using var accept = new Action<T>(Accept).ToPython();
                 scope.Set(nameof(tuple), tuple);
                 scope.Set(nameof(accept), accept);
                 scope.Exec($"{nameof(accept)}({nameof(tuple)})");
@@ -55,7 +55,7 @@ namespace Python.EmbeddingTest {
             using (var scope = Py.CreateScope())
             {
                 void Accept(object value) => restored = (T)value;
-                var accept = new Action<object>(Accept).ToPython();
+                using var accept = new Action<object>(Accept).ToPython();
                 scope.Set(nameof(tuple), tuple);
                 scope.Set(nameof(accept), accept);
                 scope.Exec($"{nameof(accept)}({nameof(tuple)})");
@@ -71,7 +71,7 @@ namespace Python.EmbeddingTest {
         static void TupleRoundtripObject<T, TTuple>()
         {
             var tuple = Activator.CreateInstance(typeof(T), 42.0, "42", new object());
-            var pyTuple = TupleCodec<TTuple>.Instance.TryEncode(tuple);
+            using var pyTuple = TupleCodec<TTuple>.Instance.TryEncode(tuple);
             Assert.IsTrue(TupleCodec<TTuple>.Instance.TryDecode(pyTuple, out object restored));
             Assert.AreEqual(expected: tuple, actual: restored);
         }
@@ -85,7 +85,7 @@ namespace Python.EmbeddingTest {
         static void TupleRoundtripGeneric<T, TTuple>()
         {
             var tuple = Activator.CreateInstance(typeof(T), 42, "42", new object());
-            var pyTuple = TupleCodec<TTuple>.Instance.TryEncode(tuple);
+            using var pyTuple = TupleCodec<TTuple>.Instance.TryEncode(tuple);
             Assert.IsTrue(TupleCodec<TTuple>.Instance.TryDecode(pyTuple, out T restored));
             Assert.AreEqual(expected: tuple, actual: restored);
         }
@@ -98,9 +98,9 @@ namespace Python.EmbeddingTest {
             var codec = ListDecoder.Instance;
             var items = new List<PyObject>() { new PyInt(1), new PyInt(2), new PyInt(3) };
 
-            var pyList = new PyList(items.ToArray());
+            using var pyList = new PyList(items.ToArray());
 
-            var pyListType = pyList.GetPythonType();
+            using var pyListType = pyList.GetPythonType();
             Assert.IsTrue(codec.CanDecode(pyListType, typeof(IList<bool>)));
             Assert.IsTrue(codec.CanDecode(pyListType, typeof(IList<int>)));
             Assert.IsFalse(codec.CanDecode(pyListType, typeof(System.Collections.IEnumerable)));
@@ -128,8 +128,8 @@ namespace Python.EmbeddingTest {
             Assert.Throws(typeof(InvalidCastException), () => { var x = stringList[0]; });
 
             //can't convert python iterable to list (this will require a copy which isn't lossless)
-            var foo = GetPythonIterable();
-            var fooType = foo.GetPythonType();
+            using var foo = GetPythonIterable();
+            using var fooType = foo.GetPythonType();
             Assert.IsFalse(codec.CanDecode(fooType, typeof(IList<int>)));
         }
 
@@ -140,8 +140,8 @@ namespace Python.EmbeddingTest {
             var items = new List<PyObject>() { new PyInt(1), new PyInt(2), new PyInt(3) };
 
             //SequenceConverter can only convert to any ICollection
-            var pyList = new PyList(items.ToArray());
-            var listType = pyList.GetPythonType();
+            using var pyList = new PyList(items.ToArray());
+            using var listType = pyList.GetPythonType();
             //it can convert a PyList, since PyList satisfies the python sequence protocol
 
             Assert.IsFalse(codec.CanDecode(listType, typeof(bool)));

--- a/src/embed_tests/pyinitialize.cs
+++ b/src/embed_tests/pyinitialize.cs
@@ -151,51 +151,6 @@ namespace Python.EmbeddingTest
             // Wrong:   (4 * 2) + 1 + 1 + 1 = 11
             Assert.That(shutdown_count, Is.EqualTo(12));
         }
-
-        [Test]
-        public static void TestRunExitFuncs()
-        {
-            if (Runtime.Runtime.GetDefaultShutdownMode() == ShutdownMode.Normal)
-            {
-                // If the runtime using the normal mode,
-                // callback registered by atexit will be called after we release the clr information,
-                // thus there's no chance we can check it here.
-                Assert.Ignore("Skip on normal mode");
-            }
-            Runtime.Runtime.Initialize();
-            PyObject atexit;
-            try
-            {
-                atexit = Py.Import("atexit");
-            }
-            catch (PythonException e)
-            {
-                string msg = e.ToString();
-                bool isImportError = e.Is(Exceptions.ImportError);
-                Runtime.Runtime.Shutdown();
-
-                if (isImportError)
-                {
-                    Assert.Ignore("no atexit module");
-                }
-                else
-                {
-                    Assert.Fail(msg);
-                }
-                PythonEngine.InteropConfiguration = InteropConfiguration.MakeDefault();
-                return;
-            }
-            bool called = false;
-            Action callback = () =>
-            {
-                called = true;
-            };
-            atexit.InvokeMethod("register", callback.ToPython()).Dispose();
-            atexit.Dispose();
-            Runtime.Runtime.Shutdown();
-            Assert.True(called);
-            PythonEngine.InteropConfiguration = InteropConfiguration.MakeDefault();
-        }
     }
 
     public class ImportClassShutdownRefcountClass { }

--- a/src/runtime/ReflectedClrType.cs
+++ b/src/runtime/ReflectedClrType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 
@@ -49,9 +50,9 @@ internal sealed class ReflectedClrType : PyType
         return pyType;
     }
 
-    internal void Restore(InterDomainContext context)
+    internal void Restore(Dictionary<string, object?> context)
     {
-        var cb = context.Storage.GetValue<ClassBase>("impl");
+        var cb = (ClassBase)context["impl"]!;
 
         Debug.Assert(cb is not null);
 

--- a/src/runtime/StateSerialization/ClassManagerState.cs
+++ b/src/runtime/StateSerialization/ClassManagerState.cs
@@ -10,6 +10,6 @@ namespace Python.Runtime.StateSerialization;
 [Serializable]
 internal class ClassManagerState
 {
-    public Dictionary<ReflectedClrType, InterDomainContext> Contexts { get; set; }
+    public Dictionary<ReflectedClrType, Dictionary<string, object?>> Contexts { get; set; }
     public Dictionary<MaybeType, ReflectedClrType> Cache { get; set; }
 }

--- a/src/runtime/StateSerialization/ICLRObjectStorer.cs
+++ b/src/runtime/StateSerialization/ICLRObjectStorer.cs
@@ -4,6 +4,6 @@ namespace Python.Runtime;
 
 public interface ICLRObjectStorer
 {
-    ICollection<CLRMappedItem> Store(CLRWrapperCollection wrappers, RuntimeDataStorage storage);
-    CLRWrapperCollection Restore(RuntimeDataStorage storage);
+    ICollection<CLRMappedItem> Store(CLRWrapperCollection wrappers, Dictionary<string, object?> storage);
+    CLRWrapperCollection Restore(Dictionary<string, object?> storage);
 }

--- a/src/runtime/StateSerialization/SharedObjectsState.cs
+++ b/src/runtime/StateSerialization/SharedObjectsState.cs
@@ -12,6 +12,6 @@ internal class SharedObjectsState
 {
     public Dictionary<PyObject, CLRObject> InternalStores { get; init; }
     public Dictionary<PyObject, ExtensionType> Extensions { get; init; }
-    public RuntimeDataStorage Wrappers { get; init; }
-    public Dictionary<PyObject, InterDomainContext> Contexts { get; init; }
+    public Dictionary<string, object?> Wrappers { get; init; }
+    public Dictionary<PyObject, Dictionary<string, object?>> Contexts { get; init; }
 }

--- a/src/runtime/Util.cs
+++ b/src/runtime/Util.cs
@@ -13,7 +13,7 @@ namespace Python.Runtime
         internal const string UnstableApiMessage =
             "This API is unstable, and might be changed or removed in the next minor release";
         internal const string MinimalPythonVersionRequired =
-            "Only Python 3.5 or newer is supported";
+            "Only Python 3.6 or newer is supported";
         internal const string InternalUseOnly =
             "This API is for internal use only";
 

--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -65,12 +65,15 @@ namespace Python.Runtime
 
         internal static ClassManagerState SaveRuntimeData()
         {
-            var contexts = new Dictionary<ReflectedClrType, InterDomainContext>();
+            var contexts = new Dictionary<ReflectedClrType, Dictionary<string, object?>>();
             foreach (var cls in cache)
             {
-                var context = contexts[cls.Value] = new InterDomainContext();
                 var cb = (ClassBase)ManagedType.GetManagedObject(cls.Value)!;
-                cb.Save(cls.Value, context);
+                var context = cb.Save(cls.Value);
+                if (context is not null)
+                {
+                    contexts[cls.Value] = context;
+                }
 
                 // Remove all members added in InitBaseClass.
                 // this is done so that if domain reloads and a member of a
@@ -201,7 +204,7 @@ namespace Python.Runtime
             return impl;
         }
 
-        internal static void InitClassBase(Type type, ClassBase impl, PyType pyType)
+        internal static void InitClassBase(Type type, ClassBase impl, ReflectedClrType pyType)
         {
             // First, we introspect the managed type and build some class
             // information, including generating the member descriptors

--- a/src/runtime/clrobject.cs
+++ b/src/runtime/clrobject.cs
@@ -53,13 +53,13 @@ namespace Python.Runtime
             return Create(ob, cc);
         }
 
-        internal static void Restore(object ob, BorrowedReference pyHandle, InterDomainContext context)
+        internal static void Restore(object ob, BorrowedReference pyHandle, Dictionary<string, object?> context)
         {
             var co = new CLRObject(ob);
             co.OnLoad(pyHandle, context);
         }
 
-        protected override void OnLoad(BorrowedReference ob, InterDomainContext? context)
+        protected override void OnLoad(BorrowedReference ob, Dictionary<string, object?>? context)
         {
             base.OnLoad(ob, context);
             GCHandle gc = GCHandle.Alloc(this);

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -95,7 +95,7 @@ namespace Python.Runtime
             return res;
         }
 
-        protected override void OnLoad(BorrowedReference ob, InterDomainContext? context)
+        protected override void OnLoad(BorrowedReference ob, Dictionary<string, object?>? context)
         {
             base.OnLoad(ob, context);
             SetupGc(ob, Runtime.PyObject_TYPE(ob));

--- a/src/runtime/extensiontype.cs
+++ b/src/runtime/extensiontype.cs
@@ -80,16 +80,17 @@ namespace Python.Runtime
 
             tp_clear(lastRef.Borrow());
 
-            bool deleted = loadedExtensions.Remove(lastRef.DangerousGetAddress());
-            Debug.Assert(deleted);
-
             // we must decref our type: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_dealloc
             DecrefTypeAndFree(lastRef.Steal());
         }
 
         public static int tp_clear(BorrowedReference ob)
         {
-            TryFreeGCHandle(ob);
+            if (TryFreeGCHandle(ob))
+            {
+                bool deleted = loadedExtensions.Remove(ob.DangerousGetAddress());
+                Debug.Assert(deleted);
+            }
 
             int res = ClassBase.BaseUnmanagedClear(ob);
             return res;

--- a/src/runtime/finalizer.cs
+++ b/src/runtime/finalizer.cs
@@ -27,7 +27,7 @@ namespace Python.Runtime
             public Exception Error { get; }
         }
 
-        public static readonly Finalizer Instance = new Finalizer();
+        public static Finalizer Instance { get; } = new ();
 
         public event EventHandler<CollectArgs>? BeforeCollect;
         public event EventHandler<ErrorArgs>? ErrorHandler;

--- a/src/runtime/importhook.cs
+++ b/src/runtime/importhook.cs
@@ -87,11 +87,11 @@ class DotNetFinder(importlib.abc.MetaPathFinder):
             }
 
             TeardownNameSpaceTracking();
+            clrModule.ResetModuleMembers();
             Runtime.Py_CLEAR(ref py_clr_module!);
 
             root.Dispose();
             root = null!;
-            CLRModule.Reset();
         }
 
         private static Dictionary<PyString, PyObject> GetDotNetModules()

--- a/src/runtime/interop.cs
+++ b/src/runtime/interop.cs
@@ -61,7 +61,7 @@ namespace Python.Runtime
     /// </summary>
     // Py_TPFLAGS_*
     [Flags]
-    public enum TypeFlags: int
+    public enum TypeFlags: long
     {
         HeapType = (1 << 9),
         BaseType = (1 << 10),

--- a/src/runtime/managedtype.cs
+++ b/src/runtime/managedtype.cs
@@ -109,19 +109,18 @@ namespace Python.Runtime
             return clearFunc(ob);
         }
 
-        internal void Save(BorrowedReference ob, InterDomainContext context)
+        internal Dictionary<string, object?>? Save(BorrowedReference ob)
         {
-            OnSave(ob, context);
+            return OnSave(ob);
         }
 
-#warning context appears to be unused
-        internal void Load(BorrowedReference ob, InterDomainContext? context)
+        internal void Load(BorrowedReference ob, Dictionary<string, object?>? context)
         {
             OnLoad(ob, context);
         }
 
-        protected virtual void OnSave(BorrowedReference ob, InterDomainContext context) { }
-        protected virtual void OnLoad(BorrowedReference ob, InterDomainContext? context) { }
+        protected virtual Dictionary<string, object?>? OnSave(BorrowedReference ob) => null;
+        protected virtual void OnLoad(BorrowedReference ob, Dictionary<string, object?>? context) { }
 
         protected static void ClearObjectDict(BorrowedReference ob)
         {

--- a/src/runtime/metatype.cs
+++ b/src/runtime/metatype.cs
@@ -37,6 +37,10 @@ namespace Python.Runtime
 
         public static void Release()
         {
+            if (Runtime.HostedInPython)
+            {
+                _metaSlotsHodler.ResetSlots();
+            }
             PyCLRMetaType.Dispose();
         }
 

--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -21,7 +21,6 @@ namespace Python.Runtime
         private MethodInfo[]? _info = null;
         private readonly List<MaybeMethodInfo> infoList;
         internal string name;
-        internal PyObject? unbound;
         internal readonly MethodBinder binder;
         internal bool is_static = false;
 
@@ -164,11 +163,8 @@ namespace Python.Runtime
 
             if (ob == null)
             {
-                if (self.unbound is null)
-                {
-                    self.unbound = new PyObject(new MethodBinding(self, target: null, targetType: new PyType(tp)).Alloc().Steal());
-                }
-                return new NewReference(self.unbound);
+                var binding = new MethodBinding(self, target: null, targetType: new PyType(tp));
+                return binding.Alloc();
             }
 
             if (Runtime.PyObject_IsInstance(ob, tp) < 1)

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -339,6 +339,7 @@ namespace Python.Runtime
                 else if (forceBreakLoops)
                 {
                     NullGCHandles(CLRObject.reflectedObjects);
+                    CLRObject.reflectedObjects.Clear();
                 }
             }
             return false;

--- a/src/runtime/runtime_state.cs
+++ b/src/runtime/runtime_state.cs
@@ -10,7 +10,7 @@ namespace Python.Runtime
     {
         public static void Save()
         {
-            if (!PySys_GetObject("dummy_gc").IsNull)
+            if (!PySys_GetObject("initial_modules").IsNull)
             {
                 throw new Exception("Runtime State set already");
             }

--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -49,11 +49,11 @@ namespace Python.Runtime
             pythonBaseTypeProvider = PythonEngine.InteropConfiguration.pythonBaseTypeProviders;
         }
 
-        internal static void RemoveTypes(ShutdownMode shutdownMode)
+        internal static void RemoveTypes()
         {
             foreach (var type in cache.Values)
             {
-                if (shutdownMode == ShutdownMode.Extension
+                if (Runtime.HostedInPython
                     && _slotsHolders.TryGetValue(type, out var holder))
                 {
                     // If refcount > 1, it needs to reset the managed slot,
@@ -540,7 +540,7 @@ namespace Python.Runtime
             Util.WriteIntPtr(type, TypeOffset.tp_methods, mdefStart);
 
             // XXX: Hard code with mode check.
-            if (Runtime.ShutdownMode != ShutdownMode.Reload)
+            if (Runtime.HostedInPython)
             {
                 slotsHolder.Set(TypeOffset.tp_methods, (t, offset) =>
                 {
@@ -559,7 +559,7 @@ namespace Python.Runtime
             slotsHolder.KeeapAlive(thunkInfo);
 
             // XXX: Hard code with mode check.
-            if (Runtime.ShutdownMode != ShutdownMode.Reload)
+            if (Runtime.HostedInPython)
             {
                 IntPtr mdefAddr = mdef;
                 slotsHolder.AddDealloctor(() =>

--- a/tests/domain_tests/TestRunner.cs
+++ b/tests/domain_tests/TestRunner.cs
@@ -48,6 +48,8 @@ namespace Python.DomainReloadTests
             /// </summary>
             public string Name;
 
+            public override string ToString() => Name;
+
             /// <summary>
             /// The C# code to run in the first domain.
             /// </summary>
@@ -1135,8 +1137,7 @@ def after_reload():
         /// <summary>
         /// The runner's code. Runs the python code
         /// This is a template for string.Format
-        /// Arg 0 is the reload mode: ShutdownMode.Reload or other.
-        /// Arg 1 is the no-arg python function to run, before or after.
+        /// Arg 0 is the no-arg python function to run, before or after.
         /// </summary>
         const string CaseRunnerTemplate = @"
 using System;
@@ -1150,14 +1151,14 @@ namespace CaseRunner
         {{
             try
             {{
-                PythonEngine.Initialize(mode:{0});
+                PythonEngine.Initialize();
                 using (Py.GIL())
                 {{
                     var temp = AppDomain.CurrentDomain.BaseDirectory;
                     dynamic sys = Py.Import(""sys"");
                     sys.path.append(new PyString(temp));
                     dynamic test_mod = Py.Import(""domain_test_module.mod"");
-                    test_mod.{1}_reload();
+                    test_mod.{0}_reload();
                 }}
                 PythonEngine.Shutdown();
             }}
@@ -1280,9 +1281,9 @@ namespace CaseRunner
             return CreateAssembly(TestAssemblyName + ".dll", code, exe: false);
         }
 
-        static string CreateCaseRunnerAssembly(string verb, string shutdownMode = "ShutdownMode.Reload")
+        static string CreateCaseRunnerAssembly(string verb)
         {
-            var code = string.Format(CaseRunnerTemplate, shutdownMode, verb);
+            var code = string.Format(CaseRunnerTemplate, verb);
             var name = "TestCaseRunner.exe";
 
             return CreateAssembly(name, code, exe: true);

--- a/tests/domain_tests/test_domain_reload.py
+++ b/tests/domain_tests/test_domain_reload.py
@@ -65,7 +65,6 @@ def test_method_return_type_change():
 def test_field_type_change():
     _run_test("field_type_change")
 
-@pytest.mark.xfail(reason="Events not yet serializable")
 def test_rename_event():
     _run_test('event_rename')
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This removes all shutdown modes, except `Reload` (which you don't need to specify, because it is the only one left).

This means Python C runtime is never actually shut down when .NET calls `PythonEngine.Shutdown()`. Instead, anything from .NET exposed to Python before `Shutdown` becomes unavailable until `PythonEngine.Initialize()` is called again (which can be done from a different `AppDomain`).

### Any other comments?

Also in this change:
- dropped Python 3.6 support
- fixed Python derived types not being decrefed when an instance is deallocated
- reduced time and amount of storage needed for runtime reload
- removed circular reference loop between Type <-> `ConstructorBinding`(s)
+ exposed `Runtime.TryCollectingGarbage`

A review from @amos402 would be welcome