### PR TITLE
Disabled implicit seq to array conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ or the DLL must be loaded in advance. This must be done before calling any other
 -   BREAKING: disabled implicit conversion from C# enums to Python `int` and back.
 One must now either use enum members (e.g. `MyEnum.Option`), or use enum constructor
 (e.g. `MyEnum(42)` or `MyEnum(42, True)` when `MyEnum` does not have a member with value 42).
+-   BREAKING: disabled implicit conversion from Python objects implementing sequence protocol to
+.NET arrays when the target .NET type is `System.Object`. The conversion is still attempted when the
+target type is a `System.Array`.
 -   Sign Runtime DLL with a strong name
 -   Implement loading through `clr_loader` instead of the included `ClrModule`, enables
     support for .NET Core

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -389,11 +389,6 @@ namespace Python.Runtime
                     return true;
                 }
 
-                if (Runtime.PySequence_Check(value))
-                {
-                    return ToArray(value, typeof(object[]), out result, setError);
-                }
-
                 result = new PyObject(value);
                 return true;
             }

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -577,6 +577,13 @@ def test_object_conversion():
     ob.ObjectField = Foo
     assert ob.ObjectField == Foo
 
+    class PseudoSeq:
+        def __getitem__(self, idx):
+           return 0
+
+    ob.ObjectField = PseudoSeq()
+    assert ob.ObjectField.__class__.__name__ == "PseudoSeq"
+
 
 def test_null_conversion():
     """Test null conversion."""


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Disabled implicit conversion from Python objects implementing sequence protocol to .NET arrays when the target .NET type is `System.Object`. The conversion is still attempted when the target type is a `System.Array`.

Many Python types implement sequence protocol. In many cases such conversion looses too much important data.

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1900


### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
