### PR TITLE
When process is exiting, there's no need to save live .NET objects

### DIFF
--- a/src/runtime/pythonengine.cs
+++ b/src/runtime/pythonengine.cs
@@ -296,6 +296,7 @@ namespace Python.Runtime
 
         static void OnProcessExit(object _, EventArgs __)
         {
+            Runtime.ProcessIsTerminating = true;
             Shutdown();
         }
 

--- a/src/runtime/runtime.cs
+++ b/src/runtime/runtime.cs
@@ -92,6 +92,7 @@ namespace Python.Runtime
         }
 
         internal static bool HostedInPython;
+        internal static bool ProcessIsTerminating;
 
         /// Initialize the runtime...
         /// </summary>
@@ -254,7 +255,7 @@ namespace Python.Runtime
 
             var state = PyGILState_Ensure();
 
-            if (!HostedInPython)
+            if (!HostedInPython && !ProcessIsTerminating)
             {
                 // avoid saving dead objects
                 TryCollectingGarbage(runs: 3);


### PR DESCRIPTION
This removes the need to ensure that all .NET objects references by Python when app stops are serializable. Also saves some time.