### PR TITLE
2574 StackOverflow Exception On Super Method Call Fix

### DIFF
--- a/src/runtime/Types/ClassDerived.cs
+++ b/src/runtime/Types/ClassDerived.cs
@@ -253,7 +253,7 @@ namespace Python.Runtime
 
 
                 // override the virtual method to call out to the python method, if there is one.
-                AddVirtualMethod(method, baseType, typeBuilder, isDeclared);
+                AddVirtualMethod(method, typeBuilder);
             }
 
             // Add any additional methods and properties explicitly exposed from Python.
@@ -384,10 +384,8 @@ namespace Python.Runtime
         /// and calls it, otherwise fall back to the base class method.
         /// </summary>
         /// <param name="method">virtual method to be overridden</param>
-        /// <param name="baseType">Python callable object</param>
         /// <param name="typeBuilder">TypeBuilder for the new type the method is to be added to</param>
-        /// <param name="isDeclared"></param>
-        private static void AddVirtualMethod(MethodInfo method, Type baseType, TypeBuilder typeBuilder, bool isDeclared)
+        private static void AddVirtualMethod(MethodInfo method, TypeBuilder typeBuilder)
         {
             ParameterInfo[] parameters = method.GetParameters();
             Type[] parameterTypes = (from param in parameters select param.ParameterType).ToArray();

--- a/src/runtime/Types/ClassDerived.cs
+++ b/src/runtime/Types/ClassDerived.cs
@@ -396,7 +396,7 @@ namespace Python.Runtime
             string? baseMethodName = null;
             if (!method.IsAbstract)
             {
-                baseMethodName = "_" + baseType.Name + "__" + method.Name;
+                baseMethodName = "_" + method.DeclaringType.Name + "__" + method.Name;
                 MethodBuilder baseMethodBuilder = typeBuilder.DefineMethod(baseMethodName,
                     MethodAttributes.Public |
                     MethodAttributes.Final |

--- a/src/testing/classtest.cs
+++ b/src/testing/classtest.cs
@@ -70,5 +70,10 @@ namespace Python.Test
                 throw new Exception("Expected ISayHello and SimpleClass instance");
             }
         }
+
+        public virtual string SayGoodbye()
+        {
+            return "!";
+        }
     }
 }

--- a/src/testing/classtest.cs
+++ b/src/testing/classtest.cs
@@ -76,4 +76,9 @@ namespace Python.Test
             return "!";
         }
     }
+
+    public class SimpleClass2 : SimpleClass
+    {
+        // this class does not override SayGoodbye.
+    }
 }

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -339,8 +339,42 @@ def test_virtual_generic_method():
     assert obj.VirtMethod[int](5) == 5
 
 def test_implement_interface_and_class():
+    import clr
+    class DualSubClass0(ISayHello1, SimpleClass):
+        __namespace__ = "Test0"
+        def SayHello(self):
+            return "hello"
+
+        @clr.clrmethod(str, [])
+        def SayGoodbye(self):
+            return "bye" + super().SayGoodbye()
+
+def test_multi_level_subclass():
+    """
+    Test multi levels of subclassing. This has shown verious issues, like stack overflow
+    exception if a method was not implemented in the middle of the tree.
+    """
+    import clr
     class DualSubClass0(ISayHello1, SimpleClass):
         __namespace__ = "Test"
         def SayHello(self):
             return "hello"
-    obj = DualSubClass0()
+        def SayGoodbye(self):
+            return "bye" + super().SayGoodbye()
+    class DualSubClass1(DualSubClass0):
+        __namespace__ = "Test"
+        def SayHello(self):
+            return super().SayHello() + " hi1"
+    class DualSubClass2(DualSubClass1):
+        __namespace__ = "Test"
+    class DualSubClass3(DualSubClass2):
+        __namespace__ = "Test"
+        def SayHello(self):
+            return super().SayHello() + " hi3"
+        def SayGoodbye(self):
+            return super().SayGoodbye() + "!"
+    obj = DualSubClass3()
+    helloResult = obj.SayHello()
+    goodByeResult = obj.SayGoodbye()
+    assert goodByeResult =="bye!!"
+    assert helloResult == "hello hi1 hi3"

--- a/tests/test_subclass.py
+++ b/tests/test_subclass.py
@@ -9,7 +9,7 @@
 import System
 import pytest
 from Python.Test import (IInterfaceTest, SubClassTest, EventArgsTest,
-                         FunctionsTest, IGenericInterface, GenericVirtualMethodTest, SimpleClass, ISayHello1)
+                         FunctionsTest, IGenericInterface, GenericVirtualMethodTest, SimpleClass, SimpleClass2, ISayHello1)
 from System.Collections.Generic import List
 
 
@@ -355,7 +355,7 @@ def test_multi_level_subclass():
     exception if a method was not implemented in the middle of the tree.
     """
     import clr
-    class DualSubClass0(ISayHello1, SimpleClass):
+    class DualSubClass0(ISayHello1, SimpleClass2):
         __namespace__ = "Test"
         def SayHello(self):
             return "hello"


### PR DESCRIPTION
~**Update: Does not actually fix #2574, but a similar problem(#2629). I'll provide a fix for 2574 as well.**~
**Update 2: Now this also fixes #2574**
This fixed an issue with a StackOverflow exception being  generated when a virtual method is being called, but a class in the middle of the inheritance tree does not override the method.

This happens because the CallVirtual method calls the method on the python object if the wrapper got generated, causing everything to be evaluated again from the top. Doing it this way, causes the the python method only to get invoked if there is an implementation on the class, which can then correctly call `super().Method()`.

For the finalizer fix, we now skip generating the call to PyFinalize if the base class is already a python class, because if that is the case the finalize method has already been added.

Additionally it simplifies how the generated code for virtual methods look. Now, a virtual wrapper method is not automatically generated. Only if the method is actually being overwritten by the class it will prompt the generation of a virtual method wrapper.

### Does this close any currently open issues?
This closes #2574, #2627, #2629

### Any other comments?

...

### Checklist

Check all those that are applicable and complete.

-   [ ] Make sure to include one or more tests for your change
-   [ ] If an enhancement PR, please create docs and at best an example
-   [ ] Ensure you have signed the [.NET Foundation CLA](https://cla.dotnetfoundation.org/pythonnet/pythonnet)
-   [ ] Add yourself to [`AUTHORS`](../blob/master/AUTHORS.md)
-   [ ] Updated the [`CHANGELOG`](../blob/master/CHANGELOG.md)
