### PR TITLE
Fixed new line character at the end of informational version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <AssemblyProduct>Python.NET</AssemblyProduct>
     <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
-    <FullVersion>$([System.IO.File]::ReadAllText("version.txt"))</FullVersion>
+    <FullVersion>$([System.IO.File]::ReadAllText("version.txt").Trim())</FullVersion>
     <VersionPrefix>$(FullVersion.Split('-', 2)[0])</VersionPrefix>
     <VersionSuffix Condition="$(FullVersion.Contains('-'))">$(FullVersion.Split('-', 2)[1])</VersionSuffix>
   </PropertyGroup>

--- a/pythonnet.sln
+++ b/pythonnet.sln
@@ -21,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repo", "Repo", "{441A0123-F
 		CHANGELOG.md = CHANGELOG.md
 		LICENSE = LICENSE
 		README.rst = README.rst
+		version.txt = version.txt
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{D301657F-5EAF-4534-B280-B858D651B2E5}"

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -31,6 +31,7 @@ def test_import_clr():
 def test_version_clr():
     import clr
     assert clr.__version__ >= "3.0.0"
+    assert clr.__version__[-1] != "\n"
 
 
 def test_preload_var():


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Prior to this change `clr.__version__` would have a newline character at the end, e.g. `'3.0.0-rc3\n'`

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change