### PR TITLE
Fix docstring for directly constructed types

### DIFF
--- a/src/runtime/ClassManager.cs
+++ b/src/runtime/ClassManager.cs
@@ -87,7 +87,7 @@ namespace Python.Runtime
                     if ((Runtime.PyDict_DelItemString(dict.Borrow(), member) == -1) &&
                         (Exceptions.ExceptionMatches(Exceptions.KeyError)))
                     {
-                        // Trying to remove a key that's not in the dictionary 
+                        // Trying to remove a key that's not in the dictionary
                         // raises an error. We don't care about it.
                         Runtime.PyErr_Clear();
                     }
@@ -215,7 +215,7 @@ namespace Python.Runtime
             impl.indexer = info.indexer;
             impl.richcompare.Clear();
 
-            
+
             // Finally, initialize the class __dict__ and return the object.
             using var newDict = Runtime.PyObject_GenericGetDict(pyType.Reference);
             BorrowedReference dict = newDict.Borrow();
@@ -270,6 +270,15 @@ namespace Python.Runtime
                         doc = co.GetDocString();
                         Runtime.PyDict_SetItem(dict, PyIdentifier.__doc__, doc.Borrow());
                     }
+                }
+
+                if (Runtime.PySequence_Contains(dict, PyIdentifier.__doc__) != 1)
+                {
+                    // Ensure that at least some doc string is set
+                    using var fallbackDoc = Runtime.PyString_FromString(
+                        $"Python wrapper for .NET type {type}"
+                    );
+                    Runtime.PyDict_SetItem(dict, PyIdentifier.__doc__, fallbackDoc.Borrow());
                 }
             }
             doc.Dispose();
@@ -562,7 +571,7 @@ namespace Python.Runtime
 
             return ci;
         }
-        
+
         /// <summary>
         /// This class owns references to PyObjects in the `members` member.
         /// The caller has responsibility to DECREF them.

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -25,3 +25,10 @@ def test_doc_without_ctor():
     assert DocWithoutCtorTest.__doc__ == 'DocWithoutCtorTest Class'
     assert DocWithoutCtorTest.TestMethod.__doc__ == 'DocWithoutCtorTest TestMethod'
     assert DocWithoutCtorTest.StaticTestMethod.__doc__ == 'DocWithoutCtorTest StaticTestMethod'
+
+
+def test_doc_primitve():
+    from System import Int64, String
+
+    assert Int64.__doc__ is not None
+    assert String.__doc__ is not None

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -15,7 +15,6 @@ def test_enum_standard_attrs():
     assert DayOfWeek.__name__ == 'DayOfWeek'
     assert DayOfWeek.__module__ == 'System'
     assert isinstance(DayOfWeek.__dict__, DictProxyType)
-    assert DayOfWeek.__doc__ is None
 
 
 def test_enum_get_member():
@@ -139,7 +138,7 @@ def test_enum_undefined_value():
     # This should fail because our test enum doesn't have it.
     with pytest.raises(ValueError):
         Test.FieldTest().EnumField = Test.ShortEnum(20)
-    
+
     # explicitly permit undefined values
     Test.FieldTest().EnumField = Test.ShortEnum(20, True)
 
@@ -157,6 +156,6 @@ def test_enum_conversion():
 
     with pytest.raises(TypeError):
         Test.FieldTest().EnumField = "str"
-    
+
     with pytest.raises(TypeError):
         Test.FieldTest().EnumField = 1


### PR DESCRIPTION
Fix missing docstring for types with custom constructors

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
