### PR TITLE
Config-less CoreCLR and improved runtime load message

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft src/runtime
 prune src/runtime/obj
 prune src/runtime/bin
+include src/pythonnet.snk
 include Directory.Build.*
 include pythonnet.sln
 include version.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {text = "MIT"}
 readme = "README.rst"
 
 dependencies = [
-    "clr_loader>=0.1.7"
+    "clr_loader>=0.2.2,<0.3.0"
 ]
 
 classifiers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,10 +53,12 @@ def pytest_configure(config):
     runtime_params = {}
 
     if runtime_opt == "coreclr":
-        fw = "net6.0"
-        runtime_params["runtime_config"] = str(
-            bin_path / "Python.Test.runtimeconfig.json"
-        )
+        # This is optional now:
+        #
+        # fw = "net6.0"
+        # runtime_params["runtime_config"] = str(
+        #     bin_path / "Python.Test.runtimeconfig.json"
+        # )
         collect_ignore.append("domain_tests/test_domain_reload.py")
     else:
         domain_tests_dir = cwd / "domain_tests"


### PR DESCRIPTION

### What does this implement/fix? Explain your changes.

- Bump clr-loader dependency to 0.2.0 and adjust interface, allows to load a .NET Core Python.NET by just setting `PYTHONNET_RUNTIME=coreclr` or `from pythonnet import set_runtime; set_runtime("coreclr")`
- Improve error message if the runtime fails to load

### Does this close any currently open issues?

#1868

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
