### PR TITLE
Improve exception message when possible

### DIFF
--- a/src/embed_tests/TestPythonException.cs
+++ b/src/embed_tests/TestPythonException.cs
@@ -43,6 +43,25 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
+        public void TestMessageComplete()
+        {
+            using (Py.GIL())
+            {
+                try
+                {
+                    // importing a module with syntax error 'x = 01' will throw
+                    PyModule.FromString(Guid.NewGuid().ToString(), "x = 01");
+                }
+                catch (PythonException exception)
+                {
+                    Assert.True(exception.Message.Contains("x = 01"));
+                    return;
+                }
+                Assert.Fail("No Exception was thrown!");
+            }
+        }
+
+        [Test]
         public void TestNoError()
         {
             // There is no PyErr to fetch

--- a/src/runtime/PythonException.cs
+++ b/src/runtime/PythonException.cs
@@ -129,10 +129,20 @@ namespace Python.Runtime
 
             try
             {
-                var normalizedValue = new NewReference(value.Borrow());
+                var normalizedValue = new NewReference();
+                if (!value.IsNone() && !value.IsNull())
+                {
+                    normalizedValue = new NewReference(value.Borrow());
+                }
                 Runtime.PyErr_NormalizeException(type: ref type, val: ref normalizedValue, tb: ref traceback);
 
-                return FromPyErr(typeRef: type.Borrow(), valRef: value.Borrow(), nValRef: normalizedValue.Borrow(), tbRef: traceback.BorrowNullable(), out dispatchInfo);
+                var valRef = normalizedValue.Borrow();
+                if (!value.IsNone() && !value.IsNull())
+                {
+                    // try using value instead of the 'normalizedValue' since it containes more information
+                    valRef = value.Borrow();
+                }
+                return FromPyErr(typeRef: type.Borrow(), valRef: valRef, nValRef: normalizedValue.Borrow(), tbRef: traceback.BorrowNullable(), out dispatchInfo);
             }
             finally
             {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- Improve exception message when possible. See added unit test failing in master, master has `invalid token (none, line 1)` message`

### Does this close any currently open issues?

N/A

### Any other comments?

N/A

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
