### PR TITLE
Improve loader robustness 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -86,3 +86,4 @@
 -   ([@gpetrou](https://github.com/gpetrou))
 -   Ehsan Iran-Nejad ([@eirannejad](https://github.com/eirannejad))
 -   ([@legomanww](https://github.com/legomanww))
+-   Effendi Soewono ([@sefgit](https://github.com/sefgit))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Fixed
 
+- Improve loader (AddReference) robustness. Ignore and print loader error and try to continue to load if possible.
 
 ## [3.0.3](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.3) - 2023-10-11
 

--- a/src/runtime/AssemblyManager.cs
+++ b/src/runtime/AssemblyManager.cs
@@ -416,7 +416,7 @@ namespace Python.Runtime
                     // Return all types that were successfully loaded
                     foreach (var item in exc.LoaderExceptions)
                     {
-                        System.Console.Error.WriteLine("[pythonnet] {0}", item.Message);
+                        Debug.WriteLine("[pythonnet] {0}", item.Message);
                     }
                     return exc.Types.Where(x => x != null && IsExported(x)).ToArray();
                 }
@@ -429,7 +429,7 @@ namespace Python.Runtime
                 }
                 catch (FileNotFoundException)
                 {
-                    System.Console.Error.WriteLine("[pythonnet] {0} File not found", a.GetName());
+                    Debug.WriteLine("[pythonnet] {0} File not found", a.GetName());
                     return new Type[0];
                 }
                 catch (System.TypeLoadException e)
@@ -442,7 +442,7 @@ namespace Python.Runtime
                     {
                         foreach (var item in exc.LoaderExceptions)
                         {
-                            System.Console.Error.WriteLine("[pythonnet] {0}", item.Message);
+                            Debug.WriteLine("[pythonnet] {0}", item.Message);
                         }
                         // Return all types that were successfully loaded
                         return exc.Types.Where(x => x != null && IsExported(x)).ToArray();
@@ -450,7 +450,7 @@ namespace Python.Runtime
                 }
                 catch (Exception e) // System.TypeLoadException
                 {
-                    System.Console.Error.WriteLine("[pythonnet] {0} {1}", a.GetName(), e);
+                    Debug.WriteLine("[pythonnet] {0} {1}", a.GetName(), e);
                     return new Type[0];
                 }
 

--- a/src/runtime/AssemblyManager.cs
+++ b/src/runtime/AssemblyManager.cs
@@ -414,6 +414,10 @@ namespace Python.Runtime
                 catch (ReflectionTypeLoadException exc)
                 {
                     // Return all types that were successfully loaded
+                    foreach (var item in exc.LoaderExceptions)
+                    {
+                        System.Console.Error.WriteLine("[pythonnet] {0}", item.Message);
+                    }
                     return exc.Types.Where(x => x != null && IsExported(x)).ToArray();
                 }
             }
@@ -425,8 +429,31 @@ namespace Python.Runtime
                 }
                 catch (FileNotFoundException)
                 {
+                    System.Console.Error.WriteLine("[pythonnet] {0} File not found", a.GetName());
                     return new Type[0];
                 }
+                catch (System.TypeLoadException e)
+                {
+                    try
+                    {
+                        return a.GetTypes().Where(IsExported).ToArray();
+                    }
+                    catch (ReflectionTypeLoadException exc)
+                    {
+                        foreach (var item in exc.LoaderExceptions)
+                        {
+                            System.Console.Error.WriteLine("[pythonnet] {0}", item.Message);
+                        }
+                        // Return all types that were successfully loaded
+                        return exc.Types.Where(x => x != null && IsExported(x)).ToArray();
+                    }
+                }
+                catch (Exception e) // System.TypeLoadException
+                {
+                    System.Console.Error.WriteLine("[pythonnet] {0} {1}", a.GetName(), e);
+                    return new Type[0];
+                }
+
             }
         }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Ignore and print loader error and proceed with loading if possible.

There are cases where
 "import <namespace>" in python failed even when clr.AddReference() succeeded, especially when loading "manipulated (probably protected/obfuscated)" C# DLL.

### Does this close any currently open issues?

unknown

### Any other comments?



### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [X] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
