### PR TITLE
On shutdown from Python release all slot holders

### DIFF
--- a/pythonnet.sln
+++ b/pythonnet.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repo", "Repo", "{441A0123-F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{D301657F-5EAF-4534-B280-B858D651B2E5}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\ARM.yml = .github\workflows\ARM.yml
 		.github\workflows\main.yml = .github\workflows\main.yml
 		.github\workflows\nuget-preview.yml = .github\workflows\nuget-preview.yml
 	EndProjectSection

--- a/pythonnet/__init__.py
+++ b/pythonnet/__init__.py
@@ -16,7 +16,7 @@ def set_runtime(runtime):
 
 
 def set_default_runtime() -> None:
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         set_runtime(clr_loader.get_netfx())
     else:
         set_runtime(clr_loader.get_mono())
@@ -36,14 +36,15 @@ def load():
         set_default_runtime()
 
     dll_path = join(dirname(__file__), "runtime", "Python.Runtime.dll")
-    
+
     _LOADER_ASSEMBLY = _RUNTIME.get_assembly(dll_path)
 
     func = _LOADER_ASSEMBLY["Python.Runtime.Loader.Initialize"]
-    if func(''.encode("utf8")) != 0:
+    if func(b"") != 0:
         raise RuntimeError("Failed to initialize Python.Runtime.dll")
 
     import atexit
+
     atexit.register(unload)
 
 
@@ -51,7 +52,7 @@ def unload():
     global _RUNTIME
     if _LOADER_ASSEMBLY is not None:
         func = _LOADER_ASSEMBLY["Python.Runtime.Loader.Shutdown"]
-        if func(b"") != 0:
+        if func(b"full_shutdown") != 0:
             raise RuntimeError("Failed to call Python.NET shutdown")
 
     if _RUNTIME is not None:

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -54,8 +54,9 @@ namespace Python.Runtime
         }
 
         private static bool _isInitialized = false;
-
         internal static bool IsInitialized => _isInitialized;
+        private static bool _typesInitialized = false;
+        internal static bool TypeManagerInitialized => _typesInitialized;
         internal static readonly bool Is32Bit = IntPtr.Size == 4;
 
         // .NET core: System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -151,6 +152,7 @@ namespace Python.Runtime
             ClassManager.Reset();
             ClassDerivedObject.Reset();
             TypeManager.Initialize();
+            _typesInitialized = true;
 
             // Initialize modules that depend on the runtime class.
             AssemblyManager.Initialize();
@@ -272,6 +274,7 @@ namespace Python.Runtime
             NullGCHandles(ExtensionType.loadedExtensions);
             ClassManager.RemoveClasses();
             TypeManager.RemoveTypes();
+            _typesInitialized = false;
 
             MetaType.Release();
             PyCLRMetaType.Dispose();
@@ -291,9 +294,10 @@ namespace Python.Runtime
             Finalizer.Shutdown();
             InternString.Shutdown();
 
+            ResetPyMembers();
+
             if (!HostedInPython)
             {
-                ResetPyMembers();
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 PyGILState_Release(state);
@@ -310,7 +314,6 @@ namespace Python.Runtime
             }
             else
             {
-                ResetPyMembers();
                 PyGILState_Release(state);
             }
         }

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -832,6 +832,7 @@ namespace Python.Runtime
                 var metatype = Runtime.PyObject_TYPE(Type);
                 ManagedType.TryFreeGCHandle(Type, metatype);
             }
+            Runtime.PyType_Modified(Type);
         }
 
         public static IntPtr GetDefaultSlot(int offset)

--- a/src/runtime/Types/ModuleObject.cs
+++ b/src/runtime/Types/ModuleObject.cs
@@ -542,7 +542,6 @@ namespace Python.Runtime
         /// <returns>The Type object</returns>
 
         [ModuleFunction]
-        [ForbidPythonThreads]
         public static Type GetClrType(Type type)
         {
             return type;

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -41,3 +41,7 @@ def test_run_string():
     assert sys.multiline_worked == 1
 
     PythonEngine.ReleaseLock()
+
+def test_leak_type():
+    import clr
+    sys._leaked_intptr = clr.GetClrType(System.IntPtr)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Before this fix slots of reflected types were not released to Python defaults leaving Python referencing managed code after managed runtime has already shut down.

In the original bug, the runtime in question is Mono after `mono_jit_cleanup`

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1683