### PR TITLE
 #2240 Recursion error when doing reversed python operations on C# types

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -86,3 +86,4 @@
 -   ([@gpetrou](https://github.com/gpetrou))
 -   Ehsan Iran-Nejad ([@eirannejad](https://github.com/eirannejad))
 -   ([@legomanww](https://github.com/legomanww))
+-   ([@gertdreyer](https://github.com/gertdreyer))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Fixed
 
+-   Fixed RecursionError for reverse operators on C# operable types from python. See #2240
 
 ## [3.0.3](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.3) - 2023-10-11
 

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -41,6 +41,17 @@ namespace Python.EmbeddingTest
                 _value = value;
             }
 
+            public override int GetHashCode()
+            {
+                return unchecked(65535 + _value.GetHashCode());
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is OwnInt @object &&
+                       Num == @object.Num;
+            }
+
             public static OwnInt operator -(OwnInt p1, OwnInt p2)
             {
                 return new OwnInt(p1._value - p2._value);
@@ -125,14 +136,8 @@ namespace Python.EmbeddingTest
                 return objectType.Name == "int" && targetType == typeof(OwnInt);
             }
 
-            public bool TryDecode<T>(PyObject pyObj, out T? value)
+            public bool TryDecode<T>(PyObject pyObj, out T value)
             {
-                if (pyObj.PyType.Name != "int" || typeof(T) != typeof(OwnInt))
-                {
-                    value = default(T);
-                    return false;
-                }
-
                 value = (T)(object)new OwnInt(pyObj.As<int>());
                 return true;
             }

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -25,9 +25,9 @@ namespace Python.EmbeddingTest
         }
 
         // Mock Integer class to test math ops on non-native dotnet types
-        public struct OwnInt
+        public readonly struct OwnInt
         {
-            private int _value;
+            private readonly int _value;
 
             public int Num => _value;
 

--- a/src/embed_tests/TestOperator.cs
+++ b/src/embed_tests/TestOperator.cs
@@ -15,12 +15,127 @@ namespace Python.EmbeddingTest
         public void SetUp()
         {
             PythonEngine.Initialize();
+            OwnIntCodec.Setup();
         }
 
         [OneTimeTearDown]
         public void Dispose()
         {
             PythonEngine.Shutdown();
+        }
+
+        // Mock Integer class to test math ops on non-native dotnet types
+        public struct OwnInt
+        {
+            private int _value;
+
+            public int Num => _value;
+
+            public OwnInt()
+            {
+                _value = 0;
+            }
+
+            public OwnInt(int value)
+            {
+                _value = value;
+            }
+
+            public static OwnInt operator -(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value - p2._value);
+            }
+
+            public static OwnInt operator +(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value + p2._value);
+            }
+
+            public static OwnInt operator *(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value * p2._value);
+            }
+
+            public static OwnInt operator /(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value / p2._value);
+            }
+
+            public static OwnInt operator %(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value % p2._value);
+            }
+
+            public static OwnInt operator ^(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value ^ p2._value);
+            }
+
+            public static bool operator <(OwnInt p1, OwnInt p2)
+            {
+                return p1._value < p2._value;
+            }
+
+            public static bool operator >(OwnInt p1, OwnInt p2)
+            {
+                return p1._value > p2._value;
+            }
+
+            public static bool operator ==(OwnInt p1, OwnInt p2)
+            {
+                return p1._value == p2._value;
+            }
+
+            public static bool operator !=(OwnInt p1, OwnInt p2)
+            {
+                return p1._value != p2._value;
+            }
+
+            public static OwnInt operator |(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value | p2._value);
+            }
+
+            public static OwnInt operator &(OwnInt p1, OwnInt p2)
+            {
+                return new OwnInt(p1._value & p2._value);
+            }
+
+            public static bool operator <=(OwnInt p1, OwnInt p2)
+            {
+                return p1._value <= p2._value;
+            }
+
+            public static bool operator >=(OwnInt p1, OwnInt p2)
+            {
+                return p1._value >= p2._value;
+            }
+        }
+
+        // Codec for mock class above.
+        public class OwnIntCodec : IPyObjectDecoder
+        {
+            public static void Setup()
+            {
+                PyObjectConversions.RegisterDecoder(new OwnIntCodec());
+            }
+
+            public bool CanDecode(PyType objectType, Type targetType)
+            {
+                return objectType.Name == "int" && targetType == typeof(OwnInt);
+            }
+
+            public bool TryDecode<T>(PyObject pyObj, out T? value)
+            {
+                if (pyObj.PyType.Name != "int" || typeof(T) != typeof(OwnInt))
+                {
+                    value = default(T);
+                    return false;
+                }
+
+                value = (T)(object)new OwnInt(pyObj.As<int>());
+                return true;
+            }
         }
 
         public class OperableObject
