### PR TITLE
Support for `BigInteger` (C#) <-> `PyInt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   .NET collection types now implement standard Python collection interfaces from `collections.abc`.
 See [Mixins/collections.py](src/runtime/Mixins/collections.py).
 -   .NET arrays implement Python buffer protocol
+-   Python integer interoperability with `System.Numerics.BigInteger`
 -   Python.NET will correctly resolve .NET methods, that accept `PyList`, `PyInt`,
 and other `PyObject` derived types when called from Python.
 -   .NET classes, that have `__call__` method are callable from Python

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 
 using NUnit.Framework;
 
@@ -129,6 +130,25 @@ namespace Python.EmbeddingTest
             var i = new PyInt(Const);
             var ni = i.As<int?>();
             Assert.AreEqual(Const, ni);
+        }
+
+        [Test]
+        public void BigIntExplicit()
+        {
+            BigInteger val = 42;
+            var i = new PyInt(val);
+            var ni = i.As<BigInteger>();
+            Assert.AreEqual(val, ni);
+            var nullable = i.As<BigInteger?>();
+            Assert.AreEqual(val, nullable);
+        }
+
+        [Test]
+        public void PyIntImplicit()
+        {
+            var i = new PyInt(1);
+            var ni = (PyObject)i.As<object>();
+            Assert.AreEqual(i.rawPtr, ni.rawPtr);
         }
 
         [Test]

--- a/src/embed_tests/TestPyInt.cs
+++ b/src/embed_tests/TestPyInt.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+
 using NUnit.Framework;
 using Python.Runtime;
 
@@ -178,6 +182,36 @@ namespace Python.EmbeddingTest
             var a = new PyInt(val);
             Assert.IsInstanceOf(typeof(long), a.ToInt64());
             Assert.AreEqual(val, a.ToInt64());
+        }
+
+        [Test]
+        public void ToBigInteger()
+        {
+            int[] simpleValues =
+            {
+                0, 1, 2,
+                0x10,
+                0x123,
+                0x1234,
+            };
+            simpleValues = simpleValues.Concat(simpleValues.Select(v => -v)).ToArray();
+
+            foreach (var val in simpleValues)
+            {
+                var pyInt = new PyInt(val);
+                Assert.AreEqual((BigInteger)val, pyInt.ToBigInteger());
+            }
+        }
+
+        [Test]
+        public void ToBigIntegerLarge()
+        {
+            BigInteger val = BigInteger.Pow(2, 1024) + 3;
+            var pyInt = new PyInt(val);
+            Assert.AreEqual(val, pyInt.ToBigInteger());
+            val = -val;
+            pyInt = new PyInt(val);
+            Assert.AreEqual(val, pyInt.ToBigInteger());
         }
     }
 }

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -455,6 +455,14 @@ namespace Python.Runtime
                 }
             }
 
+            if (obType == typeof(System.Numerics.BigInteger)
+                && Runtime.PyInt_Check(value))
+            {
+                using var pyInt = new PyInt(value);
+                result = pyInt.ToBigInteger();
+                return true;
+            }
+
             return ToPrimitive(value, obType, out result, setError);
         }
 

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -179,6 +179,7 @@ namespace Python.Runtime
 
             clrInterop = GetModuleLazy("clr.interop");
             inspect = GetModuleLazy("inspect");
+            hexCallable = new(() => new PyString("%x").GetAttr("__mod__"));
         }
 
         static void NewRun()
@@ -279,8 +280,9 @@ namespace Python.Runtime
 
             Exceptions.Shutdown();
             PythonEngine.InteropConfiguration.Dispose();
-            DisposeLazyModule(clrInterop);
-            DisposeLazyModule(inspect);
+            DisposeLazyObject(clrInterop);
+            DisposeLazyObject(inspect);
+            DisposeLazyObject(hexCallable);
             PyObjectConversions.Reset();
 
             PyGC_Collect();
@@ -352,11 +354,11 @@ namespace Python.Runtime
         public static bool TryCollectingGarbage(int runs)
             => TryCollectingGarbage(runs, forceBreakLoops: false);
 
-        static void DisposeLazyModule(Lazy<PyObject> module)
+        static void DisposeLazyObject(Lazy<PyObject> pyObject)
         {
-            if (module.IsValueCreated)
+            if (pyObject.IsValueCreated)
             {
-                module.Value.Dispose();
+                pyObject.Value.Dispose();
             }
         }
 
@@ -489,8 +491,12 @@ namespace Python.Runtime
 
         private static Lazy<PyObject> inspect;
         internal static PyObject InspectModule => inspect.Value;
+
         private static Lazy<PyObject> clrInterop;
         internal static PyObject InteropModule => clrInterop.Value;
+
+        private static Lazy<PyObject> hexCallable;
+        internal static PyObject HexCallable => hexCallable.Value;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         internal static BorrowedReference CLRMetaType => PyCLRMetaType;

--- a/src/runtime/Util/Util.cs
+++ b/src/runtime/Util/Util.cs
@@ -141,6 +141,13 @@ namespace Python.Runtime
             return reader.ReadToEnd();
         }
 
+        public static int HexToInt(char hex) => hex switch
+        {
+            >= '0' and <= '9' => hex - '0',
+            >= 'a' and <= 'f' => hex - 'a' + 10,
+            _ => throw new ArgumentOutOfRangeException(nameof(hex)),
+        };
+
         public static IEnumerator<T> GetEnumerator<T>(this IEnumerator<T> enumerator) => enumerator;
 
         public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds various conversions between `PyInt` and `System.Numerics.BigInteger`.

### Does this close any currently open issues?
fixes https://github.com/pythonnet/pythonnet/issues/1642#issuecomment-1058412759

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
