### PR TITLE
Workaround for Ubuntu-provided package version being unsupported

### DIFF
--- a/.github/workflows/ARM.yml
+++ b/.github/workflows/ARM.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade -r requirements.txt
+          pip install -r requirements.txt
           pip install pytest numpy # for tests
 
       - name: Build and Install

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ codecov
 
 wheel
 pycparser
-setuptools
-clr-loader
+clr-loader==0.2.*
 
 # Discover libpython
-find_libpython
+find_libpython==0.3.*


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

`setuptools` 66+ removed support for some formats of package version suffixes.

This change skips forced `setuptools` upgrade on our runners at least until Ubuntu changes their package name format.

### Does this close any currently open issues?

[This pull request](https://github.com/pythonnet/pythonnet/pull/2079) can not proceed due to this failure

### Any other comments?

see https://github.com/pypa/setuptools/issues/3772
