### PR TITLE
Expose serialization api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Added
 
 ### Changed
+-   Added a `FormatterFactory` member in RuntimeData to create formatters with parameters. For compatibility, the `FormatterType` member is still present and has precedence when defining both `FormatterFactory` and `FormatterType`
+-   Added a post-serialization and a pre-deserialization step callbacks to extend (de)serialization process
+-   Added an API to stash serialized data on Python capsules
 
 ### Fixed
 

--- a/src/runtime/StateSerialization/NoopFormatter.cs
+++ b/src/runtime/StateSerialization/NoopFormatter.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace Python.Runtime;
+
+public class NoopFormatter : IFormatter {
+    public object Deserialize(Stream s) => throw new NotImplementedException();
+    public void Serialize(Stream s, object o) {}
+
+    public SerializationBinder? Binder { get; set; }
+    public StreamingContext Context { get; set; }
+    public ISurrogateSelector? SurrogateSelector { get; set; }
+}

--- a/tests/domain_tests/test_domain_reload.py
+++ b/tests/domain_tests/test_domain_reload.py
@@ -88,3 +88,6 @@ def test_nested_type():
 
 def test_import_after_reload():
     _run_test("import_after_reload")
+
+def test_import_after_reload():
+    _run_test("test_serialize_unserializable_object")


### PR DESCRIPTION
Adds post-serialization and pre-deserialization hooks for additional customization.

### What does this implement/fix? Explain your changes.
This PR supersedes #1892 , offer another workaround for issues #2335 #2221 #2282 , possibly others.

### Does this close any currently open issues?

This addresses @lostmsu 's comments of exposing an API instead of adding functionality

### Any other comments?

According to Unity dev answers on the Unity forums, they will implement a ring-link architecture as a replacement for domain load/unload. I have added no tests yet in this PR considering that domain load/unload is deprecated from a .NEt perspective.
https://forum.unity.com/threads/unity-future-net-development-status.1092205/page-34#post-8918231

This PR is made in my own name, I am no longer working at the company that signed the CLA for me.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
