### PR TITLE
Fix access violation exception on shutdown (#1977)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,6 +38,7 @@
 -   Dmitriy Se ([@dmitriyse](https://github.com/dmitriyse))
 -   Félix Bourbonnais ([@BadSingleton](https://github.com/BadSingleton))
 -   Florian Treurniet ([@ftreurni](https://github.com/ftreurni))
+-   Frank Witscher ([@Frawak](https://github.com/Frawak))
 -   He-chien Tsai ([@t3476](https://github.com/t3476))
 -   Inna Wiesel ([@inna-w](https://github.com/inna-w))
 -   Ivan Cronyn ([@cronan](https://github.com/cronan))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Fixed
 
 -   Fixed RecursionError for reverse operators on C# operable types from python. See #2240
+-   Fixed possible access violation exception on shutdown (#1977)
 
 ## [3.0.3](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.3) - 2023-10-11
 

--- a/src/runtime/Types/ClrObject.cs
+++ b/src/runtime/Types/ClrObject.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -11,8 +12,8 @@ namespace Python.Runtime
     {
         internal readonly object inst;
 
-        // "borrowed" references
-        internal static readonly HashSet<IntPtr> reflectedObjects = new();
+        internal static readonly ReflectedObjectsCollection reflectedObjects = new();
+
         static NewReference Create(object ob, BorrowedReference tp)
         {
             Debug.Assert(tp != null);
@@ -67,6 +68,160 @@ namespace Python.Runtime
 
             bool isNew = reflectedObjects.Add(ob.DangerousGetAddress());
             Debug.Assert(isNew);
+        }
+
+        internal sealed class ReflectedObjectsCollection : ISet<IntPtr>, IReadOnlyCollection<IntPtr>
+        {
+            readonly HashSet<IntPtr> objects = new();
+
+            public bool Add(IntPtr item)
+            {
+                bool isNew = objects.Add(item);
+                if (isNew) IncRef(item);
+                return isNew;
+            }
+
+            public bool Remove(IntPtr item)
+            {
+                bool removed = objects.Remove(item);
+                if (removed) DecRef(item);
+                return removed;
+            }
+
+            public void Clear()
+            {
+                foreach (var item in objects)
+                {
+                    DecRef(item);
+                }
+                objects.Clear();
+            }
+
+            void IncRef(IntPtr item)
+            {
+                Runtime.Py_IncRef(new BorrowedReference(item));
+            }
+
+            void DecRef(IntPtr item)
+            {
+                Runtime.XDecref(StolenReference.DangerousFromPointer(item));
+            }
+
+            #region Implement interaces
+
+            public int Count => objects.Count;
+
+            public bool IsReadOnly => false;
+
+            bool ISet<IntPtr>.Add(IntPtr item)
+            {
+                return Add(item);
+            }
+
+            public void ExceptWith(IEnumerable<IntPtr> other)
+            {
+                var copy = new HashSet<IntPtr>(objects);
+                copy.IntersectWith(other);
+                foreach (var item in copy) DecRef(item);
+                objects.ExceptWith(other);
+            }
+
+            public void IntersectWith(IEnumerable<IntPtr> other)
+            {
+                var copy = new HashSet<IntPtr>(objects);
+                copy.SymmetricExceptWith(other);
+                copy.ExceptWith(other);
+                foreach (var item in copy) DecRef(item);
+                objects.IntersectWith(other);
+            }
+
+            public bool IsProperSubsetOf(IEnumerable<IntPtr> other)
+            {
+                return objects.IsProperSubsetOf(other);
+            }
+
+            public bool IsProperSupersetOf(IEnumerable<IntPtr> other)
+            {
+                return objects.IsProperSupersetOf(other);
+            }
+
+            public bool IsSubsetOf(IEnumerable<IntPtr> other)
+            {
+                return objects.IsSubsetOf(other);
+            }
+
+            public bool IsSupersetOf(IEnumerable<IntPtr> other)
+            {
+                return objects.IsSupersetOf(other);
+            }
+
+            public bool Overlaps(IEnumerable<IntPtr> other)
+            {
+                return objects.Overlaps(other);
+            }
+
+            public bool SetEquals(IEnumerable<IntPtr> other)
+            {
+                return objects.SetEquals(other);
+            }
+
+            public void SymmetricExceptWith(IEnumerable<IntPtr> other)
+            {
+                var copy = new HashSet<IntPtr>(objects);
+                copy.IntersectWith(other);
+                foreach (var item in copy) DecRef(item);
+                var otherCopy = new HashSet<IntPtr>(other);
+                otherCopy.ExceptWith(objects);
+                foreach (var item in otherCopy) IncRef(item);
+                objects.SymmetricExceptWith(other);
+            }
+
+            public void UnionWith(IEnumerable<IntPtr> other)
+            {
+                var otherCopy = new HashSet<IntPtr>(other);
+                otherCopy.ExceptWith(objects);
+                foreach (var item in otherCopy) IncRef(item);
+                objects.UnionWith(other);
+            }
+
+            void ICollection<IntPtr>.Add(IntPtr item)
+            {
+                Add(item);
+            }
+
+            void ICollection<IntPtr>.Clear()
+            {
+                Clear();
+            }
+
+            public bool Contains(IntPtr item)
+            {
+                return objects.Contains(item);
+            }
+
+            public void CopyTo(IntPtr[] array, int arrayIndex)
+            {
+                // Responsibility for ref count at whoever handles the array.
+                // No increment here.
+                objects.CopyTo(array, arrayIndex);
+            }
+
+            bool ICollection<IntPtr>.Remove(IntPtr item)
+            {
+                return Remove(item);
+            }
+
+            public IEnumerator<IntPtr> GetEnumerator()
+            {
+                return objects.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return objects.GetEnumerator();
+            }
+
+            #endregion
         }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When nulling the GC handles on shutdown the reference count of all objects pointed to by the IntPtr in the `reflectedObjects` are zero. This caused an exception in some scenarios because `Runtime.PyObject_TYPE(reflectedClrObject)` is called while the reference counter is at zero, hence, not being guaranteed the Python object is still there and the memory not reclaimed. The solution presented is treating the pointer in `reflectedObjects` as strong references - incrementing the respective ref count adding to the set and decrementing removing from it or clearing the entire set (the latter is already done after nulling the GC Handles).

### Does this close any currently open issues?

#1977
[Random Access Violations on shutdown](https://github.com/pythonnet/pythonnet/issues/1977)

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
