### PR TITLE
Fix access violation exception on shutdown

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,6 +38,7 @@
 -   Dmitriy Se ([@dmitriyse](https://github.com/dmitriyse))
 -   Félix Bourbonnais ([@BadSingleton](https://github.com/BadSingleton))
 -   Florian Treurniet ([@ftreurni](https://github.com/ftreurni))
+-   Frank Witscher ([@Frawak](https://github.com/Frawak))
 -   He-chien Tsai ([@t3476](https://github.com/t3476))
 -   Inna Wiesel ([@inna-w](https://github.com/inna-w))
 -   Ivan Cronyn ([@cronan](https://github.com/cronan))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 -   Fixed RecursionError for reverse operators on C# operable types from python. See #2240
 -   Fixed probing for assemblies in `sys.path` failing when a path in `sys.path` has invalid characters. See #2376
+-   Fixed possible access violation exception on shutdown. See ([#1977][i1977])
 
 ## [3.0.3](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.3) - 2023-10-11
 
@@ -970,3 +971,4 @@ This version improves performance on benchmarks significantly compared to 2.3.
 [i1481]: https://github.com/pythonnet/pythonnet/issues/1481
 [i1672]: https://github.com/pythonnet/pythonnet/pull/1672
 [i2311]: https://github.com/pythonnet/pythonnet/issues/2311
+[i1977]: https://github.com/pythonnet/pythonnet/issues/1977

--- a/src/runtime/Finalizer.cs
+++ b/src/runtime/Finalizer.cs
@@ -191,7 +191,7 @@ namespace Python.Runtime
             Instance.started = false;
         }
 
-        internal nint DisposeAll()
+        internal nint DisposeAll(bool disposeObj = true, bool disposeDerived = true, bool disposeBuffer = true)
         {
             if (_objQueue.IsEmpty && _derivedQueue.IsEmpty && _bufferQueue.IsEmpty)
                 return 0;
@@ -216,7 +216,7 @@ namespace Python.Runtime
 
                 try
                 {
-                    while (!_objQueue.IsEmpty)
+                    if (disposeObj) while (!_objQueue.IsEmpty)
                     {
                         if (!_objQueue.TryDequeue(out var obj))
                             continue;
@@ -240,7 +240,7 @@ namespace Python.Runtime
                         }
                     }
 
-                    while (!_derivedQueue.IsEmpty)
+                    if (disposeDerived) while (!_derivedQueue.IsEmpty)
                     {
                         if (!_derivedQueue.TryDequeue(out var derived))
                             continue;
@@ -258,7 +258,7 @@ namespace Python.Runtime
                         collected++;
                     }
 
-                    while (!_bufferQueue.IsEmpty)
+                    if (disposeBuffer) while (!_bufferQueue.IsEmpty)
                     {
                         if (!_bufferQueue.TryDequeue(out var buffer))
                             continue;

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -158,6 +158,7 @@ namespace Python.Runtime
             ClassManager.Reset();
             ClassDerivedObject.Reset();
             TypeManager.Initialize();
+            CLRObject.creationBlocked = false;
             _typesInitialized = true;
 
             // Initialize modules that depend on the runtime class.
@@ -356,6 +357,7 @@ namespace Python.Runtime
                 {
                     NullGCHandles(CLRObject.reflectedObjects);
                     CLRObject.reflectedObjects.Clear();
+                    CLRObject.creationBlocked = true;
                 }
             }
             return false;

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -278,6 +278,8 @@ namespace Python.Runtime
             ClearClrModules();
             RemoveClrRootModule();
 
+            TryCollectingGarbage(MaxCollectRetriesOnShutdown, forceBreakLoops: true);
+
             NullGCHandles(ExtensionType.loadedExtensions);
             ClassManager.RemoveClasses();
             TypeManager.RemoveTypes();
@@ -295,8 +297,7 @@ namespace Python.Runtime
             PyObjectConversions.Reset();
 
             PyGC_Collect();
-            bool everythingSeemsCollected = TryCollectingGarbage(MaxCollectRetriesOnShutdown,
-                                                                 forceBreakLoops: true);
+            bool everythingSeemsCollected = TryCollectingGarbage(MaxCollectRetriesOnShutdown);
             Debug.Assert(everythingSeemsCollected);
 
             Finalizer.Shutdown();

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -281,6 +281,7 @@ namespace Python.Runtime
 
             TryCollectingGarbage(MaxCollectRetriesOnShutdown, forceBreakLoops: true,
                                  obj: true, derived: false, buffer: false);
+            CLRObject.creationBlocked = true;
 
             NullGCHandles(ExtensionType.loadedExtensions);
             ClassManager.RemoveClasses();
@@ -357,7 +358,6 @@ namespace Python.Runtime
                 {
                     NullGCHandles(CLRObject.reflectedObjects);
                     CLRObject.reflectedObjects.Clear();
-                    CLRObject.creationBlocked = true;
                 }
             }
             return false;

--- a/src/runtime/Types/ClrObject.cs
+++ b/src/runtime/Types/ClrObject.cs
@@ -11,10 +11,15 @@ namespace Python.Runtime
     {
         internal readonly object inst;
 
+        internal static bool creationBlocked = false;
+
         // "borrowed" references
         internal static readonly HashSet<IntPtr> reflectedObjects = new();
         static NewReference Create(object ob, BorrowedReference tp)
         {
+            if (creationBlocked)
+                throw new InvalidOperationException("Reflected objects should not be created anymore.");
+
             Debug.Assert(tp != null);
             var py = Runtime.PyType_GenericAlloc(tp, 0);
 
@@ -61,6 +66,9 @@ namespace Python.Runtime
 
         protected override void OnLoad(BorrowedReference ob, Dictionary<string, object?>? context)
         {
+            if (creationBlocked)
+                throw new InvalidOperationException("Reflected objects should not be loaded anymore.");
+
             base.OnLoad(ob, context);
             GCHandle gc = GCHandle.Alloc(this);
             SetGCHandle(ob, gc);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

When nulling the GC handles on shutdown the reference count of all objects pointed to by the IntPtr in the `CLRObject.reflectedObjects` are zero. This caused an exception in some scenarios because `Runtime.PyObject_TYPE(reflectedClrObject)` is called while the reference counter is at zero.

After `TypeManager.RemoveTypes();` is called in the `Runtime.Shutdown()` method, reference count decrements to zero do not invoke `ClassBase.tp_clear` for managed objects anymore which normally is responsible for freeing GC handles and removing references from `CLRObject.reflectedObjects`. Collecting objects referenced in `CLRObject.reflectedObjects` only after leads to an unstable state in which the reference count for these object addresses is zero while still maintaining them to be used for further pseudo-cleanup. In that time, the memory could have been reclaimed already which leads to the exception.

### Does this close any currently open issues?

#1977 

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
