### PR TITLE
Work around potential Mono bug, that hangs the runtime when new threads start

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Embedding tests
         run: dotnet test --runtime any-${{ matrix.platform }} --logger "console;verbosity=detailed" src/embed_tests/
+        env:
+          MONO_THREADS_SUSPEND: preemptive # https://github.com/mono/mono/issues/21466
 
       - name: Python Tests (Mono)
         if: ${{ matrix.os != 'windows' }}


### PR DESCRIPTION
I suspect the issue is actually with Mono GC and the relatively new mode of suspending threads, which has a few (closed) bugs against it, complaining about hangs. In many of those bugs (you can find them [here](https://github.com/mono/mono/issues?q=is%3Aissue+MONO_THREADS_SUSPEND+hangs)) switching to the old `preemptive` mode works around the issue. I tried it for our tests, and it seems to solve it too.

The issue also vaguely mentioned in https://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#thread-startfinish-still-bad

So the fix is to simply set `MONO_THREADS_SUSPEND` to `preemptive` in CI before running tests in Mono.

Fixes https://github.com/pythonnet/pythonnet/issues/1766

This workaround seems to solve the issue on my local machine as well as in CI. I did 5+ CI full matrix reruns to confirm. Before the fix a few MacOS legs would time out in every run.

Below is some history of finding this workaround.