### PR TITLE
Clear weak reference list when an extension type is destroyed

### DIFF
--- a/src/embed_tests/ExtensionTypes.cs
+++ b/src/embed_tests/ExtensionTypes.cs
@@ -1,0 +1,32 @@
+using System;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest;
+
+public class ExtensionTypes
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        PythonEngine.Initialize();
+    }
+
+    [OneTimeTearDown]
+    public void Dispose()
+    {
+        PythonEngine.Shutdown();
+    }
+
+    [Test]
+    public void WeakrefIsNone_AfterBoundMethodIsGone()
+    {
+        using var makeref = Py.Import("weakref").GetAttr("ref");
+        var boundMethod = new UriBuilder().ToPython().GetAttr(nameof(UriBuilder.GetHashCode));
+        var weakref = makeref.Invoke(boundMethod);
+        boundMethod.Dispose();
+        Assert.IsTrue(weakref.Invoke().IsNone());
+    }
+}

--- a/src/runtime/Types/ExtensionType.cs
+++ b/src/runtime/Types/ExtensionType.cs
@@ -86,6 +86,12 @@ namespace Python.Runtime
 
         public static int tp_clear(BorrowedReference ob)
         {
+            var weakrefs = Runtime.PyObject_GetWeakRefList(ob);
+            if (weakrefs != null)
+            {
+                Runtime.PyObject_ClearWeakRefs(ob);
+            }
+
             if (TryFreeGCHandle(ob))
             {
                 bool deleted = loadedExtensions.Remove(ob.DangerousGetAddress());

--- a/src/runtime/Types/MetaType.cs
+++ b/src/runtime/Types/MetaType.cs
@@ -273,6 +273,12 @@ namespace Python.Runtime
         /// </summary>
         public static void tp_dealloc(NewReference lastRef)
         {
+            var weakrefs = Runtime.PyObject_GetWeakRefList(lastRef.Borrow());
+            if (weakrefs != null)
+            {
+                Runtime.PyObject_ClearWeakRefs(lastRef.Borrow());
+            }
+
             // Fix this when we dont cheat on the handle for subclasses!
 
             var flags = PyType.GetFlags(lastRef.Borrow());


### PR DESCRIPTION
Extension types were missed in https://github.com/pythonnet/pythonnet/pull/1758

### What does this implement/fix? Explain your changes.

Clears weakref list in extension type instances when they are destroyed