@@ -524,6 +639,121 @@ assert c.Num == a.Num << b.Num
 
 c = a >> b.Num
 assert c.Num == a.Num >> b.Num
+");
+        }
+
+        [Test]
+        public void ReverseOperatorWithCodec()
+        {
+            string name = string.Format("{0}.{1}",
+                typeof(OwnInt).DeclaringType.Name,
+                typeof(OwnInt).Name);
+            string module = MethodBase.GetCurrentMethod().DeclaringType.Namespace;
+
+            PythonEngine.Exec($@"
+from {module} import *
+cls = {name}
+a = 2
+b = cls(10)
+
+c = a + b
+assert c.Num == a + b.Num
+
+c = a - b
+assert c.Num == a - b.Num
+
+c = a * b
+assert c.Num == a * b.Num
+
+c = a / b
+assert c.Num == a // b.Num
+
+c = a % b
+assert c.Num == a % b.Num
+
+c = a & b
+assert c.Num == a & b.Num
+
+c = a | b
+assert c.Num == a | b.Num
+
+c = a ^ b
+assert c.Num == a ^ b.Num
+
+c = a == b
+assert c == (a == b.Num)
+
+c = a != b
+assert c == (a != b.Num)
+
+c = a <= b
+assert c == (a <= b.Num)
+
+c = a >= b
+assert c == (a >= b.Num)
+
+c = a < b
+assert c == (a < b.Num)
+
+c = a > b
+assert c == (a > b.Num)
+");
+        }
+
+        [Test]
+        public void ForwardOperatorWithCodec()
+        {
+            string name = string.Format("{0}.{1}",
+                 typeof(OwnInt).DeclaringType.Name,
+                 typeof(OwnInt).Name);
+            string module = MethodBase.GetCurrentMethod().DeclaringType.Namespace;
+
+            PythonEngine.Exec($@"
+from {module} import *
+cls = {name}
+a = cls(2)
+b = 10
+c = a + b
+assert c.Num == a.Num + b
+
+c = a - b
+assert c.Num == a.Num - b
+
+c = a * b
+assert c.Num == a.Num * b
+
+c = a / b
+assert c.Num == a.Num // b
+
+c = a % b
+assert c.Num == a.Num % b
+
+c = a & b
+assert c.Num == a.Num & b
+
+c = a | b
+assert c.Num == a.Num | b
+
+c = a ^ b
+assert c.Num == a.Num ^ b
+
+c = a == b
+assert c == (a.Num == b)
+
+c = a != b
+assert c == (a.Num != b)
+
+c = a <= b
+assert c == (a.Num <= b)
+
+c = a >= b
+assert c == (a.Num >= b)
+
+c = a < b
+assert c == (a.Num < b)
+
+c = a > b
+assert c == (a.Num > b)
 ");
         }
     }

--- a/src/runtime/ClassManager.cs
+++ b/src/runtime/ClassManager.cs
@@ -546,7 +546,7 @@ namespace Python.Runtime
                         ci.members[pyName] = new MethodObject(type, name, forwardMethods).AllocObject();
                     // Only methods where only the right operand is the declaring type.
                     if (reverseMethods.Length > 0)
-                        ci.members[pyNameReverse] = new MethodObject(type, name, reverseMethods, reverse_args: true).AllocObject();
+                        ci.members[pyNameReverse] = new MethodObject(type, name, reverseMethods, argsReversed: true).AllocObject();
                 }
             }
 

--- a/src/runtime/ClassManager.cs
+++ b/src/runtime/ClassManager.cs
@@ -546,7 +546,7 @@ namespace Python.Runtime
                         ci.members[pyName] = new MethodObject(type, name, forwardMethods).AllocObject();
                     // Only methods where only the right operand is the declaring type.
                     if (reverseMethods.Length > 0)
-                        ci.members[pyNameReverse] = new MethodObject(type, name, reverseMethods).AllocObject();
+                        ci.members[pyNameReverse] = new MethodObject(type, name, reverseMethods, reverse_args: true).AllocObject();
                 }
             }
 

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -34,16 +34,14 @@ namespace Python.Runtime
 
         public bool argsReversed = false;
 
