### PR TITLE
Fix clr_loader version parsing for .NET 10.*

### DIFF
--- a/pythonnet/__init__.py
+++ b/pythonnet/__init__.py
@@ -4,6 +4,22 @@ import sys
 from pathlib import Path
 from typing import Dict, Optional, Union, Any
 import clr_loader
+from clr_loader.util.runtime_spec import DotnetCoreRuntimeSpec
+
+# Monkeypatch clr_loader to fix .NET 10 version parsing
+# TODO: Remove this once clr_loader is updated
+def _patched_tfm(self) -> str:
+    parts = self.version.split(".")
+    return f"net{parts[0]}.{parts[1]}"
+
+
+def _patched_floor_version(self) -> str:
+    parts = self.version.split(".")
+    return f"{parts[0]}.{parts[1]}.0"
+
+
+DotnetCoreRuntimeSpec.tfm = property(_patched_tfm)
+DotnetCoreRuntimeSpec.floor_version = property(_patched_floor_version)
 
 __all__ = ["set_runtime", "set_runtime_from_env", "load", "unload", "get_runtime_info"]
 


### PR DESCRIPTION
The `clr_loader` library has a bug where it parses .NET versions using string slicing `[:3]`. This works for single-digit major versions (e.g., `9.0.0` becomes `9.0`), but fails for double-digit major versions like `10.0.0`, resulting in an invalid TFM `net10.` and version `10..0`.

This change adds a monkeypatch in `pythonnet/__init__.py` to override the `tfm` and `floor_version` properties of `DotnetCoreRuntimeSpec` with logic that correctly handles double-digit versions by splitting the version string. This ensures support for .NET 10+.