### PR TITLE
Temporary fix method binder for out parameters

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -84,3 +84,4 @@
 -   ([@DanBarzilian](https://github.com/DanBarzilian))
 -   ([@alxnull](https://github.com/alxnull))
 -   ([@gpetrou](https://github.com/gpetrou))
+-   Ehsan Iran-Nejad ([@eirannejad](https://github.com/eirannejad))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Instead, `PyIterable` does that.
 -   Empty parameter names (as can be generated from F#) do not cause crashes
 -   Unicode strings with surrogates were truncated when converting from Python
 -   `Reload` mode now supports generic methods (previously Python would stop seeing them after reload)
+-   Temporarily fixed issue resolving method overload when method signature has `out` parameters ([#1672](i1672))
 
 ### Removed
 
@@ -881,3 +882,4 @@ This version improves performance on benchmarks significantly compared to 2.3.
 [i1342]: https://github.com/pythonnet/pythonnet/issues/1342
 [i238]: https://github.com/pythonnet/pythonnet/issues/238
 [i1481]: https://github.com/pythonnet/pythonnet/issues/1481
+[i1672]: https://github.com/pythonnet/pythonnet/pull/1672

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -632,6 +632,9 @@ namespace Python.Runtime
                         margs[paramIndex] = defaultArgList[paramIndex - pyArgCount];
                     }
 
+                    if (parameter.ParameterType.IsByRef)
+                        outs++;
+
                     continue;
                 }
 
@@ -816,6 +819,9 @@ namespace Python.Runtime
                         // to be passed in as the parameter value
                         defaultArgList.Add(parameters[v].GetDefaultValue());
                         defaultsNeeded++;
+                    }
+                    else if (parameters[v].IsOut) {
+                        defaultArgList.Add(null);
                     }
                     else if (!paramsArray)
                     {

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -633,7 +633,9 @@ namespace Python.Runtime
                     }
 
                     if (parameter.ParameterType.IsByRef)
+                    {
                         outs++;
+                    }
 
                     continue;
                 }

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -267,7 +267,13 @@ def test_params_method_with_lists():
 
 def test_string_out_params():
     """Test use of string out-parameters."""
-    result = MethodTest.TestStringOutParams("hi")
+    result = MethodTest.TestStringOutParams("hi", "there")
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result[0] is True
+    assert result[1] == "output string"
+
+    result = MethodTest.TestStringOutParams("hi", None)
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
@@ -291,11 +297,15 @@ def test_string_ref_params():
 
 def test_value_out_params():
     """Test use of value type out-parameters."""
-    result = MethodTest.TestValueOutParams("hi")
+    result = MethodTest.TestValueOutParams("hi", 1)
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
     assert result[1] == 42
+
+    # None cannot be converted to a value type like int, long, etc.
+    with pytest.raises(TypeError):
+        MethodTest.TestValueOutParams("hi", None)
 
 
 def test_value_ref_params():
@@ -313,7 +323,13 @@ def test_value_ref_params():
 
 def test_object_out_params():
     """Test use of object out-parameters."""
-    result = MethodTest.TestObjectOutParams("hi")
+    result = MethodTest.TestObjectOutParams("hi", MethodTest())
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result[0] is True
+    assert isinstance(result[1], System.Exception)
+
+    result = MethodTest.TestObjectOutParams("hi", None)
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
@@ -337,11 +353,15 @@ def test_object_ref_params():
 
 def test_struct_out_params():
     """Test use of struct out-parameters."""
-    result = MethodTest.TestStructOutParams("hi")
+    result = MethodTest.TestStructOutParams("hi", System.Guid.NewGuid())
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
     assert isinstance(result[1], System.Guid)
+
+    # None cannot be converted to a value type like a struct
+    with pytest.raises(TypeError):
+        MethodTest.TestValueRefParams("hi", None)
 
 
 def test_struct_ref_params():

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -267,13 +267,7 @@ def test_params_method_with_lists():
 
 def test_string_out_params():
     """Test use of string out-parameters."""
-    result = MethodTest.TestStringOutParams("hi", "there")
-    assert isinstance(result, tuple)
-    assert len(result) == 2
-    assert result[0] is True
-    assert result[1] == "output string"
-
-    result = MethodTest.TestStringOutParams("hi", None)
+    result = MethodTest.TestStringOutParams("hi")
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
@@ -297,15 +291,11 @@ def test_string_ref_params():
 
 def test_value_out_params():
     """Test use of value type out-parameters."""
-    result = MethodTest.TestValueOutParams("hi", 1)
+    result = MethodTest.TestValueOutParams("hi")
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
     assert result[1] == 42
-
-    # None cannot be converted to a value type like int, long, etc.
-    with pytest.raises(TypeError):
-        MethodTest.TestValueOutParams("hi", None)
 
 
 def test_value_ref_params():
@@ -323,13 +313,7 @@ def test_value_ref_params():
 
 def test_object_out_params():
     """Test use of object out-parameters."""
-    result = MethodTest.TestObjectOutParams("hi", MethodTest())
-    assert isinstance(result, tuple)
-    assert len(result) == 2
-    assert result[0] is True
-    assert isinstance(result[1], System.Exception)
-
-    result = MethodTest.TestObjectOutParams("hi", None)
+    result = MethodTest.TestObjectOutParams("hi")
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
@@ -353,15 +337,11 @@ def test_object_ref_params():
 
 def test_struct_out_params():
     """Test use of struct out-parameters."""
-    result = MethodTest.TestStructOutParams("hi", System.Guid.NewGuid())
+    result = MethodTest.TestStructOutParams("hi")
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
     assert isinstance(result[1], System.Guid)
-
-    # None cannot be converted to a value type like a struct
-    with pytest.raises(TypeError):
-        MethodTest.TestValueRefParams("hi", None)
 
 
 def test_struct_ref_params():

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -280,6 +280,16 @@ def test_string_out_params():
     assert result[1] == "output string"
 
 
+def test_string_out_params_without_passing_string_value():
+    """Test use of string out-parameters."""
+    # @eirannejad 2022-01-13
+    result = MethodTest.TestStringOutParams("hi")
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result[0] is True
+    assert result[1] == "output string"
+
+
 def test_string_ref_params():
     """Test use of string byref parameters."""
     result = MethodTest.TestStringRefParams("hi", "there")
@@ -308,6 +318,16 @@ def test_value_out_params():
         MethodTest.TestValueOutParams("hi", None)
 
 
+def test_value_out_params_without_passing_string_value():
+    """Test use of string out-parameters."""
+    # @eirannejad 2022-01-13
+    result = MethodTest.TestValueOutParams("hi")
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result[0] is True
+    assert result[1] == 42
+
+
 def test_value_ref_params():
     """Test use of value type byref parameters."""
     result = MethodTest.TestValueRefParams("hi", 1)
@@ -330,6 +350,15 @@ def test_object_out_params():
     assert isinstance(result[1], System.Exception)
 
     result = MethodTest.TestObjectOutParams("hi", None)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result[0] is True
+    assert isinstance(result[1], System.Exception)
+
+
+def test_object_out_params_without_passing_string_value():
+    """Test use of object out-parameters."""
+    result = MethodTest.TestObjectOutParams("hi")
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert result[0] is True
@@ -362,6 +391,15 @@ def test_struct_out_params():
     # None cannot be converted to a value type like a struct
     with pytest.raises(TypeError):
         MethodTest.TestValueRefParams("hi", None)
+
+
+def test_struct_out_params_without_passing_string_value():
+    """Test use of struct out-parameters."""
+    result = MethodTest.TestStructOutParams("hi")
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result[0] is True
+    assert isinstance(result[1], System.Guid)
 
 
 def test_struct_ref_params():


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Current method binder code needs cleanup. There is an active issue with pythonnet failing to find the appropriate overload when the method signature includes `out` parameters e.g. `SomeMethod(int a, out int b)`. Current workaround is to call the method by providing bogus value for the `out` parameter e.g. `SomeMethod(1, 0)` instead of `SomeMethod(1)`

This PR pushes a temporary fix for this problem until the binder code is cleaned up. The change is intentionally minimal.

### Does this close any currently open issues?

Not sure. Can not find anything related to this by looking at open issue titles

### Any other comments?

No

### Checklist

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
