### PR TITLE
Fixed use of the process handle after Process instance is garbage collected

### DIFF
--- a/src/runtime/Native/LibraryLoader.cs
+++ b/src/runtime/Native/LibraryLoader.cs
@@ -137,17 +137,17 @@ namespace Python.Runtime.Platform
 
         static IntPtr[] GetAllModules()
         {
-            var self = Process.GetCurrentProcess().Handle;
+            using var self = Process.GetCurrentProcess();
 
             uint bytes = 0;
             var result = new IntPtr[0];
-            if (!EnumProcessModules(self, result, bytes, out var needsBytes))
+            if (!EnumProcessModules(self.Handle, result, bytes, out var needsBytes))
                 throw new Win32Exception();
             while (bytes < needsBytes)
             {
                 bytes = needsBytes;
                 result = new IntPtr[bytes / IntPtr.Size];
-                if (!EnumProcessModules(self, result, bytes, out needsBytes))
+                if (!EnumProcessModules(self.Handle, result, bytes, out needsBytes))
                     throw new Win32Exception();
             }
             return result.Take((int)(needsBytes / IntPtr.Size)).ToArray();


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Current process handle can be closed before we try to enumerate process modules because we do not keep an instance of `Process` alive.

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1939

### Any other comments?

credits to @sdao for discovering the bug and suggesting a fix
