### PR TITLE
Fix crash when event does not have `Add` method and improve message for some other internal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ### Fixed
 
 -   Fixed RecursionError for reverse operators on C# operable types from python. See #2240
+-   Fixed crash when .NET event has no `AddMethod`
 -   Fixed probing for assemblies in `sys.path` failing when a path in `sys.path` has invalid characters. See #2376
 
 ## [3.0.3](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.3) - 2023-10-11

--- a/src/runtime/ClassManager.cs
+++ b/src/runtime/ClassManager.cs
@@ -290,11 +290,13 @@ namespace Python.Runtime
 
         internal static bool ShouldBindMethod(MethodBase mb)
         {
+            if (mb is null) throw new ArgumentNullException(nameof(mb));
             return (mb.IsPublic || mb.IsFamily || mb.IsFamilyOrAssembly);
         }
 
         internal static bool ShouldBindField(FieldInfo fi)
         {
+            if (fi is null) throw new ArgumentNullException(nameof(fi));
             return (fi.IsPublic || fi.IsFamily || fi.IsFamilyOrAssembly);
         }
 
@@ -326,7 +328,7 @@ namespace Python.Runtime
 
         internal static bool ShouldBindEvent(EventInfo ei)
         {
-            return ShouldBindMethod(ei.GetAddMethod(true));
+            return ei.GetAddMethod(true) is { } add && ShouldBindMethod(add);
         }
 
         private static ClassInfo GetClassInfo(Type type, ClassBase impl)

--- a/src/runtime/InternalPythonnetException.cs
+++ b/src/runtime/InternalPythonnetException.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Python.Runtime;
+
+public class InternalPythonnetException : Exception
+{
+    public InternalPythonnetException(string message, Exception innerException)
+        : base(message, innerException) { }
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

1. Fixes crash on events with no [`AddMethod`](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.eventinfo.addmethod)
2. Adds `InternalPythonnetException` that can tell user what .NET type caused failure if an unexpected internal error occurs

### Does this close any currently open issues?

https://github.com/pythonnet/pythonnet/discussions/2405

### Checklist

Check all those that are applicable and complete.

-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
