### PR TITLE
1838 Use Python buffer protocol when converting Python objects to .NET arrays

### DIFF
--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 
 using NUnit.Framework;
 
@@ -208,6 +209,75 @@ class PyGetListImpl(test.GetListImpl):
             dynamic inst = pyImpl.Invoke();
             List<string> result = inst.GetList();
             CollectionAssert.AreEqual(new[] { "testing" }, result);
+        }
+
+        [Test]
+        public void TestConvertNumpyFloat32ArrayToManaged()
+        {
+            var testValue = new float[] { 0, 1, 2, 3 };
+            var nparr = np.arange(4, dtype: np.float32);
+
+            object convertedValue;
+            var converted = Converter.ToManaged(nparr, typeof(float[]), out convertedValue, false);
+
+            Assert.IsTrue(converted);
+            Assert.AreEqual(testValue, convertedValue);
+        }
+
+        [Test]
+        public void TestConvertNumpyFloat64_2DArrayToManaged()
+        {
+            var testValue = new double[,] {{ 0, 1, 2, 3,}, { 4, 5, 6, 7 }, { 8, 9, 10, 11 }};
+            var shape = new PyTuple(new[] {new PyInt(3), new PyInt(4)});
+            var nparr = np.arange(12, dtype: np.float64).reshape(shape);
+
+            object convertedValue;
+            var converted = Converter.ToManaged(nparr, typeof(double[,]), out convertedValue, false);
+
+            Assert.IsTrue(converted);
+            Assert.AreEqual(testValue, convertedValue);
+        }
+
+        [Test]
+        public void TestConvertBytearrayToManaged()
+        {
+            var testValue = Encoding.ASCII.GetBytes("test");
+            using var str = PythonEngine.Eval("'test'.encode('ascii')");
+
+            object convertedValue;
+            var converted = Converter.ToManaged(str, typeof(byte[]), out convertedValue, false);
+
+            Assert.IsTrue(converted);
+            Assert.AreEqual(testValue, convertedValue);
+        }
+
+        [Test]
+        public void TestConvertCharArrayToManaged()
+        {
+            var testValue = new char[] { 't', 'e', 's', 't' };
+            using var str = PythonEngine.Eval("'test'.encode('ascii')");
+
+            object convertedValue;
+            var converted = Converter.ToManaged(str, typeof(char[]), out convertedValue, false);
+
+            Assert.IsTrue(converted);
+            Assert.AreEqual(testValue, convertedValue);
+        }
+
+        dynamic np
+        {
+            get
+            {
+                try
+                {
+                    return Py.Import("numpy");
+                }
+                catch (PythonException)
+                {
+                    Assert.Inconclusive("Numpy or dependency not installed");
+                    return null;
+                }
+            }
         }
     }
 

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -264,6 +264,36 @@ class PyGetListImpl(test.GetListImpl):
             Assert.AreEqual(testValue, convertedValue);
         }
 
