### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pythonnet/__init__.py
+++ b/pythonnet/__init__.py
@@ -121,7 +121,7 @@ def load(
 
 
 def unload() -> None:
-    """Explicitly unload a laoded runtime and shut down Python.NET"""
+    """Explicitly unload a loaded runtime and shut down Python.NET"""
 
     global _RUNTIME, _LOADER_ASSEMBLY
     if _LOADER_ASSEMBLY is not None:

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -15,7 +15,7 @@ def test_relative_missing_import():
 
 def test_import_all_on_second_time():
     """Test import all attributes after a normal import without '*'.
-    Due to import * only allowed at module level, the test body splited
+    Due to import * only allowed at module level, the test body splitted
     to a module file."""
     from . import importtest
     del sys.modules[importtest.__name__]


### PR DESCRIPTION
There are small typos in:
- pythonnet/__init__.py
- tests/test_import.py

Fixes:
- Should read `splitted` rather than `splited`.
- Should read `loaded` rather than `laoded`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md