### PR TITLE
Added `ToPythonAs<T>()` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Added
 
+-   Added `ToPythonAs<T>()` extension method to allow for explicit conversion using a specific type. ([#2311][i2311])
+
 ### Changed
 
 ### Fixed
@@ -960,3 +962,4 @@ This version improves performance on benchmarks significantly compared to 2.3.
 [i238]: https://github.com/pythonnet/pythonnet/issues/238
 [i1481]: https://github.com/pythonnet/pythonnet/issues/1481
 [i1672]: https://github.com/pythonnet/pythonnet/pull/1672
+[i2311]: https://github.com/pythonnet/pythonnet/issues/2311

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -185,6 +185,15 @@ namespace Python.EmbeddingTest
             Assert.AreEqual(pyObject.DangerousGetAddressOrNull(), proxiedHandle);
         }
 
+        [Test]
+        public void GenericToPython()
+        {
+            int i = 42;
+            var pyObject = i.ToPythonAs<IConvertible>();
+            var type = pyObject.GetPythonType();
+            Assert.AreEqual(nameof(IConvertible), type.Name);
+        }
+
         // regression for https://github.com/pythonnet/pythonnet/issues/451
         [Test]
         public void CanGetListFromDerivedClass()

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -133,7 +133,8 @@ namespace Python.Runtime
             if (EncodableByUser(type, value))
             {
                 var encoded = PyObjectConversions.TryEncode(value, type);
-                if (encoded != null) {
+                if (encoded != null)
+                {
                     return new NewReference(encoded);
                 }
             }
@@ -334,7 +335,7 @@ namespace Python.Runtime
 
             if (obType.IsGenericType && obType.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
-                if( value == Runtime.PyNone )
+                if (value == Runtime.PyNone)
                 {
                     result = null;
                     return true;
@@ -979,6 +980,12 @@ namespace Python.Runtime
         {
             if (o is null) return Runtime.None;
             return Converter.ToPython(o, o.GetType()).MoveToPyObject();
+        }
+
+        public static PyObject ToPythonAs<T>(this T? o)
+        {
+            if (o is null) return Runtime.None;
+            return Converter.ToPython(o, typeof(T)).MoveToPyObject();
         }
     }
 }


### PR DESCRIPTION
Added `ToPythonAs<T>()`  extension method to allow for explicit conversion using a specific type

### What does this implement/fix? Explain your changes.

The existing `ToPython()` extension always uses current object type. There are scenarios though where objects have to be explicitly represented as their base types or interfaces. For example, `42.ToPython()` produces Python `int`, but there's currently no easy way from C# to pass `42` as `IConvertible` so that Python could call the `IConvertible` members.

The new extension can be used for this purpose: `42.ToPythonAs<IConvertible>()` will return a `PyObject` that has all `IConvertible` members.

### Does this close any currently open issues?

fixes https://github.com/pythonnet/pythonnet/issues/2311

### Any other comments?

N/A

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
