### PR TITLE
Clear weakref list when reflected object is destroyed

### DIFF
--- a/src/embed_tests/TestInstanceWrapping.cs
+++ b/src/embed_tests/TestInstanceWrapping.cs
@@ -34,6 +34,16 @@ namespace Python.EmbeddingTest
             }
         }
 
+        [Test]
+        public void WeakRefIsNone_AfterObjectIsGone()
+        {
+            using var makeref = Py.Import("weakref").GetAttr("ref");
+            var ub = new UriBuilder().ToPython();
+            using var weakref = makeref.Invoke(ub);
+            ub.Dispose();
+            Assert.IsTrue(weakref.Invoke().IsNone());
+        }
+
         class Base {}
         class Derived: Base { }
 

--- a/src/runtime/Runtime.Delegates.cs
+++ b/src/runtime/Runtime.Delegates.cs
@@ -78,6 +78,7 @@ public unsafe partial class Runtime
             PyObject_RichCompareBool = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int, int>)GetFunctionByName(nameof(PyObject_RichCompareBool), GetUnmanagedDll(_PythonDll));
             PyObject_IsInstance = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int>)GetFunctionByName(nameof(PyObject_IsInstance), GetUnmanagedDll(_PythonDll));
             PyObject_IsSubclass = (delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int>)GetFunctionByName(nameof(PyObject_IsSubclass), GetUnmanagedDll(_PythonDll));
+            PyObject_ClearWeakRefs = (delegate* unmanaged[Cdecl]<BorrowedReference, void>)GetFunctionByName(nameof(PyObject_ClearWeakRefs), GetUnmanagedDll(_PythonDll));
             PyCallable_Check = (delegate* unmanaged[Cdecl]<BorrowedReference, int>)GetFunctionByName(nameof(PyCallable_Check), GetUnmanagedDll(_PythonDll));
             PyObject_IsTrue = (delegate* unmanaged[Cdecl]<BorrowedReference, int>)GetFunctionByName(nameof(PyObject_IsTrue), GetUnmanagedDll(_PythonDll));
             PyObject_Not = (delegate* unmanaged[Cdecl]<BorrowedReference, int>)GetFunctionByName(nameof(PyObject_Not), GetUnmanagedDll(_PythonDll));
@@ -361,6 +362,7 @@ public unsafe partial class Runtime
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int, int> PyObject_RichCompareBool { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int> PyObject_IsInstance { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, BorrowedReference, int> PyObject_IsSubclass { get; }
+        internal static delegate* unmanaged[Cdecl]<BorrowedReference, void> PyObject_ClearWeakRefs { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, int> PyCallable_Check { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, int> PyObject_IsTrue { get; }
         internal static delegate* unmanaged[Cdecl]<BorrowedReference, int> PyObject_Not { get; }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -993,6 +993,18 @@ namespace Python.Runtime
 
         internal static int PyObject_IsSubclass(BorrowedReference ob, BorrowedReference type) => Delegates.PyObject_IsSubclass(ob, type);
 
+        internal static void PyObject_ClearWeakRefs(BorrowedReference ob) => Delegates.PyObject_ClearWeakRefs(ob);
+
+        internal static BorrowedReference PyObject_GetWeakRefList(BorrowedReference ob)
+        {
+            Debug.Assert(ob != null);
+            var type = PyObject_TYPE(ob);
+            int offset = Util.ReadInt32(type, TypeOffset.tp_weaklistoffset);
+            if (offset == 0) return BorrowedReference.Null;
+            Debug.Assert(offset > 0);
+            return Util.ReadRef(ob, offset);
+        }
+
 
         internal static int PyCallable_Check(BorrowedReference o) => Delegates.PyCallable_Check(o);
 

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -346,6 +346,12 @@ namespace Python.Runtime
 
         public static int tp_clear(BorrowedReference ob)
         {
+            var weakrefs = Runtime.PyObject_GetWeakRefList(ob);
+            if (weakrefs != null)
+            {
+                Runtime.PyObject_ClearWeakRefs(ob);
+            }
+
             if (TryFreeGCHandle(ob))
             {
                 IntPtr addr = ob.DangerousGetAddress();


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

According to [official documentation](https://docs.python.org/3/extending/newtypes.html#weak-reference-support) for defining extension types, if they are to support weak references, they must clear weak reference list associated with the instance in `tp_clear`.

This was missed when https://github.com/pythonnet/pythonnet/pull/1267 was superseded.

P.S. without the fix corresponding test would crash with segfault due to an attempt to dereference an object that no longer exists via a weak reference to it.

### Does this close any currently open issues?

N/A

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change