### PR TITLE
Delete target object from event handler collections when it has no more event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Fixed
 
+-   Fixed objects leaking when Python attached event handlers to them even if they were later removed
+
 
 ## [3.0.0](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.0) - 2022-09-29
 

--- a/src/embed_tests/Events.cs
+++ b/src/embed_tests/Events.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+using NUnit.Framework;
+
+using Python.Runtime;
+
+namespace Python.EmbeddingTest;
+
+public class Events
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        PythonEngine.Initialize();
+    }
+
+    [OneTimeTearDown]
+    public void Dispose()
+    {
+        PythonEngine.Shutdown();
+    }
+
+    [Test]
+    public void UsingDoesNotLeak()
+    {
+        using var scope = Py.CreateScope();
+        scope.Exec(@"
+import gc
+
+from Python.EmbeddingTest import ClassWithEventHandler
+
+def event_handler():
+    pass
+
+for _ in range(2000):
+    example = ClassWithEventHandler()
+    example.LeakEvent += event_handler
+    example.LeakEvent -= event_handler
+    del example
+
+gc.collect()
+");
+        Runtime.Runtime.TryCollectingGarbage(10);
+        Assert.AreEqual(0, ClassWithEventHandler.alive);
+    }
+}
+
+public class ClassWithEventHandler
+{
+    internal static int alive;
+
+    public event EventHandler LeakEvent;
+    private Array arr;  // dummy array to exacerbate memory leak
+
+    public ClassWithEventHandler()
+    {
+        Interlocked.Increment(ref alive);
+        this.arr = new int[800];
+    }
+
+    ~ClassWithEventHandler()
+    {
+        Interlocked.Decrement(ref alive);
+    }
+}

--- a/src/runtime/Finalizer.cs
+++ b/src/runtime/Finalizer.cs
@@ -364,6 +364,8 @@ namespace Python.Runtime
     {
         public IntPtr PyObj;
         public BorrowedReference Ref => new(PyObj);
+        public ManagedType? Managed => ManagedType.GetManagedObject(Ref);
+        public nint RefCount => Runtime.Refcount(Ref);
         public int RuntimeRun;
 #if TRACE_ALLOC
         public string StackTrace;

--- a/src/runtime/PythonTypes/PyObject.cs
+++ b/src/runtime/PythonTypes/PyObject.cs
@@ -1051,9 +1051,20 @@ namespace Python.Runtime
             return Runtime.GetManagedString(strval.BorrowOrThrow());
         }
 
-        string? DebuggerDisplay => DebugUtil.HaveInterpreterLock()
-            ? this.ToString()
-            : $"pyobj at 0x{this.rawPtr:X} (get Py.GIL to see more info)";
+        ManagedType? InternalManagedObject => ManagedType.GetManagedObject(this.Reference);
+
+        string? DebuggerDisplay
+        {
+            get
+            {
+                if (DebugUtil.HaveInterpreterLock())
+                    return this.ToString();
+                var obj = this.InternalManagedObject;
+                return obj is { }
+                    ? obj.ToString()
+                    : $"pyobj at 0x{this.rawPtr:X} (get Py.GIL to see more info)";
+            }
+        }
 
 
         /// <summary>

--- a/src/runtime/Util/EventHandlerCollection.cs
+++ b/src/runtime/Util/EventHandlerCollection.cs
@@ -99,6 +99,10 @@ internal class EventHandlerCollection: Dictionary<object, List<Handler>>
                 continue;
             }
             list.RemoveAt(i);
+            if (list.Count == 0)
+            {
+                Remove(key);
+            }
             return true;
         }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The objects were leaking because they were kept as keys in a dictionary, that stored event handlers corresponding to object.

This change ensures that when the last handler is removed from an object, the object is removed from that dictionary.

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/1972

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
