### PR TITLE
Proposal: Implement binding manager to hold binding overrides

### DIFF
--- a/src/runtime/BindingOptions.cs
+++ b/src/runtime/BindingOptions.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Python.Runtime
+{
+    public class BindingOptions
+    {
+        private bool _SuppressDocs = false;
+        private bool _SuppressOverloads = false;
+
+        //[ModuleProperty]
+        public bool SuppressDocs
+        {
+            get { return _SuppressDocs; }
+            set { _SuppressDocs = value; }
+        }
+
+        //[ModuleProperty]
+        public bool SuppressOverloads
+        {
+            get { return _SuppressOverloads; }
+            set { _SuppressOverloads = value; }
+        }
+    }
+
+    public class BindingManager
+    {
+        static IDictionary<Type, BindingOptions> _typeOverrides = new Dictionary<Type, BindingOptions>();
+        static IDictionary<Assembly, BindingOptions> _assemblyOverrides = new Dictionary<Assembly, BindingOptions>();
+        static BindingOptions _defaultBindingOptions = new BindingOptions();
+
+        public static BindingOptions GetBindingOptions(Type type)
+        {
+            if (_typeOverrides.ContainsKey(type))
+            {
+                return _typeOverrides[type];
+            }
+
+            if (_assemblyOverrides.ContainsKey(type.Assembly))
+            {
+                return _assemblyOverrides[type.Assembly];
+            }
+            return _defaultBindingOptions;
+        }
+
+        public static BindingOptions DefaultBindingOptions => _defaultBindingOptions;
+
+        public static void SetBindingOptions(Type type, BindingOptions options)
+        {
+            _typeOverrides[type] = options;
+        }
+
+        public static void SetBindingOptions(Assembly assembly, BindingOptions options)
+        {
+            _assemblyOverrides[assembly] = options;
+        }
+
+        public static void Clear()
+        {
+            _typeOverrides.Clear();
+            _assemblyOverrides.Clear();
+        }
+    }
+}

--- a/src/runtime/ClassManager.cs
+++ b/src/runtime/ClassManager.cs
@@ -210,6 +210,7 @@ namespace Python.Runtime
             // information, including generating the member descriptors
             // that we'll be putting in the Python class __dict__.
 
+            var bindingOptions = BindingManager.GetBindingOptions(type);
             ClassInfo info = GetClassInfo(type, impl);
 
             impl.indexer = info.indexer;
@@ -255,7 +256,7 @@ namespace Python.Runtime
                 if (co.NumCtors > 0 && !co.HasCustomNew())
                 {
                     // Implement Overloads on the class object
-                    if (!CLRModule._SuppressOverloads)
+                    if (!bindingOptions.SuppressOverloads)
                     {
                         // HACK: __init__ points to instance constructors.
                         // When unbound they fully instantiate object, so we get overloads for free from MethodBinding.
@@ -266,7 +267,7 @@ namespace Python.Runtime
                     }
 
                     // don't generate the docstring if one was already set from a DocStringAttribute.
-                    if (!CLRModule._SuppressDocs && doc.IsNull())
+                    if (!bindingOptions.SuppressDocs && doc.IsNull())
                     {
                         doc = co.GetDocString();
                         Runtime.PyDict_SetItem(dict, PyIdentifier.__doc__, doc.Borrow());

--- a/src/runtime/Types/ClrModule.cs
+++ b/src/runtime/Types/ClrModule.cs
@@ -16,7 +16,6 @@ namespace Python.Runtime
         protected static bool interactive_preload = true;
         internal static bool preload;
         // XXX Test performance of new features //
-        internal static bool _SuppressDocs = false;
         internal static bool _SuppressOverloads = false;
 
         static CLRModule()
@@ -39,10 +38,6 @@ namespace Python.Runtime
         {
             interactive_preload = true;
             preload = false;
-
-            // XXX Test performance of new features //
-            _SuppressDocs = false;
-            _SuppressOverloads = false;
         }
 
         /// <summary>
@@ -82,15 +77,15 @@ namespace Python.Runtime
         //[ModuleProperty]
         public static bool SuppressDocs
         {
-            get { return _SuppressDocs; }
-            set { _SuppressDocs = value; }
+            get { return BindingManager.DefaultBindingOptions.SuppressDocs; }
+            set { BindingManager.DefaultBindingOptions.SuppressDocs = value; }
         }
 
         //[ModuleProperty]
         public static bool SuppressOverloads
         {
-            get { return _SuppressOverloads; }
-            set { _SuppressOverloads = value; }
+            get { return BindingManager.DefaultBindingOptions.SuppressOverloads; }
+            set { BindingManager.DefaultBindingOptions.SuppressOverloads = value; }
         }
 
         [ModuleFunction]


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This adds a place to register at runtime options to customize the binding of types. This customization can be specified at a type or assembly level.

### Does this close any currently open issues?

No, but it can be used as a way to close issues going forwards - especially in cases where there is disagreement about what the correct way to bind to python, or if there are legacy compatibility reasons to bind in a way that is not the default way. For example, in the `ansys-pythonnet` fork, this is proposed to be used in two ways:

1. to bind properties and methods coming from [explicit interface implementation](https://github.com/ansys/ansys-pythonnet/pull/23) in order to satisfy a requirement in one library for compatibility with legacy IronPython scripts. In IronPython, explicit interface implementations are provided in Python, even when that is not the idiomatic choice.
2. to automatically add [pep8 aliases](https://github.com/ansys/ansys-pythonnet/pull/24), allowing python code to use normal python style even when the C# library uses the normal C# style.

As this is just a proposal - I will move forward with the checklist if the maintainers of pythonnet agree with the direction.

### Example usage (from python)

```
m = clr.AddReference('MyLib')
from Python.Runtime import BindingManager, BindingOptions
binding_options = BindingOptions()
binding_options.SuppressDocs = True
BindingManager.SetBindingOptions(m, binding_options)
```

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
