### PR TITLE
Bump setuptools and adjust license information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=80"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pythonnet"
 description = ".NET and Mono integration for Python"
-license = {text = "MIT"}
+license = "MIT"
 
 readme = "README.rst"
 
@@ -18,7 +18,6 @@ requires-python = ">=3.10, <3.14"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: C#",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
@@ -55,7 +54,6 @@ Sources = "https://github.com/pythonnet/pythonnet"
 [tool.setuptools]
 zip-safe = false
 py-modules = ["clr"]
-license-files = []
 
 [tool.setuptools.dynamic.version]
 file = "version.txt"


### PR DESCRIPTION
The `project.license` entry in `pyproject.toml` should be a bare string
now and the license tag is removed.
