### PR TITLE
Implicit float conversion in function calls

### DIFF
--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -710,7 +710,7 @@ namespace Python.Runtime
                     {
                         if (Runtime.Is32Bit)
                         {
-                            if (!Runtime.PyLong_Check(value))
+                            if (!Runtime.PyInt_Check(value))
                             {
                                 goto type_error;
                             }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1145,9 +1145,7 @@ namespace Python.Runtime
         }
 
         internal static bool PyFloat_Check(BorrowedReference ob)
-        {
-            return PyObject_TYPE(ob) == PyFloatType;
-        }
+            => PyObject_TypeCheck(ob, PyFloatType);
 
         /// <summary>
         /// Return value: New reference.

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1101,11 +1101,6 @@ namespace Python.Runtime
 
         internal static NewReference PyInt_FromInt64(long value) => PyLong_FromLongLong(value);
 
-        internal static bool PyLong_Check(BorrowedReference ob)
-        {
-            return PyObject_TYPE(ob) == PyLongType;
-        }
-
         internal static NewReference PyLong_FromLongLong(long value) => Delegates.PyLong_FromLongLong(value);
 
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Uses `__float__` when available if a Python object is passed to a function with a `Double` or `Single` parameter.

### Does this close any currently open issues?

#1833

### Any other comments?

This is not yet supported for integer types, which would use `__int__`
or `__index__` (for Python >=3.10), as the respective logic is for some
reason only implemented for `AsLongLong` and `AsLong`, not for the
unsigned counterparts and also not for the `AsSize_t` variants that we
are using.


### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
