### PR TITLE
1783 Implement Interface And Inherit Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Fixed error occuring when inheriting a class containing a virtual generic method.
 -   Make a second call to `pythonnet.load` a no-op, as it was intended.
 
+- Added support for multiple inheritance when inheriting from a class and/or multiple interfaces.
+
 ## [3.0.1](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.1) - 2022-11-03
 
 ### Added

--- a/src/python_tests_runner/PythonTestRunner.cs
+++ b/src/python_tests_runner/PythonTestRunner.cs
@@ -35,6 +35,7 @@ namespace Python.PythonTestsRunner
             // Add the test that you want to debug here.
             yield return new[] { "test_indexer", "test_boolean_indexer" };
             yield return new[] { "test_delegate", "test_bool_delegate" };
+            yield return new[] { "test_subclass", "test_implement_interface_and_class" };
         }
 
         /// <summary>

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1836,6 +1836,12 @@ namespace Python.Runtime
                 return *Delegates.Py_NoSiteFlag;
             });
         }
+
+        internal static uint PyTuple_GetSize(BorrowedReference tuple)
+        {
+            IntPtr r = Delegates.PyTuple_Size(tuple);
+            return (uint)r.ToInt32();
+        }
     }
 
     internal class BadPythonDllException : MissingMethodException

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -1836,12 +1836,6 @@ namespace Python.Runtime
                 return *Delegates.Py_NoSiteFlag;
             });
         }
-
-        internal static uint PyTuple_GetSize(BorrowedReference tuple)
-        {
-            IntPtr r = Delegates.PyTuple_Size(tuple);
-            return (uint)r.ToInt32();
-        }
     }
 
     internal class BadPythonDllException : MissingMethodException

--- a/src/runtime/StateSerialization/MaybeType.cs
+++ b/src/runtime/StateSerialization/MaybeType.cs
@@ -15,7 +15,7 @@ namespace Python.Runtime
         const string SerializationName = "n";
         readonly string name;
         readonly Type type;
-        
+
         public string DeletedMessage
         {
             get

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -374,7 +374,7 @@ namespace Python.Runtime
             return new PyTuple(bases);
         }
 
-        internal static NewReference CreateSubType(BorrowedReference py_name, IList<ClassBase> py_base_type, IList<Type> interfaces, BorrowedReference dictRef)
+        internal static NewReference CreateSubType(BorrowedReference py_name, ClassBase py_base_type, IList<Type> interfaces, BorrowedReference dictRef)
         {
             // Utility to create a subtype of a managed type with the ability for the
             // a python subtype able to override the managed implementation
@@ -415,9 +415,7 @@ namespace Python.Runtime
             }
 
             // create the new managed type subclassing the base managed type
-            var baseClass = py_base_type.FirstOrDefault();
-
-            return ReflectedClrType.CreateSubclass(baseClass, interfaces, name,
+            return ReflectedClrType.CreateSubclass(py_base_type, interfaces, name,
                 ns: (string?)namespaceStr,
                 assembly: (string?)assembly,
                 dict: dictRef);

--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -374,7 +374,7 @@ namespace Python.Runtime
             return new PyTuple(bases);
         }
 
-        internal static NewReference CreateSubType(BorrowedReference py_name, BorrowedReference py_base_type, BorrowedReference dictRef)
+        internal static NewReference CreateSubType(BorrowedReference py_name, IList<ClassBase> py_base_type, IList<Type> interfaces, BorrowedReference dictRef)
         {
             // Utility to create a subtype of a managed type with the ability for the
             // a python subtype able to override the managed implementation
@@ -415,17 +415,12 @@ namespace Python.Runtime
             }
 
             // create the new managed type subclassing the base managed type
-            if (ManagedType.GetManagedObject(py_base_type) is ClassBase baseClass)
-            {
-                return ReflectedClrType.CreateSubclass(baseClass, name,
-                                                       ns: (string?)namespaceStr,
-                                                       assembly: (string?)assembly,
-                                                       dict: dictRef);
-            }
-            else
-            {
-                return Exceptions.RaiseTypeError("invalid base class, expected CLR class type");
-            }
+            var baseClass = py_base_type.FirstOrDefault();
+
+            return ReflectedClrType.CreateSubclass(baseClass, interfaces, name,
+                ns: (string?)namespaceStr,
+                assembly: (string?)assembly,
+                dict: dictRef);
         }
 
         internal static IntPtr WriteMethodDef(IntPtr mdef, IntPtr name, IntPtr func, PyMethodFlags flags, IntPtr doc)

--- a/src/runtime/Types/ReflectedClrType.cs
+++ b/src/runtime/Types/ReflectedClrType.cs
@@ -68,7 +68,7 @@ internal sealed class ReflectedClrType : PyType
         TypeManager.InitializeClass(this, cb, cb.type.Value);
     }
 
-    internal static NewReference CreateSubclass(ClassBase baseClass,
+    internal static NewReference CreateSubclass(ClassBase baseClass, IList<Type> interfaces,
                                                 string name, string? assembly, string? ns,
                                                 BorrowedReference dict)
     {
@@ -76,6 +76,7 @@ internal sealed class ReflectedClrType : PyType
         {
             Type subType = ClassDerivedObject.CreateDerivedType(name,
                 baseClass.type.Value,
+                interfaces,
                 dict,
                 ns,
                 assembly);

--- a/src/testing/classtest.cs
+++ b/src/testing/classtest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 
 namespace Python.Test
@@ -58,5 +59,16 @@ namespace Python.Test
 
     internal class InternalClass
     {
+    }
+
+    public class SimpleClass
+    {
+        public static void TestObject(object obj)
+        {
+            if ((!(obj is ISayHello1 && obj is SimpleClass)))
+            {
+                throw new Exception("Expected ISayHello and SimpleClass instance");
+            }
+        }
     }
 }

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -9,7 +9,7 @@
 import System
 import pytest
 from Python.Test import (IInterfaceTest, SubClassTest, EventArgsTest,
-                         FunctionsTest, IGenericInterface, GenericVirtualMethodTest)
+                         FunctionsTest, IGenericInterface, GenericVirtualMethodTest, SimpleClass, ISayHello1)
 from System.Collections.Generic import List
 
 
@@ -338,4 +338,9 @@ def test_virtual_generic_method():
     obj = OverloadingSubclass2()
     assert obj.VirtMethod[int](5) == 5
 
-
+def test_implement_interface_and_class():
+    class DualSubClass0(ISayHello1, SimpleClass):
+        __namespace__ = "Test"
+        def SayHello(self):
+            return "hello"
+    obj = DualSubClass0()


### PR DESCRIPTION
Added support for multiple inheritance when inheriting from one base class and/or multiple interfaces.

Added a unit test verifying that it works with a simple class and interface. This unit test would previously have failed since multiple types are in the class super class list.

Close #1783

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [X] If an enhancement PR, please create docs and at best an example
-   [X] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
