### PR TITLE
Implement IConvertible on PyObject

### DIFF
--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -550,7 +550,7 @@ namespace Python.Runtime
         /// <summary>
         /// Convert a Python value to an instance of a primitive managed type.
         /// </summary>
-        private static bool ToPrimitive(BorrowedReference value, Type obType, out object? result, bool setError)
+        internal static bool ToPrimitive(BorrowedReference value, Type obType, out object? result, bool setError)
         {
             result = null;
             if (obType.IsEnum)

--- a/src/runtime/PythonTypes/PyFloat.cs
+++ b/src/runtime/PythonTypes/PyFloat.cs
@@ -101,5 +101,7 @@ namespace Python.Runtime
             PythonException.ThrowIfIsNull(op);
             return new PyFloat(op.Steal());
         }
+
+        public override TypeCode GetTypeCode() => TypeCode.Double;
     }
 }

--- a/src/runtime/PythonTypes/PyInt.cs
+++ b/src/runtime/PythonTypes/PyInt.cs
@@ -230,5 +230,7 @@ namespace Python.Runtime
             using var _ = Py.GIL();
             return ToBigInteger().ToString(format, formatProvider);
         }
+
+        public override TypeCode GetTypeCode() => TypeCode.Int64;
     }
 }

--- a/src/runtime/PythonTypes/PyObject.IConvertible.cs
+++ b/src/runtime/PythonTypes/PyObject.IConvertible.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Python.Runtime;
+
+public partial class PyObject : IConvertible
+{
+    public virtual TypeCode GetTypeCode() => TypeCode.Object;
+
+    private T DoConvert<T>()
+    {
+        using var _ = Py.GIL();
+        if (Converter.ToPrimitive(Reference, typeof(T), out object? result, setError: false))
+        {
+            return (T)result!;
+        }
+        else
+        {
+            throw new InvalidCastException();
+        }
+    }
+
+    public bool ToBoolean(IFormatProvider provider) => DoConvert<bool>();
+    public byte ToByte(IFormatProvider provider) => DoConvert<byte>();
+    public char ToChar(IFormatProvider provider) => DoConvert<char>();
+    public short ToInt16(IFormatProvider provider) => DoConvert<short>();
+    public int ToInt32(IFormatProvider provider) => DoConvert<int>();
+    public long ToInt64(IFormatProvider provider) => DoConvert<long>();
+    public sbyte ToSByte(IFormatProvider provider) => DoConvert<sbyte>();
+    public ushort ToUInt16(IFormatProvider provider) => DoConvert<ushort>();
+    public uint ToUInt32(IFormatProvider provider) => DoConvert<uint>();
+    public ulong ToUInt64(IFormatProvider provider) => DoConvert<ulong>();
+
+    public float ToSingle(IFormatProvider provider) => DoConvert<float>();
+    public double ToDouble(IFormatProvider provider) => DoConvert<double>();
+
+    public string ToString(IFormatProvider provider) => DoConvert<string>();
+
+    public DateTime ToDateTime(IFormatProvider provider) => throw new InvalidCastException();
+    public decimal ToDecimal(IFormatProvider provider) => throw new InvalidCastException();
+
+    public object ToType(Type conversionType, IFormatProvider provider)
+    {
+        if (Converter.ToManaged(Reference, conversionType, out object? result, setError: false))
+        {
+            return result!;
+        }
+        else
+        {
+            throw new InvalidCastException();
+        }
+    }
+
+}

--- a/src/runtime/PythonTypes/PyString.cs
+++ b/src/runtime/PythonTypes/PyString.cs
@@ -59,5 +59,7 @@ namespace Python.Runtime
         {
             return Runtime.PyString_Check(value.obj);
         }
+
+        public override TypeCode GetTypeCode() => TypeCode.String;
     }
 }

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -670,3 +670,10 @@ def test_int_param_resolution_required():
     data = list(mri.MethodA(0x100000000, 10))
     assert len(data) == 10
     assert data[0] == 0
+
+def test_iconvertible_conversion():
+    change_type = System.Convert.ChangeType
+
+    assert 1024 == change_type(1024, System.Int32)
+    assert 1024 == change_type(1024, System.Int64)
+    assert 1024 == change_type(1024, System.Int16)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Implements the [IConvertible](https://docs.microsoft.com/en-us/dotnet/api/system.iconvertible) interface for `PyObject` instances.

### Does this close any currently open issues?

Should fix #1755.

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [X] If an enhancement PR, please create docs and at best an example
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
