### PR TITLE
Fix `GetBuffer` throwing `ArgumentOutOfRangeException`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -85,3 +85,4 @@
 -   ([@alxnull](https://github.com/alxnull))
 -   ([@gpetrou](https://github.com/gpetrou))
 -   Ehsan Iran-Nejad ([@eirannejad](https://github.com/eirannejad))
+-   ([@legomanww](https://github.com/legomanww))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 -   Make a second call to `pythonnet.load` a no-op, as it was intended.
 
 - Added support for multiple inheritance when inheriting from a class and/or multiple interfaces.
+- Fixed error occuring when calling `GetBuffer` for anything other than `PyBUF.SIMPLE` 
 
 ## [3.0.1](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.1) - 2022-11-03
 

--- a/src/runtime/PythonTypes/PyBuffer.cs
+++ b/src/runtime/PythonTypes/PyBuffer.cs
@@ -11,7 +11,7 @@ namespace Python.Runtime
         private PyObject _exporter;
         private Py_buffer _view;
 
-        unsafe internal PyBuffer(PyObject exporter, PyBUF flags)
+        internal PyBuffer(PyObject exporter, PyBUF flags)
         {
             _view = new Py_buffer();
 
@@ -25,17 +25,17 @@ namespace Python.Runtime
             var intPtrBuf = new IntPtr[_view.ndim];
             if (_view.shape != IntPtr.Zero)
             {
-                Marshal.Copy(_view.shape, intPtrBuf, 0, (int)_view.len * sizeof(IntPtr));
+                Marshal.Copy(_view.shape, intPtrBuf, 0, _view.ndim);
                 Shape = intPtrBuf.Select(x => (long)x).ToArray();
             }
 
             if (_view.strides != IntPtr.Zero) {
-                Marshal.Copy(_view.strides, intPtrBuf, 0, (int)_view.len * sizeof(IntPtr));
+                Marshal.Copy(_view.strides, intPtrBuf, 0, _view.ndim);
                 Strides = intPtrBuf.Select(x => (long)x).ToArray();
             }
 
             if (_view.suboffsets != IntPtr.Zero) {
-                Marshal.Copy(_view.suboffsets, intPtrBuf, 0, (int)_view.len * sizeof(IntPtr));
+                Marshal.Copy(_view.suboffsets, intPtrBuf, 0, _view.ndim);
                 SubOffsets = intPtrBuf.Select(x => (long)x).ToArray();
             }
         }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

PyBuffer throws `System.ArgumentOutOfRangeException` when trying to use `GetBuffer()` with anything other than `PyBUF.SIMPLE` since the `Marshal.Copy` calls had a typos so it was trying to copy `shape`, `strides`, and `suboffsets` as arrays that were the full length of the source array instead of length `ndim`.

### Does this close any currently open issues?

no

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet) <- doesn't seem to be working
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
