### PR TITLE
Require newest available clr-loader

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup(
     author="The Contributors of the Python.NET Project",
     author_email="pythonnet@python.org",
     packages=["pythonnet", "pythonnet.find_libpython"],
-    install_requires=["clr_loader"],
+    install_requires=["clr_loader >= 0.1.7"],
     long_description=long_description,
     long_description_content_type="text/x-rst",
     py_modules=["clr"],


### PR DESCRIPTION
Before `pythonnet` 3.0 is finally released, we should bump clr-loader to 1.0.

### What does this implement/fix? Explain your changes.

Bump the required clr-loader version.

### Does this close any currently open issues?

Maybe #1617 was already fixed in `clr-loader`, we should in any case follow that one for now.