### PR TITLE
Best effort serialization

### DIFF
--- a/src/runtime/StateSerialization/RuntimeData.cs
+++ b/src/runtime/StateSerialization/RuntimeData.cs
@@ -44,6 +44,7 @@ namespace Python.Runtime
         private static Func<Type, bool> isNestedType = (tp) => hasVisibility(tp, TypeAttributes.NestedPrivate) || hasVisibility(tp, TypeAttributes.NestedPublic) || hasVisibility(tp, TypeAttributes.NestedFamily) || hasVisibility(tp, TypeAttributes.NestedAssembly);
         private static Func<Type, bool> isPrivateType = (tp) => hasVisibility(tp, TypeAttributes.NotPublic) || hasVisibility(tp, TypeAttributes.NestedPrivate) || hasVisibility(tp, TypeAttributes.NestedFamily) || hasVisibility( tp, TypeAttributes.NestedAssembly);
         private static Func<Type, bool> isPublicType = (tp) => hasVisibility(tp, TypeAttributes.Public) || hasVisibility(tp,TypeAttributes.NestedPublic);
+        private static Func<Type, bool> CanCreateType = (tp) => isPublicType(tp) && ((tp.Attributes & TypeAttributes.Sealed) == 0);
 
         public static object? CreateNewObject(Type baseType)
         {
@@ -108,7 +109,7 @@ namespace Python.Runtime
 
         public static Type? CreateType(Type tp)
         {
-            if (!isPublicType(tp))
+            if (!CanCreateType(tp))
             {
                 return null;
             }

--- a/src/runtime/StateSerialization/RuntimeData.cs
+++ b/src/runtime/StateSerialization/RuntimeData.cs
@@ -325,7 +325,7 @@ namespace Python.Runtime
 
             MaybeType type = obj.GetType();
             
-            if (type.Value.CustomAttributes.Any((attr) => attr.AttributeType == typeof(NonSerializedAttribute)))
+            if (type.Value.CustomAttributes.Any((attr) => attr.AttributeType == typeof(PyNet_NotSerializedAttribute)))
             {
                 // Don't serialize a _NotSerialized. Serialize the base type, and deserialize as a _NotSerialized
                 type = type.Value.BaseType;

--- a/src/runtime/StateSerialization/RuntimeData.cs
+++ b/src/runtime/StateSerialization/RuntimeData.cs
@@ -3,18 +3,303 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Dynamic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-
 using Python.Runtime.StateSerialization;
 
 using static Python.Runtime.Runtime;
 
 namespace Python.Runtime
 {
+    [System.Serializable]
+    public sealed class NotSerializedException: SerializationException
+    {
+        static string _message = "The underlying C# object has been deleted.";
+        public NotSerializedException() : base(_message){}
+        private NotSerializedException(SerializationInfo info, StreamingContext context) : base(info, context){}
+        override public void GetObjectData(SerializationInfo info, StreamingContext context) => base.GetObjectData(info, context);
+    }
+
+
+    // empty attribute to mark classes created by the "non-serializer" so we don't loop-inherit
+    // on multiple cycles of de/serialization
+    [System.AttributeUsage(System.AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    [System.Serializable]
+    sealed class PyNet_NotSerializedAttribute : System.Attribute {}
+
+    [Serializable]
+    internal static class NonSerializedTypeBuilder
+    {
+        
+        internal static AssemblyName nonSerializedAssemblyName = 
+            new AssemblyName("Python.Runtime.NonSerialized.dll, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
+        internal static AssemblyBuilder assemblyForNonSerializedClasses = 
+            AppDomain.CurrentDomain.DefineDynamicAssembly(nonSerializedAssemblyName, AssemblyBuilderAccess.Run);
+        internal static ModuleBuilder moduleBuilder = assemblyForNonSerializedClasses.DefineDynamicModule("NotSerializedModule");
+        internal static HashSet<string> dontReimplementMethods = new(){"Finalize", "Dispose", "GetType", "ReferenceEquals", "GetHashCode", "Equals"};
+        const string notSerializedSuffix = "_NotSerialized";
+
+        public static object CreateNewObject(Type baseType)
+        {
+            var myType = CreateType(baseType);
+            var myObject = Activator.CreateInstance(myType);
+            return myObject;
+        }
+
+        public static Type CreateType(Type tp)
+        {
+            Type existingType = assemblyForNonSerializedClasses.GetType(tp.Name + "_NotSerialized", throwOnError:false);
+            if (existingType is not null)
+            {
+                return existingType;
+            }
+
+            TypeBuilder tb = GetTypeBuilder(tp);
+            ConstructorBuilder constructor = tb.DefineDefaultConstructor(MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName);
+            var properties = tp.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+            foreach (var prop in properties)
+            {
+                CreateProperty(tb, prop);
+            }
+
+            var methods = tp.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+            foreach (var meth in methods)
+            {
+                CreateMethod(tb, meth);
+            }
+
+            ImplementEqualityAndHash(tb);
+
+            return tb.CreateType();
+        }
+
+        private static void ImplementEqualityAndHash(TypeBuilder tb)
+        {
+            var hashCodeMb = tb.DefineMethod("GetHashCode", 
+                                             MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.ReuseSlot,
+                                             CallingConventions.Standard,
+                                             typeof(int),
+                                             Type.EmptyTypes
+                                    );
+            var getHashIlGen = hashCodeMb.GetILGenerator();
+            getHashIlGen.Emit(OpCodes.Ldarg_0);
+            getHashIlGen.EmitCall(OpCodes.Call, typeof(object).GetMethod("GetType"), Type.EmptyTypes);
+            getHashIlGen.EmitCall(OpCodes.Call, typeof(Type).GetProperty("Name").GetMethod, Type.EmptyTypes);
+            getHashIlGen.EmitCall(OpCodes.Call, typeof(string).GetMethod("GetHashCode"), Type.EmptyTypes);
+            getHashIlGen.Emit(OpCodes.Ret);
+
+            Type[] equalsArgs = new Type[] {typeof(object), typeof(object)};
+            var equalsMb = tb.DefineMethod("Equals", 
+                                           MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.ReuseSlot,
+                                           CallingConventions.Standard,
+                                           typeof(bool),
+                                           equalsArgs
+                                           );
+            var equalsIlGen = equalsMb.GetILGenerator();
+            equalsIlGen.Emit(OpCodes.Ldarg_0); // this
+            equalsIlGen.Emit(OpCodes.Ldarg_1); // the other object
+            equalsIlGen.EmitCall(OpCodes.Call, typeof(object).GetMethod("ReferenceEquals"), equalsArgs);
+            equalsIlGen.Emit(OpCodes.Ret);
+        }
+
+        private static TypeBuilder GetTypeBuilder(Type baseType)
+        {
+            string typeSignature = baseType.Name + notSerializedSuffix;
+
+            TypeBuilder tb = moduleBuilder.DefineType(typeSignature,
+                    baseType.Attributes,
+                    baseType,
+                    baseType.GetInterfaces());
+
+            ConstructorInfo attrCtorInfo = typeof(PyNet_NotSerializedAttribute).GetConstructor(new Type[]{});
+            CustomAttributeBuilder attrBuilder = new CustomAttributeBuilder(attrCtorInfo,new object[]{});
+            tb.SetCustomAttribute(attrBuilder);
+
+            return tb;
+        }
+
+        static ILGenerator GenerateExceptionILCode(dynamic builder)
+        {
+            ILGenerator ilgen = builder.GetILGenerator();
+            var seriExc = typeof(NotSerializedException);
+            var exCtorInfo = seriExc.GetConstructor(new Type[]{});
+            ilgen.Emit(OpCodes.Newobj, exCtorInfo);
+            ilgen.ThrowException(seriExc);
+            return ilgen;
+        }
+        
+        private static MethodAttributes GetMethodAttrs (MethodInfo minfo)
+        {
+            var methAttributes = minfo.Attributes;
+            // Always implement/shadow the method
+            methAttributes &=(~MethodAttributes.Abstract);
+            methAttributes &=(~MethodAttributes.NewSlot);
+            methAttributes |= MethodAttributes.ReuseSlot;
+            methAttributes |= MethodAttributes.HideBySig;
+            methAttributes |= MethodAttributes.Final;
+
+            if (minfo.IsFinal)
+            {
+                // can't override a final method, new it instead.
+                methAttributes &= (~MethodAttributes.Virtual);
+                methAttributes |= MethodAttributes.NewSlot;
+            }
+
+            return methAttributes;
+        }
+
+        private static void CreateProperty(TypeBuilder tb, PropertyInfo pinfo)
+        {
+            string propertyName = pinfo.Name;
+            Type propertyType = pinfo.PropertyType;
+            FieldBuilder fieldBuilder = tb.DefineField("_" + propertyName, propertyType, FieldAttributes.Private);
+            PropertyBuilder propertyBuilder = tb.DefineProperty(propertyName, pinfo.Attributes, propertyType, null);
+            if (pinfo.GetMethod is not null)
+            {
+                var methAttributes = GetMethodAttrs(pinfo.GetMethod);
+                
+                MethodBuilder getPropMthdBldr = 
+                    tb.DefineMethod("get_" + propertyName, 
+                                    methAttributes,
+                                    propertyType, 
+                                    Type.EmptyTypes);
+                GenerateExceptionILCode(getPropMthdBldr);
+                propertyBuilder.SetGetMethod(getPropMthdBldr);
+            }
+            if (pinfo.SetMethod is not null)
+            {
+                var methAttributes = GetMethodAttrs(pinfo.SetMethod);
+                MethodBuilder setPropMthdBldr =
+                    tb.DefineMethod("set_" + propertyName,
+                                    methAttributes,
+                                    null,
+                                    new[] { propertyType });
+
+                GenerateExceptionILCode(setPropMthdBldr);
+                propertyBuilder.SetSetMethod(setPropMthdBldr);
+            }
+        }
+
+        private static void CreateMethod(TypeBuilder tb, MethodInfo minfo)
+        {
+            Console.WriteLine($"overimplementing method for: {minfo}  {minfo.IsVirtual}  {minfo.IsFinal}  ");
+            string methodName = minfo.Name;
+            
+            if (dontReimplementMethods.Contains(methodName))
+            {
+                // Some methods must *not* be reimplemented (who wants to throw from Dispose?)
+                // and some methods we need to implement in a more specific way (Equals, GetHashCode)
+                return;
+            }
+            var methAttributes = GetMethodAttrs(minfo);
+            var @params = (from paraminfo in minfo.GetParameters() select paraminfo.ParameterType).ToArray();
+            MethodBuilder mbuilder = tb.DefineMethod(methodName, methAttributes, minfo.CallingConvention, minfo.ReturnType, @params);
+            GenerateExceptionILCode(mbuilder);
+        }
+    }
+
+    class NotSerializableSerializer : ISerializationSurrogate
+    {
+
+        public NotSerializableSerializer()
+        {
+        }
+
+        public void GetObjectData(object obj, SerializationInfo info, StreamingContext context)
+        {
+            // This type is private to System.Runtime.Serialization. We get an
+            // object of this type when, amongst others, the type didn't exist (yet?)
+            // (dll not loaded, type was removed/renamed) when we previously
+            // deserialized the previous domain objects. Don't serialize this
+            // object.
+            if (obj.GetType().Name == "TypeLoadExceptionHolder")
+            {
+                obj = null!;
+                return;
+            }
+
+            MaybeType type = obj.GetType();
+            
+            var hasAttr = (from attr in obj.GetType().CustomAttributes select attr.AttributeType == typeof(PyNet_NotSerializedAttribute)).Count() != 0;
+            if (hasAttr)
+            {
+                // Don't serialize a _NotSerialized. Serialize the base type, and deserialize as a _NotSerialized
+                type = type.Value.BaseType;
+                obj = null!;
+            }
+
+            info.AddValue("notSerialized_tp", type);
+
+        }
+    
+        public object SetObjectData(object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
+        {
+            if (info is null)
+            {
+                // `obj` is of type TypeLoadExceptionHolder. This means the type 
+                // we're trying to load doesn't exist anymore or we haven't created
+                // it yet, and the runtime doesn't even gives us the chance to
+                // recover from this as info is null. We may even get objects
+                // this serializer did not serialize in a previous domain,
+                // like in the case of the "namespace_rename" domain reload 
+                // test: the object successfully serialized, but it cannot be
+                // deserialized.
+                // just return null.
+                return null!;
+            }
+
+            object nameObj = null!;
+            try
+            {
+                nameObj = info.GetValue($"notSerialized_tp", typeof(object));
+            }
+            catch
+            {
+                // we didn't find the expected information. We don't know
+                // what to do with this; return null.
+                return null!;
+            }
+            Debug.Assert(nameObj.GetType() == typeof(MaybeType));
+            MaybeType name = (MaybeType)nameObj;
+            Debug.Assert(name.Valid);
+            if (!name.Valid)
+            {
+                // The type couldn't be loaded
+                return null!;
+            }
+
+            obj = NonSerializedTypeBuilder.CreateNewObject(name.Value);
+            return obj;
+        }
+    }
+
+    class NonSerializableSelector : SurrogateSelector
+    {
+        public override ISerializationSurrogate? GetSurrogate (Type type, StreamingContext context, out ISurrogateSelector selector)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException();
+            }
+            if (type.IsSerializable)
+            {
+                selector = this;
+                return null; // use whichever default
+            }
+            else
+            {
+                selector = this;
+                return new NotSerializableSerializer();
+            }
+        }
+    }
+
     public static class RuntimeData
     {
         private static Type? _formatterType;
@@ -47,6 +332,73 @@ namespace Python.Runtime
             }
         }
 
+        internal static void SerializeNonSerializableTypes ()
+        {
+            // Serialize the Types (Type objects) that couldn't be (de)serialized.
+            // This needs to be done otherwise at deserialization time we get
+            // TypeLoadExceptionHolder objects and we can't even recover.
+
+            // We don't serialize the "_NotSerialized" Types, we serialize their base
+            // to recreate the "_NotSerialized" versions on the next domain load.
+            
+            Dictionary<string, MaybeType> invalidTypes = new();
+            foreach(var tp in NonSerializedTypeBuilder.assemblyForNonSerializedClasses.GetTypes())
+            {
+                invalidTypes[tp.FullName] = new MaybeType(tp.BaseType);
+            }
+
+            // delete previous data if any
+            BorrowedReference oldCapsule = PySys_GetObject("clr_nonSerializedTypes");
+            if (!oldCapsule.IsNull)
+            {
+                IntPtr oldData = PyCapsule_GetPointer(oldCapsule, IntPtr.Zero);
+                PyMem_Free(oldData);
+                PyCapsule_SetPointer(oldCapsule, IntPtr.Zero);
+            }
+            IFormatter formatter = CreateFormatter();
+            var ms = new MemoryStream();
+            formatter.Serialize(ms, invalidTypes);
+            
+            Debug.Assert(ms.Length <= int.MaxValue);
+            byte[] data = ms.GetBuffer();
+            
+            IntPtr mem = PyMem_Malloc(ms.Length + IntPtr.Size);
+            Marshal.WriteIntPtr(mem, (IntPtr)ms.Length);
+            Marshal.Copy(data, 0, mem + IntPtr.Size, (int)ms.Length);
+
+            using NewReference capsule = PyCapsule_New(mem, IntPtr.Zero, IntPtr.Zero);
+            int res = PySys_SetObject("clr_nonSerializedTypes", capsule.BorrowOrThrow());
+            PythonException.ThrowIfIsNotZero(res);
+
+        }
+
+        internal static void DeserializeNonSerializableTypes ()
+        {
+            BorrowedReference capsule = PySys_GetObject("clr_nonSerializedTypes");
+            if (capsule.IsNull)
+            {
+                // nothing to do.
+                return;
+            }
+            // get the memory stream from the capsule.
+            IntPtr mem = PyCapsule_GetPointer(capsule, IntPtr.Zero);
+            int length = (int)Marshal.ReadIntPtr(mem);
+            byte[] data = new byte[length];
+            Marshal.Copy(mem + IntPtr.Size, data, 0, length);
+            var ms = new MemoryStream(data);
+            var formatter = CreateFormatter();
+            var storage = (Dictionary<string, MaybeType>)formatter.Deserialize(ms);
+            foreach(var item in storage)
+            {
+                if(item.Value.Valid)
+                {
+                    // recreate the "_NotSerialized" Types
+                    NonSerializedTypeBuilder.CreateType(item.Value.Value);
+                }
+            }
+
+        }
+
         internal static void Stash()
         {
             var runtimeStorage = new PythonNetState
@@ -74,6 +426,8 @@ namespace Python.Runtime
             using NewReference capsule = PyCapsule_New(mem, IntPtr.Zero, IntPtr.Zero);
             int res = PySys_SetObject("clr_data", capsule.BorrowOrThrow());
             PythonException.ThrowIfIsNotZero(res);
+            SerializeNonSerializableTypes();
+
         }
 
         internal static void RestoreRuntimeData()
@@ -90,6 +444,9 @@ namespace Python.Runtime
 
         private static void RestoreRuntimeDataImpl()
         {
+            // The "_NotSerialized" Types must exist before the rest of the data
+            // is deserialized.
+            DeserializeNonSerializableTypes();
             BorrowedReference capsule = PySys_GetObject("clr_data");
             if (capsule.IsNull)
             {
@@ -123,19 +480,6 @@ namespace Python.Runtime
             PySys_SetObject("clr_data", default);
         }
 
-        static bool CheckSerializable (object o)
-        {
-            Type type = o.GetType();
-            do
-            {
-                if (!type.IsSerializable)
-                {
-                    return false;
-                }
-            } while ((type = type.BaseType) != null);
-            return true;
-        }
-
         private static SharedObjectsState SaveRuntimeDataObjects()
         {
             var contexts = new Dictionary<PyObject, Dictionary<string, object?>>(PythonReferenceComparer.Instance);
@@ -150,7 +494,6 @@ namespace Python.Runtime
             foreach (var pyObj in extensions)
             {
                 var extension = (ExtensionType)ManagedType.GetManagedObject(pyObj)!;
-                Debug.Assert(CheckSerializable(extension));
                 var context = extension.Save(pyObj);
                 if (context is not null)
                 {
@@ -170,6 +513,7 @@ namespace Python.Runtime
                                     .ToList();
             foreach (var pyObj in reflectedObjects)
             {
+                // Console.WriteLine($"saving object: {pyObj} {pyObj.rawPtr} ");
                 // Wrapper must be the CLRObject
                 var clrObj = (CLRObject)ManagedType.GetManagedObject(pyObj)!;
                 object inst = clrObj.inst;
@@ -199,10 +543,6 @@ namespace Python.Runtime
             {
                 if (!item.Stored)
                 {
-                    if (!CheckSerializable(item.Instance))
-                    {
-                        continue;
-                    }
                     var clrO = wrappers[item.Instance].First();
                     foreach (var @ref in item.PyRefs)
                     {
@@ -254,7 +594,11 @@ namespace Python.Runtime
         {
             return FormatterType != null ?
                 (IFormatter)Activator.CreateInstance(FormatterType)
-                : new BinaryFormatter();
+                : new BinaryFormatter()
+                {
+                    SurrogateSelector = new NonSerializableSelector(),
+                    // Binder = new CustomizedBinder()
+                };
         }
     }
 }

--- a/tests/domain_tests/test_domain_reload.py
+++ b/tests/domain_tests/test_domain_reload.py
@@ -1,6 +1,7 @@
 import subprocess
 import os
 import platform
+from unittest import skip
 
 import pytest
 
@@ -88,3 +89,10 @@ def test_nested_type():
 
 def test_import_after_reload():
     _run_test("import_after_reload")
+
+def test_serialize_not_serializable():
+    _run_test("serialize_not_serializable")
+
+@skip("interface methods cannot be overriden")
+def test_serialize_not_serializable_interface():
+    _run_test("serialize_not_serializable_interface")


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR adds a "last line of defense, best effort serialization" to serialize types not marked as Serializable. Such objects, when derivable, are deserialized as derived classes with all (overridable) methods and properties overriden to throw a "Not Serialized" Exception. Fields are not initialized and may be null. Instances of classes that are not derivable are null.

### Does this close any currently open issues?

No, but it is an issue we've encountered with Unity.

### Any other comments?

This is a "best effort" to ensure no SerializationExceptions are thrown on domain unloads/reloads. This should help users deal with serialization issues as sometimes unserializable classes may be in compiled libraries and therefore unmodifiable.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