+        [Test]
+        [TestCaseSource(typeof(Arrays))]
+        public void TestConvertArrayToManaged(string arrayType, Type t, object expected)
+        {
+            object convertedValue;
+            var arr = array.array(arrayType.ToPython(), expected.ToPython());
+            var converted = Converter.ToManaged(arr, t, out convertedValue, false);
+
+            Assert.IsTrue(converted);
+            Assert.AreEqual(expected, convertedValue);
+        }
+
+        public class Arrays : System.Collections.IEnumerable
+        {
+            public System.Collections.IEnumerator GetEnumerator()
+            {
+                yield return new object[] { "b", typeof(byte[]), new byte[] { 0, 1, 2, 3, 4 } };
+                yield return new object[] { "B", typeof(byte[]), new byte[] { 0, 1, 2, 3, 4 } };
+                yield return new object[] { "u", typeof(char[]), new char[] { 'a', 'b', 'c', 'd', 'e' } };
+                yield return new object[] { "h", typeof(short[]), new short[] { -2, -1, 0, 1, 2, 3, 4 } };
+                yield return new object[] { "H", typeof(ushort[]), new ushort[] { 0, 1, 2, 3, 4 } };
+                yield return new object[] { "i", typeof(int[]), new int[] { -2, -1, 0, 1, 2, 3, 4 } };
+                yield return new object[] { "I", typeof(uint[]), new uint[] { 0, 1, 2, 3, 4 } };
+                yield return new object[] { "q", typeof(long[]), new long[] { -2, -1, 0, 1, 2, 3, 4 } };
+                yield return new object[] { "q", typeof(ulong[]), new ulong[] { 0, 1, 2, 3, 4 } };
+                yield return new object[] { "f", typeof(float[]), new float[] { -2, -1, 0, 1, 2, 3, 4 } };
+                yield return new object[] { "d", typeof(double[]), new double[] { -2, -1, 0, 1, 2, 3, 4 } };
+            }
+        };
+
         dynamic np
         {
             get
@@ -275,6 +305,22 @@ class PyGetListImpl(test.GetListImpl):
                 catch (PythonException)
                 {
                     Assert.Inconclusive("Numpy or dependency not installed");
+                    return null;
+                }
+            }
+        }
+
+        dynamic array
+        {
+            get
+            {
+                try
+                {
+                    return Py.Import("array");
+                }
+                catch (PythonException)
+                {
+                    Assert.Inconclusive("Could not import array");
                     return null;
                 }
             }

--- a/src/embed_tests/TestConverter.cs
+++ b/src/embed_tests/TestConverter.cs
@@ -252,19 +252,6 @@ class PyGetListImpl(test.GetListImpl):
         }
 
         [Test]
-        public void TestConvertCharArrayToManaged()
-        {
-            var testValue = new char[] { 't', 'e', 's', 't' };
-            using var str = PythonEngine.Eval("'test'.encode('ascii')");
-
-            object convertedValue;
-            var converted = Converter.ToManaged(str, typeof(char[]), out convertedValue, false);
-
-            Assert.IsTrue(converted);
-            Assert.AreEqual(testValue, convertedValue);
-        }
-
-        [Test]
         [TestCaseSource(typeof(Arrays))]
         public void TestConvertArrayToManaged(string arrayType, Type t, object expected)
         {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

If a python object exposes the buffer protocol then copy the buffer directly to a .NET array. This works for (blittable) single- or multidimensional arrays. I added tests for numpy arrays, bytearrays and python arrays to check whether this change works across different buffer protocol implementations.

My implementation currently has the following caveats:

- The Python object must implement the buffer protocol and be **C-contiguous**. This is only relevant for multidimensional arrays. I explicitly request a C-contiguous buffer because (multidimensional) .NET arrays are C-contiguous as well. This allows copying the whole chunk of memory at once. Supporting multidimensional Fortran-contiguous buffers would make the implementation more complicated though I have not thought too much about it.
- PIL-style buffers that do not store the whole buffer contiguously but through pointers via [suboffsets](https://docs.python.org/3/c-api/buffer.html#c.Py_buffer.suboffsets) are not supported. This would also need special handling.
- The .NET element type of the array must be **blittable** and **not a struct**.  Structs can be blittable if all their members are blittable. I imagine this may make the implementation more complicated because as far as I know no there's no out-of-the-box way to check whether a type is blittable. I think this is better handled with custom Codecs?
- Works for **multidimensional arrays** which `ToArray` previously didn't handle, so we weaken a precondition of the converter. However efficient copying of multidimensional arrays is highly desirable in my opinion. 
- I use `Buffer.MemoryCopy` which is marked as not CLS-compliant. If this is not acceptable I will of course find another way.
- The implementation is done directly with the C-API. I can rewrite this with `PyBuffer` if you want.

### Does this close any currently open issues?

[1838 Use Python buffer protocol when converting Python objects to .NET arrays](https://github.com/pythonnet/pythonnet/issues/1838)

### Any other comments?

The test with bytearray to .NET byte array is currently failing for NET 6.0 due to the way the Py_Buffer struct is being marshalled. I opened a separate issue #2371 to address this.

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
