### PR TITLE
Make methods of `PyObject` inherited from its base .NET classes GIL-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ details about the cause of the failure
 -   floating point values passed from Python are no longer silently truncated
 when .NET expects an integer [#1342][i1342]
 -   More specific error messages for method argument mismatch
+-   members of `PyObject` inherited from `System.Object and `DynamicObject` now autoacquire GIL
 -   BREAKING: when inheriting from .NET types in Python if you override `__init__` you
 must explicitly call base constructor using `super().__init__(.....)`. Not doing so will lead
 to undefined behavior.
@@ -69,6 +70,7 @@ One must now either use enum members (e.g. `MyEnum.Option`), or use enum constru
 -   BREAKING: Names of .NET types (e.g. `str(__class__)`) changed to better support generic types
 -   BREAKING: overload resolution will no longer prefer basic types. Instead, first matching overload will
 be chosen.
+-   BREAKING: acquiring GIL using `Py.GIL` no longer forces `PythonEngine` to initialize
 -   BREAKING: `Exec` and `Eval` from `PythonEngine` no longer accept raw pointers.
 -   BREAKING: .NET collections and arrays are no longer automatically converted to
 Python collections. Instead, they implement standard Python

--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -473,7 +473,7 @@ DateTimeDecoder.Setup()
         }
 
         public bool CanDecode(PyType objectType, Type targetType)
-            => objectType.Handle == TheOnlySupportedSourceType.Handle
+            => PythonReferenceComparer.Instance.Equals(objectType, TheOnlySupportedSourceType)
                && targetType == typeof(TTarget);
         public bool TryDecode<T>(PyObject pyObj, out T value)
         {

--- a/src/embed_tests/TestPyObject.cs
+++ b/src/embed_tests/TestPyObject.cs
@@ -94,6 +94,13 @@ a = MemberNamesTest()
             );
             Assert.AreEqual(Exceptions.TypeError, typeErrResult.Type);
         }
+
+        // regression test from https://github.com/pythonnet/pythonnet/issues/1642
+        [Test]
+        public void InheritedMethodsAutoacquireGIL()
+        {
+            PythonEngine.Exec("from System import String\nString.Format('{0},{1}', 1, 2)");
+        }
     }
 
     public class PyObjectTestMethods

--- a/src/runtime/InternString.cs
+++ b/src/runtime/InternString.cs
@@ -39,7 +39,7 @@ namespace Python.Runtime
             {
                 NewReference pyStr = Runtime.PyUnicode_InternFromString(name);
                 var op = new PyString(pyStr.StealOrThrow());
-                Debug.Assert(name == op.ToString());
+                Debug.Assert(name == op.As<string>());
                 SetIntern(name, op);
                 var field = type.GetField("f" + name, PyIdentifierFieldFlags)!;
                 field.SetValue(null, op.rawPtr);

--- a/src/runtime/Py.cs
+++ b/src/runtime/Py.cs
@@ -10,15 +10,7 @@ using Python.Runtime.Native;
 
 public static class Py
 {
-    public static GILState GIL()
-    {
-        if (!PythonEngine.IsInitialized)
-        {
-            PythonEngine.Initialize();
-        }
-
-        return PythonEngine.DebugGIL ? new DebugGILState() : new GILState();
-    }
+    public static GILState GIL() => PythonEngine.DebugGIL ? new DebugGILState() : new GILState();
 
     public static PyModule CreateScope() => new();
     public static PyModule CreateScope(string name)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

passing Python objects to unsuspecting .NET methods, that accept `object` would lead to crash if those methods try to use standard .NET `System.Object` members without acquiring the Python GIL first.

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1642

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
