### PR TITLE
Add __version__

### DIFF
--- a/pythonnet/__init__.py
+++ b/pythonnet/__init__.py
@@ -10,6 +10,21 @@ _LOADER_ASSEMBLY: Optional[clr_loader.Assembly] = None
 _LOADED: bool = False
 
 
+try:
+    import importlib.metadata
+    __version__ = importlib.metadata.version("pythonnet")
+except Exception:
+    try:
+        import pkg_resources  # part of setuptools
+        __version__ = pkg_resources.require("pythonnet")[0].version
+    except Exception:
+        try:
+            with open(Path(__file__).parent.parent / "version.txt") as f:
+                __version__ = f.read().strip()
+        except Exception:
+            __version__ = "unknown"
+
+
 def set_runtime(runtime: Union[clr_loader.Runtime, str], **params: str) -> None:
     """Set up a clr_loader runtime without loading it
 


### PR DESCRIPTION
Add `__version__` property to `pythonnet`, trying first `importlib.metadata`, then `pkg_resources`, then `version.txt` before using `"unknown"`.

Fixes #1909.

@amueller I'm still not sure whether this is needed in modern Python versions (we only support 3.7 upwards nowadays), but since you are also a Bonn Maths alumnus ... ;)