### PR TITLE
Fill nb_index slot for integer types

### DIFF
--- a/src/runtime/Native/ITypeOffsets.cs
+++ b/src/runtime/Native/ITypeOffsets.cs
@@ -31,6 +31,7 @@ namespace Python.Runtime.Native
         int nb_invert { get; }
         int nb_inplace_add { get; }
         int nb_inplace_subtract { get; }
+        int nb_index { get; }
         int ob_size { get; }
         int ob_type { get; }
         int qualname { get; }

--- a/src/runtime/Native/TypeOffset.cs
+++ b/src/runtime/Native/TypeOffset.cs
@@ -38,6 +38,7 @@ namespace Python.Runtime
         internal static int nb_invert { get; private set; }
         internal static int nb_inplace_add { get; private set; }
         internal static int nb_inplace_subtract { get; private set; }
+        internal static int nb_index { get; private set; }
         internal static int ob_size { get; private set; }
         internal static int ob_type { get; private set; }
         internal static int qualname { get; private set; }

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -604,6 +604,7 @@ namespace Python.Runtime
                 case TypeCode.Int32:
                 case TypeCode.Int64:
                     TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_int, new Interop.B_N(DoConvertInt), slotsHolder);
+                    TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_index, new Interop.B_N(DoConvertInt), slotsHolder);
                     TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_float, new Interop.B_N(DoConvertFloat), slotsHolder);
                     break;
                 case TypeCode.Byte:
@@ -611,10 +612,12 @@ namespace Python.Runtime
                 case TypeCode.UInt32:
                 case TypeCode.UInt64:
                     TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_int, new Interop.B_N(DoConvertUInt), slotsHolder);
+                    TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_index, new Interop.B_N(DoConvertUInt), slotsHolder);
                     TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_float, new Interop.B_N(DoConvertFloat), slotsHolder);
                     break;
                 case TypeCode.Double:
                 case TypeCode.Single:
+                    TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_int, new Interop.B_N(DoConvertInt), slotsHolder);
                     TypeManager.InitializeSlotIfEmpty(pyType, TypeOffset.nb_float, new Interop.B_N(DoConvertFloat), slotsHolder);
                     break;
             }

--- a/src/runtime/Types/OperatorMethod.cs
+++ b/src/runtime/Types/OperatorMethod.cs
@@ -54,6 +54,7 @@ namespace Python.Runtime
 
                 ["__int__"] = new SlotDefinition("__int__", TypeOffset.nb_int),
                 ["__float__"] = new SlotDefinition("__float__", TypeOffset.nb_float),
+                ["__index__"] = new SlotDefinition("__float__", TypeOffset.nb_index),
             };
             ComparisonOpMap = new Dictionary<string, string>
             {

--- a/src/runtime/Types/OperatorMethod.cs
+++ b/src/runtime/Types/OperatorMethod.cs
@@ -54,7 +54,7 @@ namespace Python.Runtime
 
                 ["__int__"] = new SlotDefinition("__int__", TypeOffset.nb_int),
                 ["__float__"] = new SlotDefinition("__float__", TypeOffset.nb_float),
-                ["__index__"] = new SlotDefinition("__float__", TypeOffset.nb_index),
+                ["__index__"] = new SlotDefinition("__index__", TypeOffset.nb_index),
             };
             ComparisonOpMap = new Dictionary<string, string>
             {

--- a/src/runtime/Util/OpsHelper.cs
+++ b/src/runtime/Util/OpsHelper.cs
@@ -87,5 +87,9 @@ namespace Python.Runtime
             => typeof(T).GetEnumUnderlyingType() == typeof(UInt64)
             ? new PyInt(Convert.ToUInt64(value))
             : new PyInt(Convert.ToInt64(value));
+        [ForbidPythonThreads]
+#pragma warning disable IDE1006 // Naming Styles - must match Python
+        public static PyInt __int__(T value) => __index__(value);
+#pragma warning restore IDE1006 // Naming Styles
     }
 }

--- a/src/runtime/Util/OpsHelper.cs
+++ b/src/runtime/Util/OpsHelper.cs
@@ -82,7 +82,7 @@ namespace Python.Runtime
     {
         [ForbidPythonThreads]
 #pragma warning disable IDE1006 // Naming Styles - must match Python
-        public static PyInt __int__(T value)
+        public static PyInt __index__(T value)
 #pragma warning restore IDE1006 // Naming Styles
             => typeof(T).GetEnumUnderlyingType() == typeof(UInt64)
             ? new PyInt(Convert.ToUInt64(value))

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -743,9 +743,9 @@ def test_explicit_conversion():
         assert float(t(127)) == 127.0
         assert float(t(-127)) == -127.0
 
-    assert int(Int64.MaxValue) == 2**63 - 1
-    assert int(Int64.MinValue) == -2**63
-    assert int(UInt64.MaxValue) == 2**64 - 1
+    assert int(Int64(Int64.MaxValue)) == 2**63 - 1
+    assert int(Int64(Int64.MinValue)) == -2**63
+    assert int(UInt64(UInt64.MaxValue)) == 2**64 - 1
 
     for t in [Single, Double]:
         assert float(t(0.125)) == 0.125

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -721,6 +721,7 @@ def test_intptr_construction():
             UIntPtr(v)
 
 def test_explicit_conversion():
+    from operator import index
     from System import (
         Int64, UInt64, Int32, UInt32, Int16, UInt16, Byte, SByte, Boolean
     )
@@ -730,10 +731,13 @@ def test_explicit_conversion():
     assert int(Boolean(True)) == 1
 
     for t in [UInt64, UInt32, UInt16, Byte]:
+        assert index(t(127)) == 127
         assert int(t(127)) == 127
         assert float(t(127)) == 127.0
 
     for t in [Int64, Int32, Int16, SByte]:
+        assert index(t(127)) == 127
+        assert index(t(-127)) == -127
         assert int(t(127)) == 127
         assert int(t(-127)) == -127
         assert float(t(127)) == 127.0
@@ -745,3 +749,6 @@ def test_explicit_conversion():
 
     for t in [Single, Double]:
         assert float(t(0.125)) == 0.125
+        assert int(t(123.4)) == 123
+        with pytest.raises(TypeError):
+            index(t(123.4))


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fills slot for `__index__` as a follow up to #1904. In Python >= 3.10, use of `__int__` for quite a few conversion cases has been removed.

### Does this close any currently open issues?

-/-

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