-        internal MethodBinder(bool argsReversed = false)
+        internal MethodBinder()
         {
             list = new List<MaybeMethodBase>();
-            this.argsReversed = argsReversed;
         }
 
-        internal MethodBinder(MethodInfo mi, bool argsReversed = false)
+        internal MethodBinder(MethodInfo mi)
         {
             list = new List<MaybeMethodBase> { new MaybeMethodBase(mi) };
-            this.argsReversed = argsReversed;
         }
 
         public int Count
@@ -276,11 +274,10 @@ namespace Python.Runtime
         /// <param name="inst">The Python target of the method invocation.</param>
         /// <param name="args">The Python arguments.</param>
         /// <param name="kw">The Python keyword arguments.</param>
-        /// <param name="argsReversed">Reverse arguments of methods. Used for methods such as __radd__, __rsub__, __rmod__ etc</param>
         /// <returns>A Binding if successful.  Otherwise null.</returns>
-        internal Binding? Bind(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, bool argsReversed = false)
+        internal Binding? Bind(BorrowedReference inst, BorrowedReference args, BorrowedReference kw)
         {
-            return Bind(inst, args, kw, null, null, argsReversed);
+            return Bind(inst, args, kw, null, null);
         }
 
         /// <summary>
@@ -293,11 +290,10 @@ namespace Python.Runtime
         /// <param name="args">The Python arguments.</param>
         /// <param name="kw">The Python keyword arguments.</param>
         /// <param name="info">If not null, only bind to that method.</param>
-        /// <param name="argsReversed">Reverse arguments of methods. Used for methods such as __radd__, __rsub__, __rmod__ etc</param>
         /// <returns>A Binding if successful.  Otherwise null.</returns>
-        internal Binding? Bind(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info, bool argsReversed = false)
+        internal Binding? Bind(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info)
         {
-            return Bind(inst, args, kw, info, null, argsReversed);
+            return Bind(inst, args, kw, info, null);
         }
 
         private readonly struct MatchedMethod
@@ -341,9 +337,8 @@ namespace Python.Runtime
         /// <param name="kw">The Python keyword arguments.</param>
         /// <param name="info">If not null, only bind to that method.</param>
         /// <param name="methodinfo">If not null, additionally attempt to bind to the generic methods in this array by inferring generic type parameters.</param>
-        /// <param name="argsReversed">Reverse arguments of methods. Used for methods such as __radd__, __rsub__, __rmod__ etc</param>
         /// <returns>A Binding if successful.  Otherwise null.</returns>
-        internal Binding? Bind(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info, MethodBase[]? methodinfo, bool argsReversed = false)
+        internal Binding? Bind(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info, MethodBase[]? methodinfo)
         {
             // loop to find match, return invoker w/ or w/o error
             var kwargDict = new Dictionary<string, PyObject>();
@@ -819,14 +814,14 @@ namespace Python.Runtime
             return match;
         }
 
-        internal virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, bool argsReversed = false)
+        internal virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw)
         {
-            return Invoke(inst, args, kw, null, null, argsReversed);
+            return Invoke(inst, args, kw, null, null);
         }
 
-        internal virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info, bool argsReversed = false)
+        internal virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info)
         {
-            return Invoke(inst, args, kw, info, null, argsReversed = false);
+            return Invoke(inst, args, kw, info, null);
         }
 
         protected static void AppendArgumentTypes(StringBuilder to, BorrowedReference args)
@@ -862,7 +857,7 @@ namespace Python.Runtime
             to.Append(')');
         }
 
-        internal virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info, MethodBase[]? methodinfo, bool argsReversed = false)
+        internal virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, MethodBase? info, MethodBase[]? methodinfo)
         {
             // No valid methods, nothing to bind.
             if (GetMethods().Length == 0)
@@ -875,7 +870,7 @@ namespace Python.Runtime
                 return Exceptions.RaiseTypeError(msg.ToString());
             }
 
-            Binding? binding = Bind(inst, args, kw, info, methodinfo, argsReversed);
+            Binding? binding = Bind(inst, args, kw, info, methodinfo);
             object result;
             IntPtr ts = IntPtr.Zero;
 

--- a/src/runtime/Types/MethodBinding.cs
+++ b/src/runtime/Types/MethodBinding.cs
@@ -238,7 +238,7 @@ namespace Python.Runtime
                     }
                 }
 
