### PR TITLE
Encoders no support specifying the target encoding type

### DIFF
--- a/src/runtime/Codecs/EncoderGroup.cs
+++ b/src/runtime/Codecs/EncoderGroup.cs
@@ -28,13 +28,13 @@ namespace Python.Runtime.Codecs
         /// <inheritdoc />
         public bool CanEncode(Type type) => this.encoders.Any(encoder => encoder.CanEncode(type));
         /// <inheritdoc />
-        public PyObject? TryEncode(object value)
+        public PyObject? TryEncode(object value, Type type)
         {
             if (value is null) throw new ArgumentNullException(nameof(value));
 
             foreach (var encoder in this.GetEncoders(value.GetType()))
             {
-                var result = encoder.TryEncode(value);
+                var result = encoder.TryEncode(value, type);
                 if (result != null)
                 {
                     return result;

--- a/src/runtime/Codecs/EnumPyIntCodec.cs
+++ b/src/runtime/Codecs/EnumPyIntCodec.cs
@@ -46,12 +46,11 @@ namespace Python.Runtime.Codecs
             return false;
         }
 
-        public PyObject? TryEncode(object value)
+        public PyObject? TryEncode(object value, Type type)
         {
             if (value is null) return null;
-
-            var enumType = value.GetType();
-            if (!enumType.IsEnum) return null;
+            
+            if (!type.IsEnum) return null;
 
             try
             {

--- a/src/runtime/Codecs/IPyObjectEncoder.cs
+++ b/src/runtime/Codecs/IPyObjectEncoder.cs
@@ -13,6 +13,7 @@ public interface IPyObjectEncoder
     bool CanEncode(Type type);
     /// <summary>
     /// Attempts to encode CLR object <paramref name="value"/> into Python object
+    /// using the specified <paramref name="type"/>
     /// </summary>
-    PyObject? TryEncode(object value);
+    PyObject? TryEncode(object value, Type type);
 }

--- a/src/runtime/Codecs/PyObjectConversions.cs
+++ b/src/runtime/Codecs/PyObjectConversions.cs
@@ -54,7 +54,7 @@ namespace Python.Runtime
 
             foreach (var encoder in clrToPython.GetOrAdd(type, GetEncoders))
             {
-                var result = encoder.TryEncode(obj);
+                var result = encoder.TryEncode(obj, type);
                 if (result != null) return result;
             }
 

--- a/src/runtime/Codecs/RawProxyEncoder.cs
+++ b/src/runtime/Codecs/RawProxyEncoder.cs
@@ -8,7 +8,7 @@ namespace Python.Runtime.Codecs
     /// </summary>
     public class RawProxyEncoder: IPyObjectEncoder
     {
-        public PyObject TryEncode(object value)
+        public PyObject TryEncode(object value, Type type)
         {
             if (value is null) throw new ArgumentNullException(nameof(value));
 

--- a/src/runtime/Codecs/TupleCodecs.cs
+++ b/src/runtime/Codecs/TupleCodecs.cs
@@ -18,20 +18,19 @@ namespace Python.Runtime.Codecs
                    && type.Name.StartsWith(typeof(TTuple).Name + '`');
         }
 
-        public PyObject? TryEncode(object value)
+        public PyObject? TryEncode(object value, Type type)
         {
             if (value == null) return null;
 
-            var tupleType = value.GetType();
-            if (tupleType == typeof(object)) return null;
-            if (!this.CanEncode(tupleType)) return null;
-            if (tupleType == typeof(TTuple)) return new PyTuple();
+            if (type == typeof(object)) return null;
+            if (!this.CanEncode(type)) return null;
+            if (type == typeof(TTuple)) return new PyTuple();
 
-            nint fieldCount = tupleType.GetGenericArguments().Length;
+            nint fieldCount = type.GetGenericArguments().Length;
             using var tuple = Runtime.PyTuple_New(fieldCount);
             PythonException.ThrowIfIsNull(tuple);
             int fieldIndex = 0;
-            foreach (FieldInfo field in tupleType.GetFields())
+            foreach (FieldInfo field in type.GetFields())
             {
                 var item = field.GetValue(value);
                 using var pyItem = Converter.ToPython(item, field.FieldType);

--- a/src/runtime/Converter.cs
+++ b/src/runtime/Converter.cs
@@ -987,5 +987,11 @@ namespace Python.Runtime
             if (o is null) return Runtime.None;
             return Converter.ToPython(o, typeof(T)).MoveToPyObject();
         }
+
+        public static PyObject ToPythonAs(this object o, Type type)
+        {
+            if (o is null) return Runtime.None;
+            return Converter.ToPython(o, type).MoveToPyObject();
+        }
     }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
When you have an object that implements multiple interfaces in an explicit way, there's no easy way in Encoders to specify which of the interface we want to encode.
This PR allows that, by introducing an extra type paramater in the TryEncode method, implementors can know understand what is the target type that should be used. Also there's a new extension method that allows specifying the target type, when the type is not. known at build time (thus we can't use the generic version of the ToPython).
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
