### PR TITLE
Fix the PyGILState_STATE type

### DIFF
--- a/src/runtime/native/PyGILState.cs
+++ b/src/runtime/native/PyGILState.cs
@@ -1,11 +1,8 @@
-using System;
-using System.Runtime.InteropServices;
-
 namespace Python.Runtime.Native;
 
 /// <remarks><c>PyGILState_STATE</c></remarks>
-[StructLayout(LayoutKind.Sequential)]
-struct PyGILState
+enum PyGILState
 {
-    IntPtr handle;
+    PyGILState_LOCKED,
+    PyGILState_UNLOCKED 
 }


### PR DESCRIPTION
CPython uses a bare `enum` here, both of .NET and C default to `int`
enums, so this should be closer to the truth if no special compile
options are used.

Attempts to fix #1606.
