### PR TITLE
Handle bad paths in `sys.path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Fixed
 
 -   Fixed RecursionError for reverse operators on C# operable types from python. See #2240
+-   Fixed probing for assemblies in `sys.path` failing when a path in `sys.path` has invalid characters. See #2376
 
 ## [3.0.3](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.3) - 2023-10-11
 

--- a/src/runtime/AssemblyManager.cs
+++ b/src/runtime/AssemblyManager.cs
@@ -200,6 +200,13 @@ namespace Python.Runtime
                 }
                 else
                 {
+                    int invalidCharIndex = head.IndexOfAny(Path.GetInvalidPathChars());
+                    if (invalidCharIndex >= 0)
+                    {
+                        using var importWarning = Runtime.PyObject_GetAttrString(Exceptions.exceptions_module, "ImportWarning");
+                        Exceptions.warn($"Path entry '{head}' has invalid char at position {invalidCharIndex}", importWarning.BorrowOrThrow());
+                        continue;
+                    }
                     path = Path.Combine(head, name);
                 }
 

--- a/src/runtime/Exceptions.cs
+++ b/src/runtime/Exceptions.cs
@@ -270,7 +270,7 @@ namespace Python.Runtime
             }
 
             using var warn = Runtime.PyObject_GetAttrString(warnings_module.obj, "warn");
-            Exceptions.ErrorCheck(warn.Borrow());
+            warn.BorrowOrThrow();
 
             using var argsTemp = Runtime.PyTuple_New(3);
             BorrowedReference args = argsTemp.BorrowOrThrow();
@@ -283,7 +283,7 @@ namespace Python.Runtime
             Runtime.PyTuple_SetItem(args, 2, level.StealOrThrow());
 
             using var result = Runtime.PyObject_CallObject(warn.Borrow(), args);
-            Exceptions.ErrorCheck(result.Borrow());
+            result.BorrowOrThrow();
         }
 
         public static void warn(string message, BorrowedReference exception)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -344,6 +344,20 @@ def test_clr_add_reference():
     with pytest.raises(FileNotFoundException):
         AddReference("somethingtotallysilly")
 
+
+def test_clr_add_reference_bad_path():
+    import sys
+    from clr import AddReference
+    from System.IO import FileNotFoundException
+    bad_path = "hello\0world"
+    sys.path.append(bad_path)
+    try:
+        with pytest.raises(FileNotFoundException):
+            AddReference("test_clr_add_reference_bad_path")
+    finally:
+        sys.path.remove(bad_path)
+
+
 def test_clr_get_clr_type():
     """Test clr.GetClrType()."""
     from clr import GetClrType


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

User can add arbitrary strings to `sys.path`. When we probe for assemblies in `sys.path` the ones that were not valid paths caused the probing to fail, never reaching the valid ones that actually had the desired assembly.

This change handles these cases by generating a warning and continuing to probe in other directories.

### Does this close any currently open issues?

fixes #2376

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
