### PR TITLE
Add note about assembly locations and code block for getting assembly load errors to python.rst

### DIFF
--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -150,11 +150,14 @@ that you can import an assembly, put the directory containing the assembly in
 ``sys.path``.
 
 .. note::
-    All dependencies of the assembly you're loading need to be findable throught PYTHONPATH (``sys.path``) as well.
-    If any dependency cannot be found, you will get import errors. To ensure all dependencies are available, its advisable to build
-    using ``dotnet publish -o /path/to/yourproject/bin`` or equivalent, which will store all required DLLs in the folder specified with ``-o``.
+    All dependencies of the assembly you're loading need to be in a folder which is
+    listed in PYTHONPATH (``sys.path``) as well. If any dependency cannot be found, you
+    will get import errors. To ensure all dependencies are available, its advisable to build
+    using ``dotnet publish -o /path/to/yourproject/bin`` (or equivalent), which will store all
+    required DLLs in the folder specified with ``-o``.
 
-You can use ``assembly.GetExportedTypes()`` to check which assembly you could not load. It will raise a error for files it could not find.
+You can use ``assembly.GetExportedTypes()`` to check which assembly you could not load.
+It will raise a error for files it could not find.
 If everything is found, it may print ``System.Type[]`` or a list of types:
 
 .. code:: python

--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -149,6 +149,26 @@ addition to the usual application base and the GAC (if applicable). To ensure
 that you can import an assembly, put the directory containing the assembly in
 ``sys.path``.
 
+.. note::
+    All dependencies of the assembly you're loading need to be findable throught PYTHONPATH (``sys.path``) as well.
+    If any dependency cannot be found, you will get import errors. To ensure all dependencies are available, its advisable to build
+    using ``dotnet publish -o /path/to/yourproject/bin`` or equivalent, which will store all required DLLs in the folder specified with ``-o``.
+
+You can use ``assembly.GetExportedTypes()`` to check which assembly you could not load. It will raise a error for files it could not find.
+If everything is found, it may print ``System.Type[]`` or a list of types:
+
+.. code:: python
+
+   t = clr.AddReference("libNOM.io")
+   try:
+       print(t.GetExportedTypes())
+   except Exception as e:
+       print(
+           "Error loading assembly, this assembly may not be found in sys.path:\n\t",
+           e.Message,)
+       exit()
+
+
 Interacting with .NET
 ---------------------
 


### PR DESCRIPTION

### What does this implement/fix? Explain your changes.

Currently, `import NamespaceName` fails if dependency assemblies could not be loaded, with a normal "ModuleNotFoundError: No module named ..." error. `assembly.GetExportedTypes()` can be used to actually receive a error for one of the assemblies which were not found.

This PR documents this in the .rst file for python usage.

### Does this close any currently open issues?

Unsure

### Any other comments?

Figuring out that this is why i got ModuleNotFound took me 3 hours, and i want to help others avoid this hassle.

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change (purely a docs change)
-   [x] If an enhancement PR, please create docs and at best an example
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md) (purely a docs change)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md) (do docs changes go in the changelog?)
