### PR TITLE
Fix warning regarding undefined __module__ on GC Offset Base

### DIFF
--- a/src/runtime/typemanager.cs
+++ b/src/runtime/typemanager.cs
@@ -456,7 +456,7 @@ namespace Python.Runtime
             int size = Util.ReadInt32(Runtime.PyTypeType, TypeOffset.tp_basicsize)
                        + IntPtr.Size // tp_clr_inst_offset
             ;
-            var result = new PyType(new TypeSpec("GC Offset Base", basicSize: size,
+            var result = new PyType(new TypeSpec("clr._internal.GCOffsetBase", basicSize: size,
                 new TypeSpec.Slot[]
                 {
 
@@ -480,7 +480,7 @@ namespace Python.Runtime
 
             PyType gcOffsetBase = CreateMetatypeWithGCHandleOffset();
 
-            PyType type = AllocateTypeObject("CLR Metatype", metatype: gcOffsetBase);
+            PyType type = AllocateTypeObject("CLRMetatype", metatype: gcOffsetBase);
 
             Util.WriteRef(type, TypeOffset.tp_base, new NewReference(gcOffsetBase).Steal());
 
@@ -509,7 +509,7 @@ namespace Python.Runtime
             }
             
             BorrowedReference dict = Util.ReadRef(type, TypeOffset.tp_dict);
-            using (var mod = Runtime.PyString_FromString("CLR"))
+            using (var mod = Runtime.PyString_FromString("clr._internal"))
                 Runtime.PyDict_SetItemString(dict, "__module__", mod.Borrow());
 
             // The type has been modified after PyType_Ready has been called

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,7 @@ def is_clr_root_module(ob):
 
 
 def is_clr_class(ob):
-    return type(ob).__name__ == 'CLR Metatype'  # for now
+    return type(ob).__name__ == 'CLRMetatype' and type(ob).__module__ == 'clr._internal'  # for now
 
 
 class ClassicClass:


### PR DESCRIPTION
Also makes the type names a bit more Python-esque. The `clr._internal`
module doesn't exist, but that is no difference to the previous setup.

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
