### PR TITLE
Fix (U)IntPtr construction

### DIFF
--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -298,6 +298,36 @@ namespace Python.Runtime
             {
                 case CLRObject co:
                     object tmp = co.inst;
+                    if (obType == typeof(IntPtr))
+                    {
+                        switch (tmp)
+                        {
+                            case nint val:
+                                result = new IntPtr(val);
+                                return true;
+                            case Int64 val:
+                                result = new IntPtr(val);
+                                return true;
+                            case Int32 val:
+                                result = new IntPtr(val);
+                                return true;
+                        }
+                    }
+                    if (obType == typeof(UIntPtr))
+                    {
+                        switch (tmp)
+                        {
+                            case nuint val:
+                                result = new UIntPtr(val);
+                                return true;
+                            case UInt64 val:
+                                result = new UIntPtr(val);
+                                return true;
+                            case UInt32 val:
+                                result = new UIntPtr(val);
+                                return true;
+                        }
+                    }
                     if (obType.IsInstanceOfType(tmp))
                     {
                         result = tmp;

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -298,36 +298,6 @@ namespace Python.Runtime
             {
                 case CLRObject co:
                     object tmp = co.inst;
-                    if (obType == typeof(IntPtr))
-                    {
-                        switch (tmp)
-                        {
-                            case nint val:
-                                result = new IntPtr(val);
-                                return true;
-                            case Int64 val:
-                                result = new IntPtr(val);
-                                return true;
-                            case Int32 val:
-                                result = new IntPtr(val);
-                                return true;
-                        }
-                    }
-                    if (obType == typeof(UIntPtr))
-                    {
-                        switch (tmp)
-                        {
-                            case nuint val:
-                                result = new UIntPtr(val);
-                                return true;
-                            case UInt64 val:
-                                result = new UIntPtr(val);
-                                return true;
-                            case UInt32 val:
-                                result = new UIntPtr(val);
-                                return true;
-                        }
-                    }
                     if (obType.IsInstanceOfType(tmp))
                     {
                         result = tmp;
@@ -391,7 +361,7 @@ namespace Python.Runtime
             // conversions (Python string -> managed string).
             if (obType == objectType)
             {
-                if (Runtime.IsStringType(value))
+                if (Runtime.PyString_Check(value))
                 {
                     return ToPrimitive(value, stringType, out result, setError);
                 }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -59,6 +59,11 @@ namespace Python.Runtime
         internal static bool TypeManagerInitialized => _typesInitialized;
         internal static readonly bool Is32Bit = IntPtr.Size == 4;
 
+        // Available in newer .NET Core versions (>= 5) as IntPtr.MaxValue etc.
+        internal static readonly long IntPtrMaxValue = Is32Bit ? Int32.MaxValue : Int64.MaxValue;
+        internal static readonly long IntPtrMinValue = Is32Bit ? Int32.MinValue : Int64.MinValue;
+        internal static readonly ulong UIntPtrMaxValue = Is32Bit ? UInt32.MaxValue : UInt64.MaxValue;
+
         // .NET core: System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
         internal static bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
 

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1281,13 +1281,6 @@ namespace Python.Runtime
         //====================================================================
         // Python string API
         //====================================================================
-        internal static bool IsStringType(BorrowedReference op)
-        {
-            BorrowedReference t = PyObject_TYPE(op);
-            return (t == PyStringType)
-                || (t == PyUnicodeType);
-        }
-
         internal static bool PyString_Check(BorrowedReference ob)
         {
             return PyObject_TYPE(ob) == PyStringType;

--- a/src/runtime/Types/ClassObject.cs
+++ b/src/runtime/Types/ClassObject.cs
@@ -173,9 +173,14 @@ namespace Python.Runtime
                 else if (Runtime.PyInt_Check(op))
                 {
                     long? num = Runtime.PyLong_AsLongLong(op);
-                    if (num is long n)
+                    if (num is long n && n >= Runtime.IntPtrMinValue && n <= Runtime.IntPtrMaxValue)
                     {
                         result = new IntPtr(n);
+                    }
+                    else
+                    {
+                        Exceptions.SetError(Exceptions.OverflowError, "value not in range for IntPtr");
+                        return default;
                     }
                 }
             }
@@ -200,9 +205,14 @@ namespace Python.Runtime
                 else if (Runtime.PyInt_Check(op))
                 {
                     ulong? num = Runtime.PyLong_AsUnsignedLongLong(op);
-                    if (num is ulong n)
+                    if (num is ulong n && n <= Runtime.UIntPtrMaxValue)
                     {
                         result = new UIntPtr(n);
+                    }
+                    else
+                    {
+                        Exceptions.SetError(Exceptions.OverflowError, "value not in range for UIntPtr");
+                        return default;
                     }
                 }
             }

--- a/src/runtime/Types/ClassObject.cs
+++ b/src/runtime/Types/ClassObject.cs
@@ -129,7 +129,7 @@ namespace Python.Runtime
 
         /// <summary>
         /// Create a new Python object for a primitive type
-        /// 
+        ///
         /// The primitive types are Boolean, Byte, SByte, Int16, UInt16,
         /// Int32, UInt32, Int64, UInt64, IntPtr, UIntPtr, Char, Double,
         /// and Single.
@@ -170,6 +170,14 @@ namespace Python.Runtime
                             break;
                     }
                 }
+                else if (Runtime.PyInt_Check(op))
+                {
+                    long? num = Runtime.PyLong_AsLongLong(op);
+                    if (num is long n)
+                    {
+                        result = new IntPtr(n);
+                    }
+                }
             }
 
             if (type == typeof(UIntPtr))
@@ -187,6 +195,14 @@ namespace Python.Runtime
                         case UInt32 val:
                             result = new UIntPtr(val);
                             break;
+                    }
+                }
+                else if (Runtime.PyInt_Check(op))
+                {
+                    ulong? num = Runtime.PyLong_AsUnsignedLongLong(op);
+                    if (num is ulong n)
+                    {
+                        result = new UIntPtr(n);
                     }
                 }
             }