-                return self.m.Invoke(target is null ? BorrowedReference.Null : target, args, kw, self.info.UnsafeValue, self.m.binder.argsReversed);
+                return self.m.Invoke(target is null ? BorrowedReference.Null : target, args, kw, self.info.UnsafeValue);
             }
             finally
             {

--- a/src/runtime/Types/MethodBinding.cs
+++ b/src/runtime/Types/MethodBinding.cs
@@ -237,7 +237,8 @@ namespace Python.Runtime
                         }
                     }
                 }
-                return self.m.Invoke(target is null ? BorrowedReference.Null : target, args, kw, self.info.UnsafeValue);
+
+                return self.m.Invoke(target is null ? BorrowedReference.Null : target, args, kw, self.info.UnsafeValue, self.m.binder.args_reversed);
             }
             finally
             {

--- a/src/runtime/Types/MethodBinding.cs
+++ b/src/runtime/Types/MethodBinding.cs
@@ -238,7 +238,7 @@ namespace Python.Runtime
                     }
                 }
 
-                return self.m.Invoke(target is null ? BorrowedReference.Null : target, args, kw, self.info.UnsafeValue, self.m.binder.args_reversed);
+                return self.m.Invoke(target is null ? BorrowedReference.Null : target, args, kw, self.info.UnsafeValue, self.m.binder.argsReversed);
             }
             finally
             {

--- a/src/runtime/Types/MethodObject.cs
+++ b/src/runtime/Types/MethodObject.cs
@@ -19,20 +19,20 @@ namespace Python.Runtime
     {
         [NonSerialized]
         private MethodBase[]? _info = null;
+
         private readonly List<MaybeMethodInfo> infoList;
         internal string name;
         internal readonly MethodBinder binder;
         internal bool is_static = false;
-
         internal PyString? doc;
         internal MaybeType type;
 
-        public MethodObject(MaybeType type, string name, MethodBase[] info, bool allow_threads)
+        public MethodObject(MaybeType type, string name, MethodBase[] info, bool allow_threads, bool reverse_args = false)
         {
             this.type = type;
             this.name = name;
             this.infoList = new List<MaybeMethodInfo>();
-            binder = new MethodBinder();
+            binder = new MethodBinder(reverse_args);
             foreach (MethodBase item in info)
             {
                 this.infoList.Add(item);
@@ -45,8 +45,8 @@ namespace Python.Runtime
             binder.allow_threads = allow_threads;
         }
 
-        public MethodObject(MaybeType type, string name, MethodBase[] info)
-            : this(type, name, info, allow_threads: AllowThreads(info))
+        public MethodObject(MaybeType type, string name, MethodBase[] info, bool reverse_args = false)
+            : this(type, name, info, allow_threads: AllowThreads(info), reverse_args)
         {
         }
 
@@ -67,14 +67,14 @@ namespace Python.Runtime
             }
         }
 
-        public virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw)
+        public virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, bool reverse_args = false)
         {
-            return Invoke(inst, args, kw, null);
+            return Invoke(inst, args, kw, null, reverse_args);
         }
 
-        public virtual NewReference Invoke(BorrowedReference target, BorrowedReference args, BorrowedReference kw, MethodBase? info)
+        public virtual NewReference Invoke(BorrowedReference target, BorrowedReference args, BorrowedReference kw, MethodBase? info, bool reverse_args = false)
         {
-            return binder.Invoke(target, args, kw, info, this.info);
+            return binder.Invoke(target, args, kw, info, this.info, reverse_args);
         }
 
         /// <summary>

--- a/src/runtime/Types/MethodObject.cs
+++ b/src/runtime/Types/MethodObject.cs
@@ -27,12 +27,12 @@ namespace Python.Runtime
         internal PyString? doc;
         internal MaybeType type;
 
-        public MethodObject(MaybeType type, string name, MethodBase[] info, bool allow_threads, bool reverse_args = false)
+        public MethodObject(MaybeType type, string name, MethodBase[] info, bool allow_threads, bool argsReversed = false)
         {
             this.type = type;
             this.name = name;
             this.infoList = new List<MaybeMethodInfo>();
-            binder = new MethodBinder(reverse_args);
+            binder = new MethodBinder(argsReversed);
             foreach (MethodBase item in info)
             {
                 this.infoList.Add(item);
@@ -45,8 +45,8 @@ namespace Python.Runtime
             binder.allow_threads = allow_threads;
         }
 
-        public MethodObject(MaybeType type, string name, MethodBase[] info, bool reverse_args = false)
-            : this(type, name, info, allow_threads: AllowThreads(info), reverse_args)
+        public MethodObject(MaybeType type, string name, MethodBase[] info, bool argsReversed = false)
+            : this(type, name, info, allow_threads: AllowThreads(info), argsReversed)
         {
         }
 
@@ -67,14 +67,14 @@ namespace Python.Runtime
             }
         }
 
