### PR TITLE
Update __init__.py

### DIFF
--- a/pythonnet/__init__.py
+++ b/pythonnet/__init__.py
@@ -1,4 +1,5 @@
 import sys
+from os import environ
 from pathlib import Path
 from typing import Dict, Optional, Union
 import clr_loader
@@ -28,9 +29,8 @@ def set_runtime(runtime: Union[clr_loader.Runtime, str], **params: str) -> None:
 
 
 def _get_params_from_env(prefix: str) -> Dict[str, str]:
-    from os import environ
 
-    full_prefix = f"PYTHONNET_{prefix.upper()}"
+    full_prefix = f"PYTHONNET_{prefix.upper()}_"
     len_ = len(full_prefix)
 
     env_vars = {
@@ -49,7 +49,7 @@ def _create_runtime_from_spec(
         if sys.platform == "win32":
             spec = "netfx"
         else:
-            spec = "mono"
+            spec = environ.get("PYTHONNET_RUNTIME", "mono")
 
     params = params or _get_params_from_env(spec)
 
@@ -78,7 +78,6 @@ def set_default_runtime() -> None:
     for all environments but Windows, on Windows the legacy .NET Framework is
     used.
     """
-    from os import environ
 
     print("Set default RUNTIME")
     raise RuntimeError("Shouldn't be called here")


### PR DESCRIPTION
Fix environment variables parsing issue under Linux

### What does this implement/fix? Explain your changes.

To enable "coreclr" support under linux

### Does this close any currently open issues?

Yes. By setting `export PYTHONNET_RUNTIME=coreclr`, the last version did not work.

### Any other comments?

The "coreclr" does not work as "mono"

`TypeError: Exception has been thrown by the target of an invocation. 

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
