### PR TITLE
use enum name in repr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Added
 
+- use enum name in repr
+
 ### Changed
 
 ### Fixed

--- a/src/runtime/Types/ClassObject.cs
+++ b/src/runtime/Types/ClassObject.cs
@@ -49,6 +49,26 @@ namespace Python.Runtime
 
 
         /// <summary>
+        /// given an enum, write a __repr__ string formatted in the same
+        /// way as a python repr string. Something like:
+        ///   '&lt;Color.GREEN: 2&gt;';
+        /// with a binary value for [Flags] enums
+        /// </summary>
+        /// <param name="inst">Instace of the enum object</param>
+        /// <returns></returns>
+        private static string getEnumReprString(object inst)
+        {
+            var obType = inst.GetType();
+
+            var isFlags = obType.IsFlagsEnum();
+            var intValue = Convert.ToInt32(inst);
+            var intStr = isFlags ? "0x" + intValue.ToString("X4") : intValue.ToString();
+
+            var repr = $"<{obType.Name}.{inst}: {intStr}>";
+            return repr;
+        }
+
+        /// <summary>
         /// ClassObject __repr__ implementation.
         /// </summary>
         public new static NewReference tp_repr(BorrowedReference ob)
@@ -57,13 +77,9 @@ namespace Python.Runtime
             {
                 return Exceptions.RaiseTypeError("invalid object");
             }
-
-            var inst = co.inst;
-            var obType = inst.GetType();
-            if (obType.IsEnum)
+            if (co.inst.GetType().IsEnum)
             {
-                var repr = string.Format("{0}.{1}", obType.Name, inst.ToString());
-                return Runtime.PyString_FromString(repr);
+                return Runtime.PyString_FromString(getEnumReprString(co.inst));
             }
 
             return ClassBase.tp_repr(ob);

--- a/src/runtime/Types/ClassObject.cs
+++ b/src/runtime/Types/ClassObject.cs
@@ -49,6 +49,27 @@ namespace Python.Runtime
 
 
         /// <summary>
+        /// ClassObject __repr__ implementation.
+        /// </summary>
+        public new static NewReference tp_repr(BorrowedReference ob)
+        {
+            if (GetManagedObject(ob) is not CLRObject co)
+            {
+                return Exceptions.RaiseTypeError("invalid object");
+            }
+
+            var inst = co.inst;
+            var obType = inst.GetType();
+            if (obType.IsEnum)
+            {
+                var repr = string.Format("{0}.{1}", obType.Name, inst.ToString());
+                return Runtime.PyString_FromString(repr);
+            }
+
+            return ClassBase.tp_repr(ob);
+        }
+
+        /// <summary>
         /// Implements __new__ for reflected classes and value types.
         /// </summary>
         static NewReference tp_new_impl(BorrowedReference tp, BorrowedReference args, BorrowedReference kw)

--- a/src/runtime/Types/ClassObject.cs
+++ b/src/runtime/Types/ClassObject.cs
@@ -60,11 +60,50 @@ namespace Python.Runtime
         {
             var obType = inst.GetType();
 
+            var integralType = obType.GetEnumUnderlyingType();
             var isFlags = obType.IsFlagsEnum();
-            var intValue = Convert.ToInt32(inst);
-            var intStr = isFlags ? "0x" + intValue.ToString("X4") : intValue.ToString();
 
-            var repr = $"<{obType.Name}.{inst}: {intStr}>";
+            string strValue = "";
+            switch (Type.GetTypeCode(integralType))
+            {
+                case TypeCode.SByte:
+                    var valueSB = Convert.ToSByte(inst);
+                    strValue = isFlags ? "0x" + valueSB.ToString("X2") : valueSB.ToString();
+                    break;
+                case TypeCode.Byte:
+                    var valueB = Convert.ToByte(inst);
+                    strValue = isFlags ? "0x" + valueB.ToString("X2") : valueB.ToString();
+                    break;
+                case TypeCode.Int16:
+                    var valueI16 = Convert.ToInt16(inst);
+                    strValue = isFlags ? "0x" + valueI16.ToString("X4") : valueI16.ToString();
+                    break;
+                case TypeCode.UInt16:
+                    var valueUI16 = Convert.ToUInt16(inst);
+                    strValue = isFlags ? "0x" + valueUI16.ToString("X4") : valueUI16.ToString();
+                    break;
+                case TypeCode.Int32:
+                    var valueI32 = Convert.ToInt32(inst);
+                    strValue = isFlags ? "0x" + valueI32.ToString("X8") : valueI32.ToString();
+                    break;
+                case TypeCode.UInt32:
+                    var valueUI32 = Convert.ToUInt32(inst);
+                    strValue = isFlags ? "0x" + valueUI32.ToString("X8") : valueUI32.ToString();
+                    break;
+                case TypeCode.Int64:
+                    var valueI64 = Convert.ToInt64(inst);
+                    strValue = isFlags ? "0x" + valueI64.ToString("X16") : valueI64.ToString();
+                    break;
+                case TypeCode.UInt64:
+                    var valueUI64 = Convert.ToUInt64(inst);
+                    strValue = isFlags ? "0x" + valueUI64.ToString("X16") : valueUI64.ToString();
+                    break;
+                default:
+                    break;
+            }
+
+
+            var repr = $"<{obType.Name}.{inst}: {strValue}>";
             return repr;
         }
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -147,7 +147,7 @@ def test_enum_repr():
     """Test enumeration repr."""
     from System import DayOfWeek
 
