### PR TITLE
change PyScope to PyModule

### DIFF
--- a/doc/source/dotnet.rst
+++ b/doc/source/dotnet.rst
@@ -110,7 +110,7 @@ Code executed from the scope will have access to the variable:
    using (Py.GIL())
    {
        // create a Python scope
-       using (PyScope scope = Py.CreateScope())
+       using (PyModule scope = Py.CreateScope())
        {
            // convert the Person object to a PyObject
            PyObject pyPerson = person.ToPython();


### PR DESCRIPTION


### What does this implement/fix? Explain your changes.
Changes in documentation. PyScope data type not found. Py.CreateScope() returns the variable of type PyModule.
...

### Does this close any currently open issues?
No
...