### PR TITLE
dlr branch fix - Propagate exceptions from TryGetMember in tp_getattro_dlr_proxy

### DIFF
--- a/src/runtime/TypeManager.cs
+++ b/src/runtime/TypeManager.cs
@@ -123,8 +123,13 @@ namespace Python.Runtime
             {
                 resolved = dynamicMemberAccessor.TryGetMember(dynamicObject, memberName, out value);
             }
-            catch
+            catch (Exception e)
             {
+                // Avoid wrapping the CLR exception via Converter.ToPython here: that would trigger
+                // CLR type initialisation which can re-enter this slot on the same live object,
+                // causing infinite recursion. A plain RuntimeError with the message is safe.
+                Runtime.PyErr_Clear();
+                Exceptions.SetError(Exceptions.RuntimeError, e.Message);
                 return default;
             }
 

--- a/src/testing/dlrtest.cs
+++ b/src/testing/dlrtest.cs
@@ -62,6 +62,12 @@ public class RejectingSetDynamicObject : DynamicStorageObject
     }
 }
 
+public class ThrowingGetDynamicObject : DynamicStorageObject
+{
+    public override bool TryGetMember(GetMemberBinder binder, out object result)
+        => throw new InvalidOperationException($"TryGetMember failed for '{binder.Name}'");
+}
+
 public class ThrowingSetDynamicObject : DynamicStorageObject
 {
     public override bool TrySetMember(SetMemberBinder binder, object value)

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -8,6 +8,7 @@ from Python.Test import DynamicMappingObject
 from Python.Test import RejectingDeleteDynamicObject
 from Python.Test import RejectingSetDynamicObject
 from Python.Test import ThrowingDeleteDynamicObject
+from Python.Test import ThrowingGetDynamicObject
 from Python.Test import ThrowingSetDynamicObject
 
 
@@ -184,6 +185,14 @@ def test_trysetmember_false_raises_attributeerror_instead_of_silent_python_setat
         obj.typoed_name = 42
 
     assert not hasattr(obj, "typoed_name")
+
+
+def test_trygetmember_exception_is_raised_in_python():
+    obj = ThrowingGetDynamicObject()
+    obj.AddDynamicMember("any_key", 1)
+
+    with pytest.raises(Exception, match="TryGetMember failed for 'any_key'"):
+        _ = obj.any_key
 
 
 def test_trysetmember_exception_is_raised_in_python():


### PR DESCRIPTION
Adds the symmetric exception-propagation fix to the DLR getter, completing the fix called out by @lostmsu in the #2706 review.

## Problem

`tp_getattro_dlr_proxy` swallowed exceptions raised from `TryGetMember` and returned `default` to Python while the prior `AttributeError` from `PyObject_GenericGetAttr` was still set. Callers therefore observed a misleading `AttributeError` instead of the real failure — exactly the kind of silent error-masking the reviewer flagged for the setter (which was fixed in d629b87).

## Fix

Set a Python exception in the catch block before returning `default`.

We use `Exceptions.SetError(Exceptions.RuntimeError, e.Message)` rather than `Exceptions.SetError(e)` deliberately. Wrapping the CLR exception object via `Converter.ToPython` triggers CLR type initialisation, which can re-enter `tp_getattro_dlr_proxy` on the same live dynamic object and recurse infinitely. A plain `RuntimeError` with the message string preserves the diagnostic information without that hazard.

## Test

Adds `ThrowingGetDynamicObject` to `dlrtest.cs` and `test_trygetmember_exception_is_raised_in_python` to `tests/test_dynamic.py`, mirroring the existing coverage for `TrySetMember`/`TryDeleteMember` exception paths.