### PR TITLE
1776 Generic Virtual Method Causes Invalid Program: Fix + test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Fixed
 
+- Fixed error occuring when inheriting a class containing a virtual generic method.
+
 ## [3.0.1](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.1) - 2022-11-03
 
 ### Added

--- a/src/python_tests_runner/PythonTestRunner.cs
+++ b/src/python_tests_runner/PythonTestRunner.cs
@@ -35,7 +35,6 @@ namespace Python.PythonTestsRunner
             // Add the test that you want to debug here.
             yield return new[] { "test_indexer", "test_boolean_indexer" };
             yield return new[] { "test_delegate", "test_bool_delegate" };
-            yield return new[] { "test_subclass", "test_virtual_generic_method" };
         }
 
         /// <summary>

--- a/src/python_tests_runner/PythonTestRunner.cs
+++ b/src/python_tests_runner/PythonTestRunner.cs
@@ -35,6 +35,7 @@ namespace Python.PythonTestsRunner
             // Add the test that you want to debug here.
             yield return new[] { "test_indexer", "test_boolean_indexer" };
             yield return new[] { "test_delegate", "test_bool_delegate" };
+            yield return new[] { "test_subclass", "test_virtual_generic_method" };
         }
 
         /// <summary>

--- a/src/runtime/Types/ClassDerived.cs
+++ b/src/runtime/Types/ClassDerived.cs
@@ -220,7 +220,10 @@ namespace Python.Runtime
             foreach (MethodInfo method in methods)
             {
                 if (!method.Attributes.HasFlag(MethodAttributes.Virtual) |
-                    method.Attributes.HasFlag(MethodAttributes.Final))
+                    method.Attributes.HasFlag(MethodAttributes.Final)
+                    // overriding generic virtual methods is not supported
+                    // so a call to that should be deferred to the base class method.
+                    || method.IsGenericMethod)
                 {
                     continue;
                 }

--- a/src/testing/generictest.cs
+++ b/src/testing/generictest.cs
@@ -136,4 +136,12 @@ namespace Python.Test
             return items;
         }
     }
+
+    public abstract class GenericVirtualMethodTest
+    {
+        public virtual Q VirtMethod<Q>(Q arg1)
+        {
+            return arg1;
+        }
+    }
 }

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -9,7 +9,7 @@
 import System
 import pytest
 from Python.Test import (IInterfaceTest, SubClassTest, EventArgsTest,
-                         FunctionsTest, IGenericInterface)
+                         FunctionsTest, IGenericInterface, GenericVirtualMethodTest)
 from System.Collections.Generic import List
 
 
@@ -327,3 +327,15 @@ def test_generic_interface():
     obj = GenericInterfaceImpl()
     SpecificInterfaceUser(obj, Int32(0))
     GenericInterfaceUser[Int32](obj, Int32(0))
+
+def test_virtual_generic_method():
+    class OverloadingSubclass(GenericVirtualMethodTest):
+        __namespace__ = "test_virtual_generic_method_cls"
+    class OverloadingSubclass2(OverloadingSubclass):
+        __namespace__ = "test_virtual_generic_method_cls"
+    obj = OverloadingSubclass()
+    assert obj.VirtMethod[int](5) == 5
+    obj = OverloadingSubclass2()
+    assert obj.VirtMethod[int](5) == 5
+
+


### PR DESCRIPTION
- If a method is virtual AND generic, it cannot be overridden by the python class. Hence the method call is deferred to the base class.
- Added a unit test which verifies this behavior is now working.

Close #1776 

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [X] If an enhancement PR, please create docs and at best an example
-   [X] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
