### PR TITLE
Allow decoders to decode Python types derived from primitives

### DIFF
--- a/src/embed_tests/Codecs.cs
+++ b/src/embed_tests/Codecs.cs
@@ -356,6 +356,19 @@ DateTimeDecoder.Setup()
         }
 
         [Test]
+        public void FloatDerivedDecoded()
+        {
+            using var scope = Py.CreateScope();
+            scope.Exec(@"class FloatDerived(float): pass");
+            using var floatDerived = scope.Eval("FloatDerived");
+            var decoder = new DecoderReturningPredefinedValue<object>(floatDerived, 42);
+            PyObjectConversions.RegisterDecoder(decoder);
+            using var result = scope.Eval("FloatDerived()");
+            object decoded = result.As<object>();
+            Assert.AreEqual(42, decoded);
+        }
+
+        [Test]
         public void ExceptionDecodedNoInstance()
         {
             PyObjectConversions.RegisterDecoder(new InstancelessExceptionDecoder());

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -361,6 +361,29 @@ namespace Python.Runtime
             // conversions (Python string -> managed string).
             if (obType == objectType)
             {
+                if (Runtime.PyString_CheckExact(value))
+                {
+                    return ToPrimitive(value, stringType, out result, setError);
+                }
+
+                if (Runtime.PyBool_CheckExact(value))
+                {
+                    return ToPrimitive(value, boolType, out result, setError);
+                }
+
+                if (Runtime.PyFloat_CheckExact(value))
+                {
+                    return ToPrimitive(value, doubleType, out result, setError);
+                }
+
+                // give custom codecs a chance to take over conversion
+                // of ints, sequences, and types derived from primitives
+                BorrowedReference pyType = Runtime.PyObject_TYPE(value);
+                if (PyObjectConversions.TryDecode(value, pyType, obType, out result))
+                {
+                    return true;
+                }
+
                 if (Runtime.PyString_Check(value))
                 {
                     return ToPrimitive(value, stringType, out result, setError);
@@ -374,13 +397,6 @@ namespace Python.Runtime
                 if (Runtime.PyFloat_Check(value))
                 {
                     return ToPrimitive(value, doubleType, out result, setError);
-                }
-
-                // give custom codecs a chance to take over conversion of ints and sequences
-                BorrowedReference pyType = Runtime.PyObject_TYPE(value);
-                if (PyObjectConversions.TryDecode(value, pyType, obType, out result))
-                {
-                    return true;
                 }
 
                 if (Runtime.PyInt_Check(value))

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1094,8 +1094,13 @@ namespace Python.Runtime
         internal static bool PyInt_Check(BorrowedReference ob)
             => PyObject_TypeCheck(ob, PyLongType);
 
+        internal static bool PyInt_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyLongType);
+
         internal static bool PyBool_Check(BorrowedReference ob)
             => PyObject_TypeCheck(ob, PyBoolType);
+        internal static bool PyBool_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyBoolType);
 
         internal static NewReference PyInt_FromInt32(int value) => PyLong_FromLongLong(value);
 
@@ -1141,6 +1146,8 @@ namespace Python.Runtime
 
         internal static bool PyFloat_Check(BorrowedReference ob)
             => PyObject_TypeCheck(ob, PyFloatType);
+        internal static bool PyFloat_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyFloatType);
 
         /// <summary>
         /// Return value: New reference.
@@ -1282,9 +1289,9 @@ namespace Python.Runtime
         // Python string API
         //====================================================================
         internal static bool PyString_Check(BorrowedReference ob)
-        {
-            return PyObject_TYPE(ob) == PyStringType;
-        }
+            => PyObject_TypeCheck(ob, PyStringType);
+        internal static bool PyString_CheckExact(BorrowedReference ob)
+            => PyObject_TypeCheckExact(ob, PyStringType);
 
         internal static NewReference PyString_FromString(string value)
         {
@@ -1643,6 +1650,8 @@ namespace Python.Runtime
             return Delegates.PyType_IsSubtype(t1, t2);
         }
 
+        internal static bool PyObject_TypeCheckExact(BorrowedReference ob, BorrowedReference tp)
+            => PyObject_TYPE(ob) == tp;
         internal static bool PyObject_TypeCheck(BorrowedReference ob, BorrowedReference tp)
         {
             BorrowedReference t = PyObject_TYPE(ob);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When a Python instance needs to be converted to `System.Object`, and the Python type is derived from one of the primitives (e.g. `numpy.float64` is derived from `float`), allow a custom decoder to override the default behavior (which would have been converting to `System.Double`).

### Does this close any currently open issues?

It addresses the primary concern of https://github.com/pythonnet/pythonnet/issues/1957

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change