### PR TITLE
Stricter coversion of primitive Python types to `System.Object`

### DIFF
--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -133,6 +133,26 @@ namespace Python.EmbeddingTest
         }
 
         [Test]
+        public void DerivedFloatIsNotFloat()
+        {
+            using var scope = Py.CreateScope();
+            scope.Exec(@"class DerivedFloat(float): pass");
+            using var derivedFloat = scope.Eval("DerivedFloat(42.0)");
+            object dotnetValue = derivedFloat.As<object>();
+            Assert.IsInstanceOf<PyObject>(dotnetValue);
+        }
+
+        [Test]
+        public void DerivedIntIsNotInt()
+        {
+            using var scope = Py.CreateScope();
+            scope.Exec(@"class DerivedInt(int): pass");
+            using var derivedInt = scope.Eval("DerivedInt(42)");
+            object dotnetValue = derivedInt.As<object>();
+            Assert.IsInstanceOf<PyObject>(dotnetValue);
+        }
+
+        [Test]
         public void BigIntExplicit()
         {
             BigInteger val = 42;

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -361,17 +361,17 @@ namespace Python.Runtime
             // conversions (Python string -> managed string).
             if (obType == objectType)
             {
-                if (Runtime.PyString_Check(value))
+                if (Runtime.PyString_CheckExact(value))
                 {
                     return ToPrimitive(value, stringType, out result, setError);
                 }
 
-                if (Runtime.PyBool_Check(value))
+                if (Runtime.PyBool_CheckExact(value))
                 {
                     return ToPrimitive(value, boolType, out result, setError);
                 }
 
-                if (Runtime.PyFloat_Check(value))
+                if (Runtime.PyFloat_CheckExact(value))
                 {
                     return ToPrimitive(value, doubleType, out result, setError);
                 }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1094,8 +1094,13 @@ namespace Python.Runtime
         internal static bool PyInt_Check(BorrowedReference ob)
             => PyObject_TypeCheck(ob, PyLongType);
 
+        internal static bool PyInt_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyLongType);
+
         internal static bool PyBool_Check(BorrowedReference ob)
             => PyObject_TypeCheck(ob, PyBoolType);
+        internal static bool PyBool_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyBoolType);
 
         internal static NewReference PyInt_FromInt32(int value) => PyLong_FromLongLong(value);
 
@@ -1141,6 +1146,8 @@ namespace Python.Runtime
 
         internal static bool PyFloat_Check(BorrowedReference ob)
             => PyObject_TypeCheck(ob, PyFloatType);
+        internal static bool PyFloat_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyFloatType);
 
         /// <summary>
         /// Return value: New reference.
@@ -1282,9 +1289,9 @@ namespace Python.Runtime
         // Python string API
         //====================================================================
         internal static bool PyString_Check(BorrowedReference ob)
-        {
-            return PyObject_TYPE(ob) == PyStringType;
-        }
+            => PyObject_TypeCheck(ob, PyStringType);
+        internal static bool PyString_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyStringType);
 
         internal static NewReference PyString_FromString(string value)
         {
@@ -1643,6 +1650,8 @@ namespace Python.Runtime
             return Delegates.PyType_IsSubtype(t1, t2);
         }
 
+        internal static bool PyObject_TypeCheckExact(BorrowedReference ob, BorrowedReference tp)
+            => PyObject_TYPE(ob) == tp;
         internal static bool PyObject_TypeCheck(BorrowedReference ob, BorrowedReference tp)
         {
             BorrowedReference t = PyObject_TYPE(ob);


### PR DESCRIPTION
When trying to convert to `System.Object`, only convert `float`, `bool`, and `str` to corresponding .NET primitives types. Do **NOT** convert instances of types derived from them.

### What does this implement/fix? Explain your changes.

This changes `Converter` to perform exact type checks when target type is `System.Object`

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1957

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