-        public virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, bool reverse_args = false)
+        public virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, bool argsReversed = false)
         {
-            return Invoke(inst, args, kw, null, reverse_args);
+            return Invoke(inst, args, kw, null, argsReversed);
         }
 
-        public virtual NewReference Invoke(BorrowedReference target, BorrowedReference args, BorrowedReference kw, MethodBase? info, bool reverse_args = false)
+        public virtual NewReference Invoke(BorrowedReference target, BorrowedReference args, BorrowedReference kw, MethodBase? info, bool argsReversed = false)
         {
-            return binder.Invoke(target, args, kw, info, this.info, reverse_args);
+            return binder.Invoke(target, args, kw, info, this.info, argsReversed);
         }
 
         /// <summary>

--- a/src/runtime/Types/MethodObject.cs
+++ b/src/runtime/Types/MethodObject.cs
@@ -32,7 +32,7 @@ namespace Python.Runtime
             this.type = type;
             this.name = name;
             this.infoList = new List<MaybeMethodInfo>();
-            binder = new MethodBinder(argsReversed);
+            binder = new MethodBinder() { argsReversed = argsReversed };
             foreach (MethodBase item in info)
             {
                 this.infoList.Add(item);
@@ -67,14 +67,14 @@ namespace Python.Runtime
             }
         }
 
-        public virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw, bool argsReversed = false)
+        public virtual NewReference Invoke(BorrowedReference inst, BorrowedReference args, BorrowedReference kw)
         {
-            return Invoke(inst, args, kw, null, argsReversed);
+            return Invoke(inst, args, kw, null);
         }
 
-        public virtual NewReference Invoke(BorrowedReference target, BorrowedReference args, BorrowedReference kw, MethodBase? info, bool argsReversed = false)
+        public virtual NewReference Invoke(BorrowedReference target, BorrowedReference args, BorrowedReference kw, MethodBase? info)
         {
-            return binder.Invoke(target, args, kw, info, this.info, argsReversed);
+            return binder.Invoke(target, args, kw, info, this.info);
         }
 
         /// <summary>

--- a/src/runtime/Types/OperatorMethod.cs
+++ b/src/runtime/Types/OperatorMethod.cs
@@ -177,17 +177,14 @@ namespace Python.Runtime
         }
 
         /// <summary>
-        /// Check if the method is performing a reverse operation.
+        /// Check if the method should have a reversed operation.
         /// </summary>
         /// <param name="method">The operator method.</param>
         /// <returns></returns>
-        public static bool IsReverse(MethodBase method)
+        public static bool HaveReverse(MethodBase method)
         {
-            Type primaryType = method.IsOpsHelper()
-                ? method.DeclaringType.GetGenericArguments()[0]
-                : method.DeclaringType;
-            Type leftOperandType = method.GetParameters()[0].ParameterType;
-            return leftOperandType != primaryType;
+            var pi = method.GetParameters();
+            return OpMethodMap.ContainsKey(method.Name) && pi.Length == 2;
         }
 
         public static void FilterMethods(MethodBase[] methods, out MethodBase[] forwardMethods, out MethodBase[] reverseMethods)
@@ -196,14 +193,11 @@ namespace Python.Runtime
             var reverseMethodsList = new List<MethodBase>();
             foreach (var method in methods)
             {
-                if (IsReverse(method))
+                forwardMethodsList.Add(method);
+                if (HaveReverse(method))
                 {
                     reverseMethodsList.Add(method);
-                } else
-                {
-                    forwardMethodsList.Add(method);
                 }
-
             }
             forwardMethods = forwardMethodsList.ToArray();
             reverseMethods = reverseMethodsList.ToArray();


### PR DESCRIPTION
### What does this fix? Explain your changes.

Reverse operators were not implemented correctly for C# types which resulted in Recursion errors when embedding C# in Python. Changed the model binding process to add reverse operators for all applicable types. Added a flag to MethodBinder that signals the operation is a reversed operation and that the arguments to the operator needs to be reversed.

Added tests and an wrapper object for int without overloaded operator methods and a wrapper codec to test the reverse operations (and forward operator on the same type for safety).
...

### Does this close any currently open issues?
This should resolve #2240.
...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [X] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [X] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [X] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
