### PR TITLE
Improved support for generic method overloading

### DIFF
--- a/src/runtime/methodobject.cs
+++ b/src/runtime/methodobject.cs
@@ -27,7 +27,7 @@ namespace Python.Runtime
         internal PyString? doc;
         internal MaybeType type;
 
-        public MethodObject(Type type, string name, MethodBase[] info, bool allow_threads = MethodBinder.DefaultAllowThreads)
+        public MethodObject(MaybeType type, string name, MethodBase[] info, bool allow_threads = MethodBinder.DefaultAllowThreads)
         {
             this.type = type;
             this.name = name;
@@ -46,6 +46,9 @@ namespace Python.Runtime
         }
 
         public bool IsInstanceConstructor => name == "__init__";
+
+        public MethodObject WithOverloads(MethodBase[] overloads)
+            => new(type, name, overloads, allow_threads: binder.allow_threads);
 
         internal MethodBase[] info
         {

--- a/src/testing/methodtest.cs
+++ b/src/testing/methodtest.cs
@@ -646,6 +646,9 @@ namespace Python.Test
             return i;
         }
 
+        public virtual void OverloadedConstrainedGeneric<T>(T generic) where T : MethodTest { }
+        public virtual void OverloadedConstrainedGeneric<T>(T generic, string str) where T: MethodTest { }
+
         public static string CaseSensitive()
         {
             return "CaseSensitive";

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -762,6 +762,18 @@ def test_missing_generic_type():
     with pytest.raises(TypeError):
         IList[bool]
 
+# https://github.com/pythonnet/pythonnet/issues/1522
+def test_overload_generic_parameter():
+    from Python.Test import MethodTest, MethodTestSub
+
+    inst = MethodTest()
+    generic = MethodTestSub()
+    inst.OverloadedConstrainedGeneric(generic)
+    inst.OverloadedConstrainedGeneric[MethodTestSub](generic)
+
+    inst.OverloadedConstrainedGeneric[MethodTestSub](generic, '42')
+    inst.OverloadedConstrainedGeneric[MethodTestSub](generic, System.String('42'))
+
 def test_invalid_generic_type_parameter():
     from Python.Test import GenericTypeWithConstraint
     with pytest.raises(TypeError):


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Prior to this change if method had multiple generic overloads, only 1 of them could be matched (whichever one reflection would return first)

Now `MethodBinder.MatchParameters` returns all matching generic overloads, not just the first one.

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1522

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