--- a/src/testing/conversiontest.cs
+++ b/src/testing/conversiontest.cs
@@ -1,5 +1,6 @@
 namespace Python.Test
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -26,6 +27,8 @@ namespace Python.Test
         public ulong UInt64Field = 0;
         public float SingleField = 0.0F;
         public double DoubleField = 0.0;
+        public IntPtr IntPtrField = IntPtr.Zero;
+        public UIntPtr UIntPtrField = UIntPtr.Zero;
         public decimal DecimalField = 0;
         public string StringField;
         public ShortEnum EnumField;
@@ -42,7 +45,7 @@ namespace Python.Test
 
     }
 
-    
+
 
     public interface ISpam
     {
@@ -63,7 +66,7 @@ namespace Python.Test
             return value;
         }
     }
-    
+
     public class UnicodeString
     {
         public string value = "안녕";

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -689,10 +689,13 @@ def test_intptr_construction():
     assert ob.UIntPtrField == UIntPtr.Zero
 
     ob.IntPtrField = IntPtr(Int64(-1))
+    assert ob.IntPtrField == IntPtr(-1)
     assert ob.IntPtrField.ToInt64() == -1
 
     ob.IntPtrField = IntPtr(Int64(1024))
+    assert ob.IntPtrField == IntPtr(1024)
     assert ob.IntPtrField.ToInt64() == 1024
 
     ob.UIntPtrField = UIntPtr(UInt64(1024))
+    assert ob.UIntPtrField == UIntPtr(1024)
     assert ob.UIntPtrField.ToUInt64() == 1024

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -680,19 +680,19 @@ def test_iconvertible_conversion():
     assert 1024 == change_type(1024, System.Int64)
     assert 1024 == change_type(1024, System.Int16)
 
-def test_intptr_conversion():
-    from System import IntPtr, UIntPtr, Int64
+def test_intptr_construction():
+    from System import IntPtr, UIntPtr, Int64, UInt64
 
     ob = ConversionTest()
 
     assert ob.IntPtrField == IntPtr.Zero
     assert ob.UIntPtrField == UIntPtr.Zero
 
-    ob.IntPtrField = IntPtr(-1)
-    assert ob.IntPtrField == IntPtr(-1)
+    ob.IntPtrField = IntPtr(Int64(-1))
+    assert ob.IntPtrField.ToInt64() == -1
 
     ob.IntPtrField = IntPtr(Int64(1024))
-    assert ob.IntPtrField == IntPtr(1024)
+    assert ob.IntPtrField.ToInt64() == 1024
 
-    ob.UIntPtrField = ob.IntPtrField
-    assert ob.UIntPtrField == UIntPtr(1024)
+    ob.UIntPtrField = UIntPtr(UInt64(1024))
+    assert ob.UIntPtrField.ToUInt64() == 1024

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -682,20 +682,34 @@ def test_iconvertible_conversion():
 
 def test_intptr_construction():
     from System import IntPtr, UIntPtr, Int64, UInt64
+    from ctypes import sizeof, c_void_p
+
+    ptr_size = sizeof(c_void_p)
+    max_intptr = 2 ** (ptr_size * 8 - 1) - 1
+    min_intptr = -max_intptr - 1
+    max_uintptr = 2 ** (ptr_size * 8) - 1
+    min_uintptr = 0
 
     ob = ConversionTest()
 
     assert ob.IntPtrField == IntPtr.Zero
     assert ob.UIntPtrField == UIntPtr.Zero
 
-    ob.IntPtrField = IntPtr(Int64(-1))
-    assert ob.IntPtrField == IntPtr(-1)
-    assert ob.IntPtrField.ToInt64() == -1
+    for v in [0, -1, 1024, max_intptr, min_intptr]:
+        ob.IntPtrField = IntPtr(Int64(v))
+        assert ob.IntPtrField == IntPtr(v)
+        assert ob.IntPtrField.ToInt64() == v
 
-    ob.IntPtrField = IntPtr(Int64(1024))
-    assert ob.IntPtrField == IntPtr(1024)
-    assert ob.IntPtrField.ToInt64() == 1024
+    for v in [min_intptr - 1, max_intptr + 1]:
+        with pytest.raises(TypeError):
+            IntPtr(v)
 
-    ob.UIntPtrField = UIntPtr(UInt64(1024))
-    assert ob.UIntPtrField == UIntPtr(1024)
-    assert ob.UIntPtrField.ToUInt64() == 1024
+    for v in [0, 1024, min_uintptr, max_uintptr, max_intptr]:
+        ob.UIntPtrField = UIntPtr(UInt64(v))
+        assert ob.UIntPtrField == UIntPtr(v)
+        assert ob.UIntPtrField.ToUInt64() == v
+
+    for v in [min_uintptr - 1, max_uintptr + 1, min_intptr]:
+        with pytest.raises(TypeError):
+            UIntPtr(v)
+

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -701,7 +701,7 @@ def test_intptr_construction():
         assert ob.IntPtrField.ToInt64() == v
 
     for v in [min_intptr - 1, max_intptr + 1]:
-        with pytest.raises(TypeError):
+        with pytest.raises(OverflowError):
             IntPtr(v)
 
     for v in [0, 1024, min_uintptr, max_uintptr, max_intptr]:
@@ -710,6 +710,6 @@ def test_intptr_construction():
         assert ob.UIntPtrField.ToUInt64() == v
 
     for v in [min_uintptr - 1, max_uintptr + 1, min_intptr]:
-        with pytest.raises(TypeError):
+        with pytest.raises(OverflowError):
             UIntPtr(v)
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -25,7 +25,7 @@ def test_bool_conversion():
 
     with pytest.raises(TypeError):
         ob.BooleanField = 1
-    
+
     with pytest.raises(TypeError):
         ob.BooleanField = 0
 
@@ -679,3 +679,20 @@ def test_iconvertible_conversion():
     assert 1024 == change_type(1024, System.Int32)
     assert 1024 == change_type(1024, System.Int64)
     assert 1024 == change_type(1024, System.Int16)
+
+def test_intptr_conversion():
+    from System import IntPtr, UIntPtr, Int64
+
+    ob = ConversionTest()
+
+    assert ob.IntPtrField == IntPtr.Zero
+    assert ob.UIntPtrField == UIntPtr.Zero
+
+    ob.IntPtrField = IntPtr(-1)
+    assert ob.IntPtrField == IntPtr(-1)
+
+    ob.IntPtrField = IntPtr(Int64(1024))
+    assert ob.IntPtrField == IntPtr(1024)
+
+    ob.UIntPtrField = ob.IntPtrField
+    assert ob.UIntPtrField == UIntPtr(1024)


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Allows creating an `IntPtr` from Python. This is currently impossible, because we rely on automatic conversion (as `IntPtr` is a primitive type) while we don't actually implement one for this type (rightly so!).

The relevant code section is:
https://github.com/pythonnet/pythonnet/blob/87d4db92f6da00b4be27b842ac2ba9875569e04d/src/runtime/Types/ClassObject.cs#L73-L89

### Does this close any currently open issues?

#1116 

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
