### PR TITLE
added missing PyThreadState_Swap to Runtime and its Delegates

### DIFF
--- a/src/runtime/Runtime.Delegates.cs
+++ b/src/runtime/Runtime.Delegates.cs
@@ -23,6 +23,7 @@ public unsafe partial class Runtime
             Py_EndInterpreter = (delegate* unmanaged[Cdecl]<PyThreadState*, void>)GetFunctionByName(nameof(Py_EndInterpreter), GetUnmanagedDll(_PythonDll));
             PyThreadState_New = (delegate* unmanaged[Cdecl]<PyInterpreterState*, PyThreadState*>)GetFunctionByName(nameof(PyThreadState_New), GetUnmanagedDll(_PythonDll));
             PyThreadState_Get = (delegate* unmanaged[Cdecl]<PyThreadState*>)GetFunctionByName(nameof(PyThreadState_Get), GetUnmanagedDll(_PythonDll));
+            PyThreadState_Swap = (delegate* unmanaged[Cdecl]<PyThreadState*, PyThreadState*>)GetFunctionByName(nameof(PyThreadState_Swap), GetUnmanagedDll(_PythonDll));
             _PyThreadState_UncheckedGet = (delegate* unmanaged[Cdecl]<PyThreadState*>)GetFunctionByName(nameof(_PyThreadState_UncheckedGet), GetUnmanagedDll(_PythonDll));
             try
             {
@@ -313,6 +314,7 @@ public unsafe partial class Runtime
         internal static delegate* unmanaged[Cdecl]<PyThreadState*, void> Py_EndInterpreter { get; }
         internal static delegate* unmanaged[Cdecl]<PyInterpreterState*, PyThreadState*> PyThreadState_New { get; }
         internal static delegate* unmanaged[Cdecl]<PyThreadState*> PyThreadState_Get { get; }
+        internal static delegate* unmanaged[Cdecl]<PyThreadState*, PyThreadState*> PyThreadState_Swap { get; }
         internal static delegate* unmanaged[Cdecl]<PyThreadState*> _PyThreadState_UncheckedGet { get; }
         internal static delegate* unmanaged[Cdecl]<int> PyGILState_Check { get; }
         internal static delegate* unmanaged[Cdecl]<PyGILState> PyGILState_Ensure { get; }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -748,6 +748,9 @@ namespace Python.Runtime
 
 
         internal static PyThreadState* PyThreadState_Get() => Delegates.PyThreadState_Get();
+        
+        
+        internal static PyThreadState* PyThreadState_Swap(PyThreadState* threadState) => Delegates.PyThreadState_Swap(threadState);
 
 
         internal static PyThreadState* _PyThreadState_UncheckedGet() => Delegates._PyThreadState_UncheckedGet();


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`PyThreadState_Swap` was missing in `Runtime` and `Runtime.Delegates` code

### Does this close any currently open issues?

No

### Any other comments?

N/A

### Checklist

Check all those that are applicable and complete.

-   Make sure to include one or more tests for your change
    ⚠️ Skipping tests since there are not any tests for specific runtime p/invokes. This method is not used anywhere in original pythonnet code base as of creating this PR
-   [X] If an enhancement PR, please create docs and at best an example
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
