### PR TITLE
Provide `__int__` instance method on enum types to support int(Enum.Member)

### DIFF
--- a/src/runtime/classmanager.cs
+++ b/src/runtime/classmanager.cs
@@ -345,8 +345,8 @@ namespace Python.Runtime
                 }
             }
 
-            // only [Flags] enums support bitwise operations
-            if (type.IsEnum && type.IsFlagsEnum())
+
+            if (type.IsEnum)
             {
                 var opsImpl = typeof(EnumOps<>).MakeGenericType(type);
                 foreach (var op in opsImpl.GetMethods(OpsHelper.BindingFlags))
@@ -354,6 +354,17 @@ namespace Python.Runtime
                     local.Add(op.Name);
                 }
                 info = info.Concat(opsImpl.GetMethods(OpsHelper.BindingFlags)).ToArray();
+
+                // only [Flags] enums support bitwise operations
+                if (type.IsFlagsEnum())
+                {
+                    opsImpl = typeof(FlagEnumOps<>).MakeGenericType(type);
+                    foreach (var op in opsImpl.GetMethods(OpsHelper.BindingFlags))
+                    {
+                        local.Add(op.Name);
+                    }
+                    info = info.Concat(opsImpl.GetMethods(OpsHelper.BindingFlags)).ToArray();
+                }
             }
 
             // Now again to filter w/o losing overloaded member info

--- a/src/runtime/operatormethod.cs
+++ b/src/runtime/operatormethod.cs
@@ -101,7 +101,7 @@ namespace Python.Runtime
             Debug.Assert(_opType != null);
 
             var staticMethods =
-                clrType.IsEnum ? typeof(EnumOps<>).MakeGenericType(clrType).GetMethods(flags)
+                clrType.IsEnum ? typeof(FlagEnumOps<>).MakeGenericType(clrType).GetMethods(flags)
                 : clrType.GetMethods(flags);
 
             foreach (var method in staticMethods)

--- a/src/runtime/opshelper.cs
+++ b/src/runtime/opshelper.cs
@@ -38,7 +38,7 @@ namespace Python.Runtime
     internal class OpsAttribute: Attribute { }
 
     [Ops]
-    internal static class EnumOps<T> where T : Enum
+    internal static class FlagEnumOps<T> where T : Enum
     {
         static readonly Func<T, T, T> and = BinaryOp(Expression.And);
         static readonly Func<T, T, T> or = BinaryOp(Expression.Or);
@@ -73,5 +73,17 @@ namespace Python.Runtime
                 return FromNumber(numericResult);
             });
         }
+    }
+
+    [Ops]
+    internal static class EnumOps<T> where T : Enum
+    {
+        [ForbidPythonThreads]
+#pragma warning disable IDE1006 // Naming Styles - must match Python
+        public static PyInt __int__(T value)
+#pragma warning restore IDE1006 // Naming Styles
+            => typeof(T).GetEnumUnderlyingType() == typeof(UInt64)
+            ? new PyInt(Convert.ToUInt64(value))
+            : new PyInt(Convert.ToInt64(value));
     }
 }

--- a/src/testing/enumtest.cs
+++ b/src/testing/enumtest.cs
@@ -72,7 +72,9 @@ namespace Python.Test
         Two,
         Three,
         Four,
-        Five
+        Five,
+        Max = long.MaxValue,
+        Min = long.MinValue,
     }
 
     public enum ULongEnum : ulong
@@ -82,7 +84,8 @@ namespace Python.Test
         Two,
         Three,
         Four,
-        Five
+        Five,
+        Max = ulong.MaxValue,
     }
 
     [Flags]

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -87,6 +87,15 @@ def test_ulong_enum():
     assert Test.ULongEnum.Two == Test.ULongEnum(2)
 
 
+def test_long_enum_to_int():
+    assert int(Test.LongEnum.Max) == 9223372036854775807
+    assert int(Test.LongEnum.Min) == -9223372036854775808
+
+
+def test_ulong_enum_to_int():
+    assert int(Test.ULongEnum.Max) == 18446744073709551615
+
+
 def test_instantiate_enum_fails():
     """Test that instantiation of an enum class fails."""
     from System import DayOfWeek


### PR DESCRIPTION
Added `EnumOps.__int__`, that provides `__int__` method for type dictionaries of reflected enum types.

### Does this close any currently open issues?

implements https://github.com/pythonnet/pythonnet/issues/1585

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
