### PR TITLE
`__delitem__` for `IList<T>` and `IDictionary<K,V>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 ## Unreleased
 
 ### Added
+
+-  Support `del obj[...]` for types derived from `IList<T>` and `IDictionary<K, V>`
+
 ### Changed
 ### Fixed
 
+-  Fixed crash when trying to `del clrObj[...]` for non-arrays
 - ci: properly exclude job (#2542)
 
 ## [3.0.5](https://github.com/pythonnet/pythonnet/releases/tag/v3.0.5) - 2024-12-13

--- a/pythonnet.sln
+++ b/pythonnet.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Repo", "Repo", "{441A0123-F
 		LICENSE = LICENSE
 		README.rst = README.rst
 		version.txt = version.txt
+		shell.nix = shell.nix
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CI", "CI", "{D301657F-5EAF-4534-B280-B858D651B2E5}"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {}}:
+let
+  fhs = pkgs.buildFHSUserEnv {
+    name = "my-fhs-environment";
+
+    targetPkgs = _: [
+      pkgs.python3
+    ];
+  };
+in fhs.env

--- a/src/runtime/MethodBinder.cs
+++ b/src/runtime/MethodBinder.cs
@@ -54,6 +54,11 @@ namespace Python.Runtime
             list.Add(m);
         }
 
+        internal void AddRange(IEnumerable<MethodBase> methods)
+        {
+            list.AddRange(methods.Select(m => new MaybeMethodBase(m)));
+        }
+
         /// <summary>
         /// Given a sequence of MethodInfo and a sequence of types, return the
         /// MethodInfo that matches the signature represented by those types.

--- a/src/runtime/Types/ArrayObject.cs
+++ b/src/runtime/Types/ArrayObject.cs
@@ -247,6 +247,12 @@ namespace Python.Runtime
         /// </summary>
         public static int mp_ass_subscript(BorrowedReference ob, BorrowedReference idx, BorrowedReference v)
         {
+            if (v.IsNull)
+            {
+                Exceptions.RaiseTypeError("'System.Array' object does not support item deletion");
+                return -1;
+            }
+
             var obj = (CLRObject)GetManagedObject(ob)!;
             var items = (Array)obj.inst;
             Type itemType = obj.inst.GetType().GetElementType();

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -497,14 +497,8 @@ namespace Python.Runtime
             // Add value to argument list
             Runtime.PyTuple_SetItem(real.Borrow(), i, v);
 
-            cls.indexer.SetItem(ob, real.Borrow());
-
-            if (Exceptions.ErrorOccurred())
-            {
-                return -1;
-            }
-
-            return 0;
+            using var result = cls.indexer.SetItem(ob, real.Borrow());
+            return result.IsNull() ? -1 : 0;
         }
 
         static NewReference tp_call_impl(BorrowedReference ob, BorrowedReference args, BorrowedReference kw)

--- a/src/runtime/Types/ClassBase.cs
+++ b/src/runtime/Types/ClassBase.cs
@@ -25,6 +25,7 @@ namespace Python.Runtime
         [NonSerialized]
         internal List<string> dotNetMembers = new();
         internal Indexer? indexer;
+        internal MethodBinder? del;
         internal readonly Dictionary<int, MethodObject> richcompare = new();
         internal MaybeType type;
 
@@ -465,6 +466,11 @@ namespace Python.Runtime
             // with the index arg (method binders expect arg tuples).
             NewReference argsTuple = default;
 
+            if (v.IsNull)
+            {
+                return DelImpl(ob, idx, cls);
+            }
+
             if (!Runtime.PyTuple_Check(idx))
             {
                 argsTuple = Runtime.PyTuple_New(1);
@@ -499,6 +505,44 @@ namespace Python.Runtime
 
             using var result = cls.indexer.SetItem(ob, real.Borrow());
             return result.IsNull() ? -1 : 0;
+        }
+
+        /// Implements __delitem__ (del x[...]) for IList&lt;T&gt; and IDictionary&lt;TKey, TValue&gt;.
+        private static int DelImpl(BorrowedReference ob, BorrowedReference idx, ClassBase cls)
+        {
+            if (cls.del is null)
+            {
+                Exceptions.SetError(Exceptions.TypeError, "object does not support item deletion");
+                return -1;
+            }
+
+            if (Runtime.PyTuple_Check(idx))
+            {
+                Exceptions.SetError(Exceptions.TypeError, "multi-index deletion not supported");
+                return -1;
+            }
+
+            using var argsTuple = Runtime.PyTuple_New(1);
+            Runtime.PyTuple_SetItem(argsTuple.Borrow(), 0, idx);
+            using var result = cls.del.Invoke(ob, argsTuple.Borrow(), kw: null);
+            if (result.IsNull())
+                return -1;
+
+            if (Runtime.PyBool_CheckExact(result.Borrow()))
+            {
+                if (Runtime.PyObject_IsTrue(result.Borrow()) != 0)
+                    return 0;
+
+                Exceptions.SetError(Exceptions.KeyError, "key not found");
+                return -1;
+            }
+
+            if (!result.IsNone())
+            {
+                Exceptions.warn("unsupported return type for __delitem__", Exceptions.TypeError);
+            }
+
+            return 0;
         }
 
         static NewReference tp_call_impl(BorrowedReference ob, BorrowedReference args, BorrowedReference kw)

--- a/src/runtime/Types/Indexer.cs
+++ b/src/runtime/Types/Indexer.cs
@@ -50,9 +50,9 @@ namespace Python.Runtime
         }
 
 
-        internal void SetItem(BorrowedReference inst, BorrowedReference args)
+        internal NewReference SetItem(BorrowedReference inst, BorrowedReference args)
         {
-            SetterBinder.Invoke(inst, args, null);
+            return SetterBinder.Invoke(inst, args, null);
         }
 
         internal bool NeedsDefaultArgs(BorrowedReference args)

--- a/src/runtime/Util/ReflectionUtil.cs
+++ b/src/runtime/Util/ReflectionUtil.cs
@@ -53,4 +53,11 @@ static class ReflectionUtil
         flags |= accessor.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic;
         return flags;
     }
+
+    public static Type? TryGetGenericDefinition(this Type type)
+    {
+        if (type is null) throw new ArgumentNullException(nameof(type));
+
+        return type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : null;
+    }
 }

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -668,3 +668,39 @@ def test_public_inherited_overloaded_indexer():
 
     with pytest.raises(TypeError):
         ob[[]]
+
+def test_del_indexer_dict():
+    """Test deleting indexers (__delitem__)."""
+    from System.Collections.Generic import Dictionary, KeyNotFoundException
+    d = Dictionary[str, str]()
+    d["delme"] = "1"
+    with pytest.raises(KeyError):
+        del d["nonexistent"]
+    del d["delme"]
+    with pytest.raises(KeyError):
+        del d["delme"]
+
+def test_del_indexer_list():
+    """Test deleting indexers (__delitem__)."""
+    from System import ArgumentOutOfRangeException
+    from System.Collections.Generic import List
+    l = List[str]()
+    l.Add("1")
+    with pytest.raises(ArgumentOutOfRangeException):
+        del l[3]
+    del l[0]
+    assert len(l) == 0
+
+def test_del_indexer_array():
+    """Test deleting indexers (__delitem__)."""
+    from System import Array
+    l = Array[str](0)
+    with pytest.raises(TypeError):
+        del l[0]
+
+def test_del_indexer_absent():
+    """Test deleting indexers (__delitem__)."""
+    from System import Uri
+    l = Uri("http://www.example.com")
+    with pytest.raises(TypeError):
+        del l[0]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Implements `__delitem__` for `IList<T>` and `IDictionary<K,V>`

Fixes memory leak on using indexer setter.

Fixes crash on attempting to do `del o[...]` on .NET objects apart from arrays.

### Does this close any currently open issues?

Fixes https://github.com/pythonnet/pythonnet/issues/2530

### Checklist

Check all those that are applicable and complete.

-   [x] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [x] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [x] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [x] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
