### PR TITLE
Allow dynamic `PyObject` conversion to `IEnumerable`

### DIFF
--- a/src/embed_tests/dynamic.cs
+++ b/src/embed_tests/dynamic.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
 using Python.Runtime;
@@ -125,6 +126,16 @@ namespace Python.EmbeddingTest
 
             // Compare in .NET
             Assert.IsTrue(sys.testattr1.Equals(sys.testattr2));
+        }
+
+        // regression test for https://github.com/pythonnet/pythonnet/issues/1680
+        [Test]
+        public void ForEach()
+        {
+            dynamic pyList = PythonEngine.Eval("[1,2,3]");
+            var list = new List<int>();
+            foreach (int item in pyList)
+                list.Add(item);
         }
     }
 }

--- a/src/runtime/PythonTypes/PyObject.cs
+++ b/src/runtime/PythonTypes/PyObject.cs
@@ -1296,6 +1296,12 @@ namespace Python.Runtime
                 return converted;
             }
 
+            if (binder.Type == typeof(System.Collections.IEnumerable) && this.IsIterable())
+            {
+                result = new PyIterable(this.Reference);
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
When the object is a Python iterable

### What does this implement/fix? Explain your changes.

Enables `foreach` loops over dynamic `PyObject` instances

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1680

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
