### PR TITLE
Fixed accessing partially overriden properties from Python

### DIFF
--- a/src/embed_tests/Inheritance.cs
+++ b/src/embed_tests/Inheritance.cs
@@ -119,6 +119,15 @@ namespace Python.EmbeddingTest
             scope.Set("exn", null);
             Assert.AreEqual(1, msg.Refcount);
         }
+
+        // https://github.com/pythonnet/pythonnet/issues/1455
+        [Test]
+        public void PropertyAccessorOverridden()
+        {
+            using var derived = new PropertyAccessorDerived().ToPython();
+            derived.SetAttr(nameof(PropertyAccessorDerived.VirtualProp), "hi".ToPython());
+            Assert.AreEqual("HI", derived.GetAttr(nameof(PropertyAccessorDerived.VirtualProp)).As<string>());
+        }
     }
 
     class ExtraBaseTypeProvider : IPythonBaseTypeProvider
@@ -190,6 +199,18 @@ namespace Python.EmbeddingTest
             }
             set => this.extras[nameof(this.XProp)] = value;
         }
+    }
+
+    public class PropertyAccessorBase
+    {
+        public virtual string VirtualProp { get; set; }
+    }
+
+    public class PropertyAccessorIntermediate: PropertyAccessorBase { }
+
+    public class PropertyAccessorDerived: PropertyAccessorIntermediate
+    {
+        public override string VirtualProp { set => base.VirtualProp = value.ToUpperInvariant(); }
     }
 
     public class ContainerClass

--- a/src/runtime/ReflectionUtil.cs
+++ b/src/runtime/ReflectionUtil.cs
@@ -1,0 +1,56 @@
+namespace Python.Runtime;
+
+using System;
+using System.Reflection;
+
+static class ReflectionUtil
+{
+    public static MethodInfo? GetBaseGetMethod(this PropertyInfo property, bool nonPublic)
+    {
+        if (property is null) throw new ArgumentNullException(nameof(property));
+
+        Type baseType = property.DeclaringType.BaseType;
+        BindingFlags bindingFlags = property.GetBindingFlags();
+
+        while (baseType is not null)
+        {
+            var baseProperty = baseType.GetProperty(property.Name, bindingFlags | BindingFlags.DeclaredOnly);
+            var accessor = baseProperty?.GetGetMethod(nonPublic);
+            if (accessor is not null)
+                return accessor;
+
+            baseType = baseType.BaseType;
+        }
+
+        return null;
+    }
+
+    public static MethodInfo? GetBaseSetMethod(this PropertyInfo property, bool nonPublic)
+    {
+        if (property is null) throw new ArgumentNullException(nameof(property));
+
+        Type baseType = property.DeclaringType.BaseType;
+        BindingFlags bindingFlags = property.GetBindingFlags();
+
+        while (baseType is not null)
+        {
+            var baseProperty = baseType.GetProperty(property.Name, bindingFlags | BindingFlags.DeclaredOnly);
+            var accessor = baseProperty?.GetSetMethod(nonPublic);
+            if (accessor is not null)
+                return accessor;
+
+            baseType = baseType.BaseType;
+        }
+
+        return null;
+    }
+
+    public static BindingFlags GetBindingFlags(this PropertyInfo property)
+    {
+        var accessor = property.GetMethod ?? property.SetMethod;
+        BindingFlags flags = default;
+        flags |= accessor.IsStatic ? BindingFlags.Static : BindingFlags.Instance;
+        flags |= accessor.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic;
+        return flags;
+    }
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

.NET `PropertyInfo.GetMethod` would not return base non-overridden accessor for a partially overridden property (e.g. only setter overridden)

Because of that when constructing `PropertyObject` we scan base classes to find base accessor (if any).

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1455

### Any other comments?

This might have performance implications due to replacement of `PropertyInfo.GetValue` with `getter.Invoke` (not tested)

### Also in the change

No need to serialize accessors - they can be reconstructed from the `PropertyInfo`

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change