### PR TITLE
Drop reference to Py_Main

### DIFF
--- a/src/runtime/Runtime.Delegates.cs
+++ b/src/runtime/Runtime.Delegates.cs
@@ -35,7 +35,6 @@ public unsafe partial class Runtime
             PyGILState_Ensure = (delegate* unmanaged[Cdecl]<PyGILState>)GetFunctionByName(nameof(PyGILState_Ensure), GetUnmanagedDll(_PythonDll));
             PyGILState_Release = (delegate* unmanaged[Cdecl]<PyGILState, void>)GetFunctionByName(nameof(PyGILState_Release), GetUnmanagedDll(_PythonDll));
             PyGILState_GetThisThreadState = (delegate* unmanaged[Cdecl]<PyThreadState*>)GetFunctionByName(nameof(PyGILState_GetThisThreadState), GetUnmanagedDll(_PythonDll));
-            Py_Main = (delegate* unmanaged[Cdecl]<int, IntPtr, int>)GetFunctionByName(nameof(Py_Main), GetUnmanagedDll(_PythonDll));
             PyEval_InitThreads = (delegate* unmanaged[Cdecl]<void>)GetFunctionByName(nameof(PyEval_InitThreads), GetUnmanagedDll(_PythonDll));
             PyEval_ThreadsInitialized = (delegate* unmanaged[Cdecl]<int>)GetFunctionByName(nameof(PyEval_ThreadsInitialized), GetUnmanagedDll(_PythonDll));
             PyEval_AcquireLock = (delegate* unmanaged[Cdecl]<void>)GetFunctionByName(nameof(PyEval_AcquireLock), GetUnmanagedDll(_PythonDll));
@@ -319,7 +318,6 @@ public unsafe partial class Runtime
         internal static delegate* unmanaged[Cdecl]<PyGILState> PyGILState_Ensure { get; }
         internal static delegate* unmanaged[Cdecl]<PyGILState, void> PyGILState_Release { get; }
         internal static delegate* unmanaged[Cdecl]<PyThreadState*> PyGILState_GetThisThreadState { get; }
-        internal static delegate* unmanaged[Cdecl]<int, IntPtr, int> Py_Main { get; }
         internal static delegate* unmanaged[Cdecl]<void> PyEval_InitThreads { get; }
         internal static delegate* unmanaged[Cdecl]<int> PyEval_ThreadsInitialized { get; }
         internal static delegate* unmanaged[Cdecl]<void> PyEval_AcquireLock { get; }

--- a/src/runtime/Runtime.cs
+++ b/src/runtime/Runtime.cs
@@ -719,20 +719,6 @@ namespace Python.Runtime
         internal static PyThreadState* PyGILState_GetThisThreadState() => Delegates.PyGILState_GetThisThreadState();
 
 
-        public static int Py_Main(int argc, string[] argv)
-        {
-            var marshaler = StrArrayMarshaler.GetInstance(null);
-            var argvPtr = marshaler.MarshalManagedToNative(argv);
-            try
-            {
-                return Delegates.Py_Main(argc, argvPtr);
-            }
-            finally
-            {
-                marshaler.CleanUpNativeData(argvPtr);
-            }
-        }
-
         internal static void PyEval_InitThreads() => Delegates.PyEval_InitThreads();
 
 


### PR DESCRIPTION
Was only used in the console and might not be available in some
embedding scenarios.
