### PR TITLE
Implemented dynamic equality and inequality for `PyObject` instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ details about the cause of the failure
      able to access members that are part of the implementation class, but not the
      interface.  Use the new `__implementation__` or `__raw_implementation__` properties to
      if you need to "downcast" to the implementation class.
+-   BREAKING: `==` and `!=` operators on `PyObject` instances now use Python comparison
+     (previously was equivalent to `object.ReferenceEquals(,)`)
 -   BREAKING: Parameters marked with `ParameterAttributes.Out` are no longer returned in addition
      to the regular method return value (unless they are passed with `ref` or `out` keyword).
 -   BREAKING: Drop support for the long-deprecated CLR.* prefix.

--- a/src/embed_tests/dynamic.cs
+++ b/src/embed_tests/dynamic.cs
@@ -128,6 +128,28 @@ namespace Python.EmbeddingTest
             Assert.IsTrue(sys.testattr1.Equals(sys.testattr2));
         }
 
+        // regression test for https://github.com/pythonnet/pythonnet/issues/1848
+        [Test]
+        public void EnumEquality()
+        {
+            using var scope = Py.CreateScope();
+            scope.Exec(@"
+import enum
+
+class MyEnum(enum.IntEnum):
+    OK = 1
+    ERROR = 2
+
+def get_status():
+    return MyEnum.OK 
+"
+);
+
+            dynamic MyEnum = scope.Get("MyEnum");
+            dynamic status = scope.Get("get_status").Invoke();
+            Assert.IsTrue(status == MyEnum.OK);
+        }
+
         // regression test for https://github.com/pythonnet/pythonnet/issues/1680
         [Test]
         public void ForEach()

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -962,31 +962,6 @@ namespace Python.Runtime
 
         internal static int PyObject_RichCompareBool(BorrowedReference value1, BorrowedReference value2, int opid) => Delegates.PyObject_RichCompareBool(value1, value2, opid);
 
-        internal static int PyObject_Compare(BorrowedReference value1, BorrowedReference value2)
-        {
-            int res;
-            res = PyObject_RichCompareBool(value1, value2, Py_LT);
-            if (-1 == res)
-                return -1;
-            else if (1 == res)
-                return -1;
-
-            res = PyObject_RichCompareBool(value1, value2, Py_EQ);
-            if (-1 == res)
-                return -1;
-            else if (1 == res)
-                return 0;
-
-            res = PyObject_RichCompareBool(value1, value2, Py_GT);
-            if (-1 == res)
-                return -1;
-            else if (1 == res)
-                return 1;
-
-            Exceptions.SetError(Exceptions.SystemError, "Error comparing objects");
-            return -1;
-        }
-
 
         internal static int PyObject_IsInstance(BorrowedReference ob, BorrowedReference type) => Delegates.PyObject_IsInstance(ob, type);
 


### PR DESCRIPTION
Also fixed unhandled Python errors during comparison attempts

### What does this implement/fix? Explain your changes.

For `==` and `!=` operators in C# to use Python equality `PyObject` must implement `operator ==` and `operator !=`. C# ignores `TryBinaryOperation` implementation for equality comparisons.

The "also" part clears Python error when comparison can not be performed.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1848

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