-    assert repr(DayOfWeek.Monday) == "Monday"
+    assert repr(DayOfWeek.Monday) == "DayOfWeek.Monday"
 
 
 def test_enum_conversion():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -149,8 +149,8 @@ def test_enum_repr():
 
     assert repr(DayOfWeek.Monday) == "<DayOfWeek.Monday: 1>"
 
-    flags_value = Test.FlagsEnum.One | Test.FlagsEnum.Two
-    assert repr(flags_value) == "<FlagsEnum.One, Two: 0x0003>"
+    assert repr(Test.FlagsEnum(7)) == "<FlagsEnum.Two, Five: 0x0007>"
+    assert repr(Test.FlagsEnum(8)) == "<FlagsEnum.8: 0x0008>"
 
 
 def test_enum_conversion():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -147,7 +147,10 @@ def test_enum_repr():
     """Test enumeration repr."""
     from System import DayOfWeek
 
-    assert repr(DayOfWeek.Monday) == "DayOfWeek.Monday"
+    assert repr(DayOfWeek.Monday) == "<DayOfWeek.Monday: 1>"
+
+    flags_value = Test.FlagsEnum.One | Test.FlagsEnum.Two
+    assert repr(flags_value) == "<FlagsEnum.One, Two: 0x0003>"
 
 
 def test_enum_conversion():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -150,7 +150,7 @@ def test_enum_repr():
     assert repr(DayOfWeek.Monday) == "<DayOfWeek.Monday: 1>"
 
     assert repr(Test.FlagsEnum(7)) == "<FlagsEnum.Two, Five: 0x0007>"
-    assert repr(Test.FlagsEnum(8)) == "<FlagsEnum.8: 0x0008>"
+    assert repr(Test.FlagsEnum(8)) == "<FlagsEnum.8: 0x00000008>"
 
 
 def test_enum_conversion():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -143,6 +143,13 @@ def test_enum_undefined_value():
     Test.FieldTest().EnumField = Test.ShortEnum(20, True)
 
 
+def test_enum_repr():
+    """Test enumeration repr."""
+    from System import DayOfWeek
+
+    assert repr(DayOfWeek.Monday) == "Monday"
+
+
 def test_enum_conversion():
     """Test enumeration conversion."""
     ob = Test.FieldTest()

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -149,7 +149,7 @@ def test_enum_repr():
 
     assert repr(DayOfWeek.Monday) == "<DayOfWeek.Monday: 1>"
 
-    assert repr(Test.FlagsEnum(7)) == "<FlagsEnum.Two, Five: 0x0007>"
+    assert repr(Test.FlagsEnum(7)) == "<FlagsEnum.Two, Five: 0x00000007>"
     assert repr(Test.FlagsEnum(8)) == "<FlagsEnum.8: 0x00000008>"
 
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Proposal to fix #2238

## Before the changes:

```
Python 3.11.4 (tags/v3.11.4:d2340ef, Jun  7 2023, 05:45:37) [MSC v.1934 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import clr; import System
>>> System.DayOfWeek.Monday
<System.DayOfWeek object at 0x0000024D5BAC7300>
```

## IronPython (as a reference):

```
IronPython 2.7.4 (2.7.0.40) on .NET 4.0.30319.42000 (64-bit)
Type "help", "copyright", "credits" or "license" for more information.
>>> import System
>>> System.DayOfWeek.Monday
System.DayOfWeek.Monday
```

## With these changes:

```
Python 3.11.4 (tags/v3.11.4:d2340ef, Jun  7 2023, 05:45:37) [MSC v.1934 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import clr; import System
>>> System.DayOfWeek.Monday
DayOfWeek.Monday
```

### Checklist

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
