### PR TITLE
Support for byref parameters when overriding .NET methods from Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Python operator method will call C# operator method for supported binary and unary operators ([#1324][p1324]).
 -   Add GetPythonThreadID and Interrupt methods in PythonEngine
 -   Ability to implement delegates with `ref` and `out` parameters in Python, by returning the modified parameter values in a tuple. ([#1355][i1355])
+-   Ability to override .NET methods that have `out` or `ref` in Python by returning the modified parameter values in a tuple. ([#1481][i1481])
 -   `PyType` - a wrapper for Python type objects, that also permits creating new heap types from `TypeSpec`
 -    Improved exception handling:
   *   exceptions can now be converted with codecs
@@ -879,3 +880,4 @@ This version improves performance on benchmarks significantly compared to 2.3.
 [i449]: https://github.com/pythonnet/pythonnet/issues/449
 [i1342]: https://github.com/pythonnet/pythonnet/issues/1342
 [i238]: https://github.com/pythonnet/pythonnet/issues/238
+[i1481]: https://github.com/pythonnet/pythonnet/issues/1481

--- a/src/runtime/delegatemanager.cs
+++ b/src/runtime/delegatemanager.cs
@@ -135,28 +135,7 @@ namespace Python.Runtime
             if (anyByRef)
             {
                 // Dispatch() will have modified elements of the args list that correspond to out parameters.
-                for (var c = 0; c < signature.Length; c++)
-                {
-                    Type t = signature[c];
-                    if (t.IsByRef)
-                    {
-                        t = t.GetElementType();
-                        // *arg = args[c]
-                        il.Emit(OpCodes.Ldarg_S, (byte)(c + 1));
-                        il.Emit(OpCodes.Ldloc_0);
-                        il.Emit(OpCodes.Ldc_I4, c);
-                        il.Emit(OpCodes.Ldelem_Ref);
-                        if (t.IsValueType)
-                        {
-                            il.Emit(OpCodes.Unbox_Any, t);
-                            il.Emit(OpCodes.Stobj, t);
-                        }
-                        else
-                        {
-                            il.Emit(OpCodes.Stind_Ref);
-                        }
-                    }
-                }
+                CodeGenerator.GenerateMarshalByRefsBack(il, signature);
             }
 
             if (method.ReturnType == voidtype)

--- a/src/testing/interfacetest.cs
+++ b/src/testing/interfacetest.cs
@@ -79,4 +79,18 @@ namespace Python.Test
         {
         }
     }
+    
+    public interface IOutArg
+    {
+        string MyMethod_Out(string name, out int index);
+    }
+
+    public class OutArgCaller
+    {
+        public static int CallMyMethod_Out(IOutArg myInterface)
+        {
+            myInterface.MyMethod_Out("myclient", out int index);
+            return index;
+        }
+    }
 }

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -93,6 +93,20 @@ def test_interface_object_returned_through_out_param():
 
     assert hello2.SayHello() == 'hello 2'
 
+def test_interface_out_param_python_impl():
+    from Python.Test import IOutArg, OutArgCaller
+
+    class MyOutImpl(IOutArg):
+        __namespace__ = "Python.Test"
+
+        def MyMethod_Out(self, name, index):
+            other_index = 101
+            return ('MyName', other_index)
+
+    py_impl = MyOutImpl()
+
+    assert 101 == OutArgCaller.CallMyMethod_Out(py_impl)
+
 
 def test_null_interface_object_returned():
     """Test None is used also for methods with interface return types"""


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This supports overriding virtual .NET methods that have `out` or `ref` parameters from Python.

The new code is emitted to
1. unpack the tuple returned from Python to extract new values for byref parameters and modify args array correspondingly
2. marshal those new values from the args array back into arguments in generated IL

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1481

### Additional notes

Related to https://github.com/pythonnet/pythonnet/pull/1364

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)