### PR TITLE
1768 .NET Attribute Support: Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ## [Unreleased][]
 
 ### Added
+-   Support for using .NET attributes for python defined classes, properties and methods.
 
 ### Changed
 

--- a/src/runtime/PythonTypes/PyObject.cs
+++ b/src/runtime/PythonTypes/PyObject.cs
@@ -25,7 +25,7 @@ namespace Python.Runtime
         /// Trace stack for PyObject's construction
         /// </summary>
         public StackTrace Traceback { get; } = new StackTrace(1);
-#endif  
+#endif
 
         protected IntPtr rawPtr = IntPtr.Zero;
         internal readonly int run = Runtime.GetRun();
@@ -165,7 +165,7 @@ namespace Python.Runtime
         {
             if (!Converter.ToManaged(obj, t, out var result, true))
             {
-                throw new InvalidCastException("cannot convert object to target type",
+                throw new InvalidCastException($"Cannot convert object to target type '{t}'.",
                     PythonException.FetchCurrentOrNull(out _));
             }
             return result;
@@ -235,7 +235,7 @@ namespace Python.Runtime
         {
             GC.SuppressFinalize(this);
             Dispose(true);
-            
+
         }
 
         internal StolenReference Steal()
@@ -1325,7 +1325,7 @@ namespace Python.Runtime
             }
             return true;
         }
-        
+
         public override bool TryBinaryOperation(BinaryOperationBinder binder, object arg, out object? result)
         {
             using var _ = Py.GIL();

--- a/src/testing/classtest.cs
+++ b/src/testing/classtest.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections;
+using Python.Runtime;
 
 namespace Python.Test
 {
@@ -58,5 +60,41 @@ namespace Python.Test
 
     internal class InternalClass
     {
+    }
+
+    public class TestAttributeAttribute : Attribute
+    {
+        public int Arg1 { get; }
+        public string Arg2 { get;}
+        public int Arg3 { get; set; }
+        public IntEnum Arg4 { get; set; }
+        public TestAttributeAttribute()
+        {
+
+        }
+        public TestAttributeAttribute(int arg1)
+        {
+            Arg1 = arg1;
+        }
+        public TestAttributeAttribute(int arg1, string arg2)
+        {
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public TestAttributeAttribute(int arg1, int arg2)
+        {
+            Arg1 = arg1;
+            Arg2 = arg2.ToString();
+        }
+
+        public static void Verify(object x, int arg1 = 1, string arg2 = "2")
+        {
+            var attr = x.GetType().GetCustomAttribute<TestAttributeAttribute>();
+            if (attr.Arg1 != arg1) throw new Exception("Verification failed");
+            if (attr.Arg2 != arg2) throw new Exception("Verification failed");
+            if (attr.Arg3 != 3) throw new Exception("Verification failed");
+            if (attr.Arg4 != IntEnum.Four) throw new Exception("Verification failed");
+        }
     }
 }

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# TODO: Add tests for ClassicClass, NewStyleClass?
+
+"""Test CLR class support."""
+
+import clr
+import Python.Test as Test
+from Python.Test import TestAttribute, TestAttributeAttribute, IntEnum
+import System
+import pytest
+
+from .utils import DictProxyType
+def test_class_attributes():
+    class TestObjectWithAttr(System.Object):
+        __namespace__ = "test_clr_attributes"
+        __clr_attributes__ = [TestAttribute(1, "2", Arg3 = 3, Arg4 = IntEnum.Four)]
+    class TestObjectWithAttr2(System.Object):
+            __namespace__ = "test_clr_attributes"
+            __clr_attributes__ = [TestAttribute(Arg3 = 3, Arg4 = IntEnum.Four)]
+    v = TestObjectWithAttr()
+    v2 = TestObjectWithAttr2()
+    TestAttributeAttribute.Verify(v)
+    TestAttributeAttribute.Verify(v2, 0, None)
+


### PR DESCRIPTION
- Added support for specifying .NET attributes using __clr_attributes__. Classes, properties and methods can specify this value.

- Added support for Attribute shorthand without  the "Attribute" ending.

- Added unit test verifying the behavior

Close #1768

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [X] If an enhancement PR, please create docs and at best an example
-   [X] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
