### PR TITLE
Converting Callable Python to Dotnet Delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Added
 
+- Added support for automatically casting callables as Delegate when passed as argument to a Managed method ([#2015][p2015]).
+
 ### Changed
 
 ### Fixed
@@ -938,3 +940,4 @@ This version improves performance on benchmarks significantly compared to 2.3.
 [i238]: https://github.com/pythonnet/pythonnet/issues/238
 [i1481]: https://github.com/pythonnet/pythonnet/issues/1481
 [i1672]: https://github.com/pythonnet/pythonnet/pull/1672
+[p2015]: https://github.com/pythonnet/pythonnet/pull/2015

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -282,19 +282,6 @@ namespace Python.Runtime
                 return true;
             }
 
-            if (typeof(System.Delegate).IsAssignableFrom(obType))
-            {
-                result = null;
-                if (Runtime.PyCallable_Check(value) < 1)
-                {
-                    Exceptions.SetError(Exceptions.TypeError, "object must be callable");
-                    return false;
-                }
-
-                result = PythonEngine.DelegateManager.GetDelegate(obType, new PyObject(value));
-                return true;
-            }
-
             if (obType.IsSubclassOf(typeof(PyObject))
                 && !obType.IsAbstract
                 && obType.GetConstructor(new[] { typeof(PyObject) }) is { } ctor)
@@ -337,6 +324,20 @@ namespace Python.Runtime
 
                 default:
                     throw new ArgumentException("We should never receive instances of other managed types");
+            }
+
+            // NOTE: generate a delegate to cast a python callable into a System.Delegate
+            if (typeof(System.Delegate).IsAssignableFrom(obType))
+            {
+                result = null;
+                if (Runtime.PyCallable_Check(value) < 1)
+                {
+                    Exceptions.SetError(Exceptions.TypeError, "object must be callable");
+                    return false;
+                }
+
+                result = PythonEngine.DelegateManager.GetDelegate(obType, new PyObject(value));
+                return true;
             }
 
             if (value == Runtime.PyNone && !obType.IsValueType)

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -282,6 +282,19 @@ namespace Python.Runtime
                 return true;
             }
 
+            if (typeof(System.Delegate).IsAssignableFrom(obType))
+            {
+                result = null;
+                if (Runtime.PyCallable_Check(value) < 1)
+                {
+                    Exceptions.SetError(Exceptions.TypeError, "object must be callable");
+                    return false;
+                }
+
+                result = PythonEngine.DelegateManager.GetDelegate(obType, new PyObject(value));
+                return true;
+            }
+
             if (obType.IsSubclassOf(typeof(PyObject))
                 && !obType.IsAbstract
                 && obType.GetConstructor(new[] { typeof(PyObject) }) is { } ctor)

--- a/tests/test_delegate_implicit.py
+++ b/tests/test_delegate_implicit.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+"""Test CLR delegate support."""
+
+import Python.Test as Test
+import System
+import pytest
+from Python.Test import DelegateTest, StringDelegate
+
+from .utils import HelloClass, hello_func, MultipleHandler, DictProxyType
+
+
+def test_delegate_implicit_from_function():
+    """Test delegate implemented with a Python function."""
+
+    d = hello_func
+    assert d() == "hello"
+
+    ob = DelegateTest()
+    assert ob.CallStringDelegate(d) == "hello"
+
+
+def test_delegate_implicit_from_method():
+    """Test delegate implemented with a Python instance method."""
+
+    inst = HelloClass()
+    d = inst.hello
+    assert d() == "hello"
+
+    ob = DelegateTest()
+    assert ob.CallStringDelegate(d) == "hello"
+
+
+def test_delegate_implicit_from_static_method():
+    """Test delegate implemented with a Python static method."""
+
+    d = HelloClass.s_hello
+    assert d() == "hello"
+
+    ob = DelegateTest()
+    assert ob.CallStringDelegate(d) == "hello"
+
+
+def test_delegate_implicit_from_class_method():
+    """Test delegate implemented with a Python class method."""
+
+    d = HelloClass.c_hello
+    assert d() == "hello"
+
+    ob = DelegateTest()
+    assert ob.CallStringDelegate(d) == "hello"
+
+
+def test_delegate_from_callable():
+    """Test delegate implemented with a Python callable object."""
+
+    inst = HelloClass()
+    d = inst
+    assert d() == "hello"
+
+    ob = DelegateTest()
+    assert ob.CallStringDelegate(d) == "hello"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When a dotnet method requries a delegate as a parameter, pythonnet fails to convert a python function into a dotnet delegate

```csharp
  public delegate void DelegateHandler(int first, float second);

  public static class DelegateParameterTest
  {
    public static void DoSomething(DelegateHandler handler) => handler(1, 2);
  }
```

⚠️  This will fail:
```python
from PyNetTests import DelegateParameterTest

def Handler(first, second):
	print(first, second)

DelegateParameterTest.DoSomething(Handler)
```

### Does this close any currently open issues?

Not that I know of

### Any other comments?

No

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [X] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
