### PR TITLE
Fixed a leak in `NewReference.Move`

### DIFF
--- a/src/runtime/Finalizer.cs
+++ b/src/runtime/Finalizer.cs
@@ -106,6 +106,7 @@ namespace Python.Runtime
 
         #endregion
 
+        [ForbidPythonThreads]
         public void Collect() => this.DisposeAll();
 
         internal void ThrottledCollect()

--- a/src/runtime/Native/NewReference.cs
+++ b/src/runtime/Native/NewReference.cs
@@ -47,7 +47,7 @@ namespace Python.Runtime
         /// </summary>
         public NewReference Move()
         {
-            var result = new NewReference(this);
+            var result = DangerousFromPointer(this.DangerousGetAddress());
             this.pointer = default;
             return result;
         }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -359,6 +359,7 @@ namespace Python.Runtime
         /// </summary>
         /// <param name="runs">Total number of GC loops to run</param>
         /// <returns><c>true</c> if a steady state was reached upon the requested number of tries (e.g. on the last try no objects were collected).</returns>
+        [ForbidPythonThreads]
         public static bool TryCollectingGarbage(int runs)
             => TryCollectingGarbage(runs, forceBreakLoops: false);
 

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -3,6 +3,7 @@
 """Test CLR class constructor support."""
 
 import pytest
+import sys
 
 import System
 
@@ -69,6 +70,19 @@ def test_default_constructor_fallback():
 
     with pytest.raises(TypeError):
         ob = DefaultConstructorMatching("2")
+
+
+def test_constructor_leak():
+    from System import Uri
+    from Python.Runtime import Runtime
+
+    uri = Uri("http://www.python.org")
+    Runtime.TryCollectingGarbage(20)
+    ref_count = sys.getrefcount(uri)
+
+    # check disabled due to GC uncertainty
+    # assert ref_count == 1
+
 
 
 def test_string_constructor():


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`NewReference.Move` used to call `NewReference` constructor that increfs the handle. However, `Move` semantics must be of transferring the ownership: the reference count should stay, ownership transferred to the new instance.

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/issues/1872

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change