### PR TITLE
1990 py int to string fix

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -85,3 +85,4 @@
 -   ([@alxnull](https://github.com/alxnull))
 -   ([@gpetrou](https://github.com/gpetrou))
 -   Ehsan Iran-Nejad ([@eirannejad](https://github.com/eirannejad))
+-   Rolf Madsen ([@rmadsen-ks](https://github.com/rmadsen-ks))

--- a/src/python_tests_runner/PythonTestRunner.cs
+++ b/src/python_tests_runner/PythonTestRunner.cs
@@ -35,6 +35,7 @@ namespace Python.PythonTestsRunner
             // Add the test that you want to debug here.
             yield return new[] { "test_indexer", "test_boolean_indexer" };
             yield return new[] { "test_delegate", "test_bool_delegate" };
+            yield return new[] { "test_delegate", "test_object_string_format" };
         }
 
         /// <summary>

--- a/src/python_tests_runner/PythonTestRunner.cs
+++ b/src/python_tests_runner/PythonTestRunner.cs
@@ -35,7 +35,7 @@ namespace Python.PythonTestsRunner
             // Add the test that you want to debug here.
             yield return new[] { "test_indexer", "test_boolean_indexer" };
             yield return new[] { "test_delegate", "test_bool_delegate" };
-            yield return new[] { "test_delegate", "test_object_string_format" };
+            yield return new[] { "test_conversion", "test_object_string_format" };
         }
 
         /// <summary>

--- a/src/runtime/PythonTypes/PyInt.cs
+++ b/src/runtime/PythonTypes/PyInt.cs
@@ -228,7 +228,8 @@ namespace Python.Runtime
         public string ToString(string format, IFormatProvider formatProvider)
         {
             using var _ = Py.GIL();
-            return ToBigInteger().ToString(format, formatProvider);
+            object val = Runtime.PyLong_AsLongLong(obj);
+            return val?.ToString() ?? ToBigInteger().ToString(format, formatProvider);
         }
 
         public override TypeCode GetTypeCode() => TypeCode.Int64;

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -752,3 +752,9 @@ def test_explicit_conversion():
         assert int(t(123.4)) == 123
         with pytest.raises(TypeError):
             index(t(123.4))
+
+def test_object_string_format():
+    from System import String
+    integer_value = 200
+    string_value = String.Format("{0}", integer_value)
+    assert string_value == "200", f"{string_value} != ""200"""

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -452,10 +452,5 @@ def test_int_ref_int_ref_string_delegate():
 
     # test return wrong type
 
-def test_object_string_format():
-    """Test boolean delegate."""
-    from System import String
-    integer_value = 200
-    string_value = String.Format("{0}", integer_value)
-    assert string_value == "200", f"{string_value} != ""200"""
+
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -451,3 +451,11 @@ def test_int_ref_int_ref_string_delegate():
     # test sig mismatch, both on managed and Python side
 
     # test return wrong type
+
+def test_object_string_format():
+    """Test boolean delegate."""
+    from System import String
+    integer_value = 200
+    string_value = String.Format("{0}", integer_value)
+    assert string_value == "200", f"{string_value} != ""200"""
+


### PR DESCRIPTION
This fixes #1990: PyInt.ToString() has wrong results for values between 128 and 255

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [X] If an enhancement PR, please create docs and at best an example
-   [X] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
